### PR TITLE
Fix inconsistent head_data

### DIFF
--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -99,7 +99,6 @@ pub fn follow_polkadot<'a, L: 'a, P: 'a>(para_id: ParaId, local: Arc<L>, polkado
 				<<L::Block as BlockT>::Header>::decode(&mut &head_data[..])
 					.map_err(|_| Error::InvalidHeadData)
 			})
-			.and_then(|h| future::ready(Ok(h)))
 			.try_for_each(move |p_head| {
 				future::ready(local.finalize(p_head.hash()).map_err(Error::Client).map(|_| ()))
 			})

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -96,10 +96,10 @@ pub fn follow_polkadot<'a, L: 'a, P: 'a>(para_id: ParaId, local: Arc<L>, polkado
 
 		finalized_heads
 			.map(|head_data| {
-				<Option<<L::Block as BlockT>::Header>>::decode(&mut &head_data[..])
+				<<L::Block as BlockT>::Header>::decode(&mut &head_data[..])
 					.map_err(|_| Error::InvalidHeadData)
 			})
-			.try_filter_map(|h| future::ready(Ok(h)))
+			.and_then(|h| future::ready(Ok(h)))
 			.try_for_each(move |p_head| {
 				future::ready(local.finalize(p_head.hash()).map_err(Error::Client).map(|_| ()))
 			})


### PR DESCRIPTION
head_data seems to be just the header of the parachain block but in this code it is deocded as an `Option<header>`.

Those data are coming from this associated type:
```rust
	/// A stream that yields finalized head-data for a certain parachain.
	type Finalized: Stream<Item = Vec<u8>> + Send;
```

I don't see why this should be an option.