### PR TITLE
Put `cumulus-parachain-upgrade` into the test parachain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -923,6 +923,7 @@ dependencies = [
  "sp-inherents",
  "sp-io",
  "sp-runtime",
+ "sp-std",
  "sp-version",
  "substrate-test-runtime-client",
 ]
@@ -936,6 +937,7 @@ dependencies = [
  "polkadot-parachain",
  "polkadot-primitives",
  "sp-inherents",
+ "sp-runtime",
  "sp-std",
 ]
 
@@ -1023,6 +1025,7 @@ dependencies = [
 name = "cumulus-test-parachain-runtime"
 version = "0.1.0"
 dependencies = [
+ "cumulus-parachain-upgrade",
  "cumulus-runtime",
  "frame-executive",
  "frame-support",

--- a/parachain-upgrade/Cargo.toml
+++ b/parachain-upgrade/Cargo.toml
@@ -5,21 +5,6 @@ authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 description = "pallet to manage parachain upgrades"
 
-[features]
-default = ['std']
-std = [
-	'serde',
-	'codec/std',
-	'frame-support/std',
-	'pallet-balances/std',
-	'cumulus-runtime/std',
-	'sp-core/std',
-	'sp-runtime/std',
-	'sp-io/std',
-	'system/std',
-	'cumulus-primitives/std',
-]
-
 [dependencies]
 # Cumulus dependencies
 cumulus-primitives = { path = "../primitives", default-features = false }
@@ -32,10 +17,10 @@ parachain = { package = "polkadot-parachain", git = "https://github.com/parityte
 frame-support = { git = "https://github.com/paritytech/substrate.git", branch = "cumulus-branch", default-features = false }
 pallet-balances = { git = "https://github.com/paritytech/substrate.git", branch = "cumulus-branch", default-features = false }
 sp-core = { git = "https://github.com/paritytech/substrate.git", branch = "cumulus-branch", version = "2.0.0-dev", default-features = false }
+sp-std = { git = "https://github.com/paritytech/substrate.git", branch = "cumulus-branch", version = "2.0.0-dev", default-features = false }
 sp-inherents = { git = "https://github.com/paritytech/substrate.git", branch = "cumulus-branch", default-features = false }
 sp-io = { git = "https://github.com/paritytech/substrate.git", branch = "cumulus-branch", default-features = false }
 sp-runtime = { git = "https://github.com/paritytech/substrate.git", branch = "cumulus-branch", default-features = false }
-sp-version = { git = "https://github.com/paritytech/substrate.git", branch = "cumulus-branch", default-features = false }
 system = { package = "frame-system", git = "https://github.com/paritytech/substrate.git", branch = "cumulus-branch", default-features = false }
 
 # Other Dependencies
@@ -45,3 +30,20 @@ serde = { version = "1.0.101", optional = true, features = ["derive"] }
 [dev-dependencies]
 sp-externalities = { git = "https://github.com/paritytech/substrate.git", branch = "cumulus-branch", default-features = false }
 substrate-test-runtime-client = { git = "https://github.com/paritytech/substrate.git", branch = "cumulus-branch", default-features = false }
+sp-version = { git = "https://github.com/paritytech/substrate.git", branch = "cumulus-branch", default-features = false }
+
+[features]
+default = ['std']
+std = [
+	'serde',
+	'codec/std',
+	'frame-support/std',
+	'pallet-balances/std',
+	'cumulus-runtime/std',
+	'sp-core/std',
+	'sp-runtime/std',
+	'sp-io/std',
+	'sp-std/std',
+	'system/std',
+	'cumulus-primitives/std',
+]

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 # Substrate dependencies
 sp-inherents = { git = "https://github.com/paritytech/substrate", branch = "cumulus-branch", default-features = false }
 sp-std = { git = "https://github.com/paritytech/substrate", branch = "cumulus-branch", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "cumulus-branch", default-features = false }
 
 # Polkadot dependencies
 polkadot-parachain = { git = "https://github.com/paritytech/polkadot", branch = "cumulus-branch", default-features = false }
@@ -25,4 +26,5 @@ std = [
 	"polkadot-primitives/std",
 	"polkadot-parachain/std",
 	"sp-inherents/std",
+	"sp-runtime/std",
 ]

--- a/primitives/src/validation_function_params.rs
+++ b/primitives/src/validation_function_params.rs
@@ -24,8 +24,7 @@ use polkadot_primitives::parachain::{GlobalValidationSchedule, LocalValidationDa
 ///
 /// This struct is the subset of [`ValidationParams`](polkadot_parachain::ValidationParams)
 /// which is of interest when upgrading parachain validation functions.
-#[derive(PartialEq, Eq, Encode, Decode, Clone, Copy, Default)]
-#[cfg_attr(feature = "std", derive(Debug))]
+#[derive(PartialEq, Eq, Encode, Decode, Clone, Copy, Default, sp_runtime::RuntimeDebug)]
 pub struct ValidationFunctionParams {
 	/// The maximum code size permitted, in bytes.
 	pub max_code_size: u32,

--- a/runtime/src/validate_block/implementation.rs
+++ b/runtime/src/validate_block/implementation.rs
@@ -25,7 +25,7 @@ use sp_trie::{delta_trie_root, read_trie_value, Layout, MemoryDB};
 
 use hash_db::{HashDB, EMPTY_PREFIX};
 
-use trie_db::{Trie, TrieDB, TrieDBIterator};
+use trie_db::{TrieDB, TrieDBIterator};
 
 use parachain::primitives::{HeadData, ValidationCode, ValidationParams, ValidationResult};
 

--- a/test/parachain/runtime/Cargo.toml
+++ b/test/parachain/runtime/Cargo.toml
@@ -33,6 +33,7 @@ pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", 
 
 # Cumulus dependencies
 cumulus-runtime = { path = "../../../runtime", default-features = false }
+cumulus-parachain-upgrade = { path = "../../../parachain-upgrade", default-features = false }
 
 [build-dependencies]
 wasm-builder-runner = { package = "substrate-wasm-builder-runner", version = "1.0.3" }
@@ -63,4 +64,5 @@ std = [
 	'pallet-sudo/std',
 	'pallet-transaction-payment/std',
 	'cumulus-runtime/std',
+	'cumulus-parachain-upgrade/std',
 ]

--- a/test/parachain/runtime/src/lib.rs
+++ b/test/parachain/runtime/src/lib.rs
@@ -230,6 +230,11 @@ impl pallet_sudo::Trait for Runtime {
 	type Event = Event;
 }
 
+impl cumulus_parachain_upgrade::Trait for Runtime {
+	type Event = Event;
+	type OnValidationFunctionParams = ();
+}
+
 construct_runtime! {
 	pub enum Runtime where
 		Block = Block,
@@ -242,6 +247,7 @@ construct_runtime! {
 		Balances: pallet_balances::{Module, Call, Storage, Config<T>, Event<T>},
 		Sudo: pallet_sudo::{Module, Call, Storage, Config<T>, Event<T>},
 		RandomnessCollectiveFlip: pallet_randomness_collective_flip::{Module, Call, Storage},
+		ParachainUpgrade: cumulus_parachain_upgrade::{Module, Call, Storage, Inherent, Event},
 	}
 }
 


### PR DESCRIPTION
This ensures that the crate compiles for `no_std`. Besides this, there
are some fixes to the crate code itself.

Fixes: https://github.com/paritytech/cumulus/issues/97

CC @akru