### PR TITLE
Fix: relay chain arguments need a first argument "command"

### DIFF
--- a/test/parachain/src/command.rs
+++ b/test/parachain/src/command.rs
@@ -98,7 +98,10 @@ pub fn run(version: VersionInfo) -> error::Result<()> {
 
 			polkadot_config.config_dir = config.in_chain_config_dir("polkadot");
 
-			let polkadot_opt: PolkadotCli = sc_cli::from_iter(opt.relaychain_args, &version);
+			let polkadot_opt: PolkadotCli = sc_cli::from_iter(
+				[version.executable_name.to_string()].iter().chain(opt.relaychain_args.iter()),
+				&version,
+			);
 			let allow_private_ipv4 = !polkadot_opt.run.network_config.no_private_ipv4;
 
 			polkadot_config.rpc_http = Some(DEFAULT_POLKADOT_RPC_HTTP.parse().unwrap());

--- a/test/parachain/tests/polkadot_argument_parsing.rs
+++ b/test/parachain/tests/polkadot_argument_parsing.rs
@@ -1,0 +1,53 @@
+// Copyright 2020 Parity Technologies (UK) Ltd.
+// This file is part of Substrate.
+
+// Substrate is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Substrate is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
+
+use assert_cmd::cargo::cargo_bin;
+use std::{convert::TryInto, process::Command, thread, time::Duration, fs};
+
+mod common;
+
+#[test]
+#[cfg(unix)]
+fn polkadot_argument_parsing() {
+	use nix::sys::signal::{kill, Signal::{self, SIGINT, SIGTERM}};
+	use nix::unistd::Pid;
+
+	fn run_command_and_kill(signal: Signal) {
+		let _ = fs::remove_dir_all("polkadot_argument_parsing");
+		let mut cmd = Command::new(cargo_bin("cumulus-test-parachain-collator"))
+			.args(&[
+				"-d", "polkadot_argument_parsing", "--", "--bootnodes",
+				"/ip4/127.0.0.1/tcp/30333/p2p/Qmbx43psh7LVkrYTRXisUpzCubbgYojkejzAgj5mteDnxy",
+				"--bootnodes",
+				"/ip4/127.0.0.1/tcp/50500/p2p/Qma6SpS7tzfCrhtgEVKR9Uhjmuv55ovC3kY6y6rPBxpWd",
+			])
+			.spawn()
+			.unwrap();
+
+		thread::sleep(Duration::from_secs(20));
+		assert!(cmd.try_wait().unwrap().is_none(), "the process should still be running");
+		kill(Pid::from_raw(cmd.id().try_into().unwrap()), signal).unwrap();
+		assert_eq!(
+			common::wait_for(&mut cmd, 30).map(|x| x.success()),
+			Some(true),
+			"the process must exit gracefully after signal {}",
+			signal,
+		);
+	}
+
+	run_command_and_kill(SIGINT);
+	run_command_and_kill(SIGTERM);
+}


### PR DESCRIPTION
Otherwise the first positional argument is just swallowed

Fixes #62 