### PR TITLE
Align trie iteration to substrate.

### DIFF
--- a/runtime/src/validate_block/implementation.rs
+++ b/runtime/src/validate_block/implementation.rs
@@ -215,17 +215,8 @@ impl<B: BlockT> Storage for WitnessStorage<B> {
 			Err(_) => panic!(),
 		};
 
-		let iterator = match TrieDBIterator::new_prefixed(&trie, prefix)
-		{
-			Ok(r) => r,
-			Err(_) => panic!(),
-		};
-
-		for x in iterator {
+		for x in TrieDBIterator::new_prefixed(&trie, prefix).expect("Creates trie iterator") {
 			let (key, _) = x.expect("Iterating trie iterator");
-
-			debug_assert!(!key.starts_with(prefix));
-
 			self.overlay.insert(key, None);
 		}
 	}

--- a/runtime/src/validate_block/implementation.rs
+++ b/runtime/src/validate_block/implementation.rs
@@ -25,7 +25,7 @@ use sp_trie::{delta_trie_root, read_trie_value, Layout, MemoryDB};
 
 use hash_db::{HashDB, EMPTY_PREFIX};
 
-use trie_db::{Trie, TrieDB};
+use trie_db::{Trie, TrieDB, TrieDBIterator};
 
 use parachain::primitives::{HeadData, ValidationCode, ValidationParams, ValidationResult};
 
@@ -215,15 +215,16 @@ impl<B: BlockT> Storage for WitnessStorage<B> {
 			Err(_) => panic!(),
 		};
 
-		let mut iter = trie.iter().expect("Creates trie iterator");
-		iter.seek(prefix).expect("Seek trie iterator");
+		let iterator = match TrieDBIterator::new_prefixed(&trie, prefix)
+		{
+			Ok(r) => r,
+			Err(_) => panic!(),
+		};
 
-		for x in iter {
+		for x in iterator {
 			let (key, _) = x.expect("Iterating trie iterator");
 
-			if !key.starts_with(prefix) {
-				break;
-			}
+			debug_assert!(!key.starts_with(prefix));
 
 			self.overlay.insert(key, None);
 		}


### PR DESCRIPTION
I was checking how proof would be checked with cumulus, and see that clear_prefix is not aligned with substrate, this PR fixes that.
(corresponding substrate code https://github.com/paritytech/substrate/blob/a2512e837003db3d3267764283edf31cf95a206c/primitives/state-machine/src/trie_backend_essence.rs#L239 ).