### PR TITLE
Introduce message broker for receiving and sending relay chain messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -798,6 +798,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "cumulus-message-broker"
+version = "0.1.0"
+
+[[package]]
 name = "cumulus-network"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -800,6 +800,13 @@ dependencies = [
 [[package]]
 name = "cumulus-message-broker"
 version = "0.1.0"
+dependencies = [
+ "cumulus-primitives 0.1.0",
+ "frame-support 2.0.0-alpha.5 (git+https://github.com/paritytech/substrate?branch=cumulus-branch)",
+ "frame-system 2.0.0-alpha.5 (git+https://github.com/paritytech/substrate?branch=cumulus-branch)",
+ "parity-scale-codec 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-inherents 2.0.0-alpha.5 (git+https://github.com/paritytech/substrate?branch=cumulus-branch)",
+]
 
 [[package]]
 name = "cumulus-network"
@@ -815,6 +822,14 @@ dependencies = [
  "sp-blockchain 2.0.0-alpha.5 (git+https://github.com/paritytech/substrate?branch=cumulus-branch)",
  "sp-consensus 0.8.0-alpha.5 (git+https://github.com/paritytech/substrate?branch=cumulus-branch)",
  "sp-runtime 2.0.0-alpha.5 (git+https://github.com/paritytech/substrate?branch=cumulus-branch)",
+]
+
+[[package]]
+name = "cumulus-primitives"
+version = "0.1.0"
+dependencies = [
+ "impl-trait-for-tuples 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-inherents 2.0.0-alpha.5 (git+https://github.com/paritytech/substrate?branch=cumulus-branch)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,9 @@
 [workspace]
 members = [
 	"consensus",
+	"message-broker",
 	"network",
+	"primitives",
 	"runtime",
 	"test/runtime",
 	"test/client",

--- a/collator/Cargo.toml
+++ b/collator/Cargo.toml
@@ -27,7 +27,7 @@ cumulus-runtime = { path = "../runtime" }
 
 # Other dependencies
 log = "0.4.8"
-codec = { package = "parity-scale-codec", version = "1.0.6", features = [ "derive" ] }
+codec = { package = "parity-scale-codec", version = "1.3.0", features = [ "derive" ] }
 futures = { version = "0.3.1", features = ["compat"] }
 parking_lot = "0.9"
 

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -24,5 +24,5 @@ polkadot-runtime = { git = "https://github.com/paritytech/polkadot", branch = "c
 # other deps
 futures = { version = "0.3.1", features = ["compat"] }
 tokio = "0.1.22"
-codec = { package = "parity-scale-codec", version = "1.0.5", features = [ "derive" ] }
+codec = { package = "parity-scale-codec", version = "1.3.0", features = [ "derive" ] }
 log = "0.4"

--- a/message-broker/Cargo.toml
+++ b/message-broker/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "cumulus-message-broker"
+version = "0.1.0"
+authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2018"
+
+[dependencies]
+# substrate deps
+frame-support = { git = "https://github.com/paritytech/substrate", branch = "cumulus-branch" }
+frame-system = { git = "https://github.com/paritytech/substrate", branch = "cumulus-branch" }
+sp-inherents = { git = "https://github.com/paritytech/substrate", branch = "cumulus-branch" }
+
+# Other dependencies
+impl-trait-for-tuples = "0.1.3"

--- a/message-broker/Cargo.toml
+++ b/message-broker/Cargo.toml
@@ -15,3 +15,13 @@ codec = { package = "parity-scale-codec", version = "1.3.0", features = [ "deriv
 
 # Cumulus dependencies
 cumulus-primitives = { path = "../primitives" }
+
+[features]
+default = [ "std" ]
+std = [
+	"frame-support/std",
+	"frame-system/std",
+	"sp-inherents/std",
+	"codec/std",
+	"cumulus-primitives/std",
+]

--- a/message-broker/Cargo.toml
+++ b/message-broker/Cargo.toml
@@ -11,4 +11,7 @@ frame-system = { git = "https://github.com/paritytech/substrate", branch = "cumu
 sp-inherents = { git = "https://github.com/paritytech/substrate", branch = "cumulus-branch" }
 
 # Other dependencies
-impl-trait-for-tuples = "0.1.3"
+codec = { package = "parity-scale-codec", version = "1.3.0", features = [ "derive" ] }
+
+# Cumulus dependencies
+cumulus-primitives = { path = "../primitives" }

--- a/message-broker/src/lib.rs
+++ b/message-broker/src/lib.rs
@@ -1,0 +1,55 @@
+// Copyright 2020 Parity Technologies (UK) Ltd.
+// This file is part of Cumulus.
+
+// Substrate is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Substrate is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Cumulus message broker pallet.
+//!
+//! This pallet provides support for handling downward and upward messages.
+
+use sp_inherents::{ProvideInherent, InherentData, InherentIdentifier, MakeFatalError};
+
+/// Something that should be called when a downward message is received.
+#[impl_trait_for_tuples::impl_for_tuples(30)]
+pub trait DownwardMessageHandler {
+	/// Handle the given downward message.
+	fn handle_downward_message(msg: &());
+}
+
+/// Configuration trait of this pallet.
+pub trait Trait: frame_system::Trait {
+	/// The downward message handlers that will be informed when a message is received.
+	type DownwardMessageHandlers: DownwardMessageHandler;
+}
+
+frame_support::decl_module! {
+	pub struct Module<T: Trait> for enum Call where origin: T::Origin {
+
+	}
+}
+
+impl<T: Trait> ProvideInherent for Module<T> {
+	type Call = Call<T>;
+	type Error = MakeFatalError<()>;
+	const INHERENT_IDENTIFIER: InherentIdentifier = INHERENT_IDENTIFIER;
+
+	fn create_inherent(data: &InherentData) -> Option<Self::Call> {
+		let data: T::Moment = extract_inherent_data(data)
+			.expect("Gets and decodes timestamp inherent data")
+			.saturated_into();
+
+		let next_time = cmp::max(data, Self::now() + T::MinimumPeriod::get());
+		Some(Call::set(next_time.into()))
+	}
+}

--- a/message-broker/src/lib.rs
+++ b/message-broker/src/lib.rs
@@ -18,6 +18,8 @@
 //!
 //! This pallet provides support for handling downward and upward messages.
 
+#![cfg_attr(not(feature = "std"), no_std)]
+
 use cumulus_primitives::{
 	inherents::{DownwardMessagesType, DOWNWARD_MESSAGES_IDENTIFIER},
 	well_known_keys, DownwardMessageHandler, UpwardMessageSender,

--- a/network/Cargo.toml
+++ b/network/Cargo.toml
@@ -20,4 +20,4 @@ polkadot-validation = { git = "https://github.com/paritytech/polkadot", branch =
 polkadot-network = { git = "https://github.com/paritytech/polkadot", branch = "cumulus-branch" }
 
 # other deps
-codec = { package = "parity-scale-codec", version = "1.0.5", features = [ "derive" ] }
+codec = { package = "parity-scale-codec", version = "1.3.0", features = [ "derive" ] }

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -10,3 +10,9 @@ sp-inherents = { git = "https://github.com/paritytech/substrate", branch = "cumu
 
 # Other dependencies
 impl-trait-for-tuples = "0.1.3"
+
+[features]
+default = [ "std" ]
+std = [
+	"sp-inherents/std",
+]

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "cumulus-primitives"
+version = "0.1.0"
+authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2018"
+
+[dependencies]
+sp-inherents = { git = "https://github.com/paritytech/substrate", branch = "cumulus-branch" }

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -5,4 +5,8 @@ authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 
 [dependencies]
+# Substrate dependencies
 sp-inherents = { git = "https://github.com/paritytech/substrate", branch = "cumulus-branch" }
+
+# Other dependencies
+impl-trait-for-tuples = "0.1.3"

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -26,3 +26,26 @@ pub mod inherents {
 	/// The type of the inherent downward messages.
 	pub type DownwardMessagesType = Vec<()>;
 }
+
+/// Well known keys for values in the storage.
+pub mod well_known_keys {
+	/// The storage key for the upward messages.
+	///
+	/// The upward messages are stored as SCALE encoded `Vec<()>`.
+	pub const UPWARD_MESSAGES: &'static [u8] = b":cumulus_upward_messages:";
+}
+
+/// Something that should be called when a downward message is received.
+#[impl_trait_for_tuples::impl_for_tuples(30)]
+pub trait DownwardMessageHandler {
+	/// Handle the given downward message.
+	fn handle_downward_message(msg: &());
+}
+
+/// Something that can send upward messages.
+pub trait UpwardMessageSender {
+	/// Send an upward message to the relay chain.
+	///
+	/// Returns an error if sending failed.
+	fn send_upward_message(msg: &()) -> Result<(), ()>;
+}

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -16,6 +16,8 @@
 
 //! Cumulus related primitive types and traits.
 
+#![cfg_attr(not(feature = "std"), no_std)]
+
 /// Inherents identifiers and types related to
 pub mod inherents {
 	use sp_inherents::InherentIdentifier;

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -1,0 +1,28 @@
+// Copyright 2020 Parity Technologies (UK) Ltd.
+// This file is part of Cumulus.
+
+// Substrate is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Substrate is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Cumulus related primitive types and traits.
+
+/// Inherents identifiers and types related to
+pub mod inherents {
+	use sp_inherents::InherentIdentifier;
+
+	/// Inherent identifier for downward messages.
+	pub const DOWNWARD_MESSAGES_IDENTIFIER: InherentIdentifier = *b"cumdownm";
+
+	/// The type of the inherent downward messages.
+	pub type DownwardMessagesType = Vec<()>;
+}

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -18,7 +18,7 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
-/// Inherents identifiers and types related to
+/// Identifiers and types related to Cumulus Inherents
 pub mod inherents {
 	use sp_inherents::InherentIdentifier;
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 # Other dependencies
-codec = { package = "parity-scale-codec", version = "1.0.5", default-features = false, features = [ "derive" ] }
+codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = [ "derive" ] }
 memory-db = { version = "0.18.0", default-features = false }
 hash-db = { version = "0.15.2", default-features = false }
 trie-db = { version = "0.20.0", default-features = false }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -14,11 +14,12 @@
 // You should have received a copy of the GNU General Public License
 // along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
 
+///! The Cumulus runtime to make a runtime a parachain.
+
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use codec::{Decode, Encode};
 use sp_runtime::traits::Block as BlockT;
-///! The Cumulus runtime to make a runtime a parachain.
 use sp_std::vec::Vec;
 
 #[cfg(not(feature = "std"))]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -14,9 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
 
-///! The Cumulus runtime to make a runtime a parachain.
-
 #![cfg_attr(not(feature = "std"), no_std)]
+
+///! The Cumulus runtime to make a runtime a parachain.
 
 use codec::{Decode, Encode};
 use sp_runtime::traits::Block as BlockT;


### PR DESCRIPTION
This provides a new crate `cumulus-message-broker` for receiving downward messages and sending upward messages. The messages are currently just `()` and will be replaced in a later pr. This also only introduces the runtime side, providing the inherent data will come later as well.