### PR TITLE
Try to workaround the invalid compilation

### DIFF
--- a/runtime/src/validate_block/implementation.rs
+++ b/runtime/src/validate_block/implementation.rs
@@ -257,8 +257,9 @@ impl<B: BlockT> Storage for WitnessStorage<B> {
 		};
 
 		for x in TrieDBIterator::new_prefixed(&trie, prefix).expect("Creates trie iterator") {
-			let (key, _) = x.expect("Iterating trie iterator");
-			self.overlay.insert(key, None);
+			if let Ok((key, _)) = x {
+				self.overlay.insert(key, None);
+			}
 		}
 	}
 


### PR DESCRIPTION
There is probably some bug in rustc which result in an invalid
compilation when using an `expect` at the given position. I'm still not
sure why this is happening, but this fix should fix it for now.