### PR TITLE
Allow custom Polkadot chainspec

### DIFF
--- a/test/parachain/src/command.rs
+++ b/test/parachain/src/command.rs
@@ -102,11 +102,15 @@ impl SubstrateCli for PolkadotCli {
 		"cumulus-test-parachain-collator"
 	}
 
-	fn load_spec(&self, _id: &str) -> std::result::Result<Box<dyn sc_service::ChainSpec>, String> {
-		polkadot_service::PolkadotChainSpec::from_json_bytes(
-			&include_bytes!("../res/polkadot_chainspec.json")[..],
-		)
-		.map(|r| Box::new(r) as Box<_>)
+	fn load_spec(&self, id: &str) -> std::result::Result<Box<dyn sc_service::ChainSpec>, String> {
+		Ok(match id {
+			"" | "local" | "dev" => Box::new(polkadot_service::PolkadotChainSpec::from_json_bytes(
+				&include_bytes!("../res/polkadot_chainspec.json")[..],
+			)?),
+			path => Box::new(chain_spec::ChainSpec::from_json_file(
+				std::path::PathBuf::from(path),
+			)?),
+		})
 	}
 }
 


### PR DESCRIPTION
This PR adds the ability to specify a custom chainspec to the embedded relay chain node by passing `--chain some-spec.json`.

This is useful for testing the collator on local polkadot testnets.