### PR TITLE
Fix block announcement validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1100,6 +1100,7 @@ dependencies = [
  "sc-network",
  "sc-service",
  "sc-transaction-pool",
+ "sp-api",
  "sp-consensus",
  "sp-core",
  "sp-inherents",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1585,7 +1585,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -1593,7 +1593,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1610,9 +1610,8 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
- "Inflector",
  "frame-benchmarking",
  "parity-scale-codec",
  "sc-cli",
@@ -1629,7 +1628,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1644,7 +1643,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata"
 version = "11.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -1655,7 +1654,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "bitmask",
  "frame-metadata",
@@ -1680,7 +1679,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "frame-support-procedural-tools",
  "proc-macro2 1.0.19",
@@ -1691,7 +1690,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -1703,7 +1702,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "proc-macro2 1.0.19",
  "quote 1.0.7",
@@ -1713,7 +1712,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -1729,7 +1728,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -2641,8 +2640,8 @@ dependencies = [
 
 [[package]]
 name = "kusama-runtime"
-version = "0.8.19"
-source = "git+https://github.com/paritytech/polkadot?branch=cumulus-branch#589bad99550989a793351dca05b88a34bbf0dbbf"
+version = "0.8.22"
+source = "git+https://github.com/paritytech/polkadot?branch=cumulus-branch#0674ba962c7494ec88cd06dd1ae0d6f6edf97975"
 dependencies = [
  "bitvec",
  "frame-executive",
@@ -3661,7 +3660,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3677,7 +3676,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3692,7 +3691,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3717,7 +3716,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3731,7 +3730,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3746,7 +3745,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3761,7 +3760,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3775,7 +3774,7 @@ dependencies = [
 [[package]]
 name = "pallet-finality-tracker"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3791,7 +3790,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3813,7 +3812,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -3829,7 +3828,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3848,7 +3847,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3864,7 +3863,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3878,7 +3877,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3893,7 +3892,7 @@ dependencies = [
 [[package]]
 name = "pallet-nicks"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3907,7 +3906,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3922,7 +3921,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3937,7 +3936,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3950,7 +3949,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "enumflags2",
  "frame-support",
@@ -3965,7 +3964,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3980,7 +3979,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4000,7 +3999,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4014,7 +4013,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4034,7 +4033,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.19",
@@ -4045,7 +4044,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4059,7 +4058,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4076,7 +4075,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4093,7 +4092,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -4111,7 +4110,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4124,7 +4123,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4138,7 +4137,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4153,7 +4152,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "enumflags2",
  "frame-support",
@@ -4467,8 +4466,8 @@ checksum = "feb3b2b1033b8a60b4da6ee470325f887758c95d5320f52f9ce0df055a55940e"
 
 [[package]]
 name = "polkadot-availability-store"
-version = "0.8.19"
-source = "git+https://github.com/paritytech/polkadot?branch=cumulus-branch#589bad99550989a793351dca05b88a34bbf0dbbf"
+version = "0.8.22"
+source = "git+https://github.com/paritytech/polkadot?branch=cumulus-branch#0674ba962c7494ec88cd06dd1ae0d6f6edf97975"
 dependencies = [
  "derive_more 0.99.9",
  "exit-future 0.2.0",
@@ -4494,8 +4493,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-cli"
-version = "0.8.19"
-source = "git+https://github.com/paritytech/polkadot?branch=cumulus-branch#589bad99550989a793351dca05b88a34bbf0dbbf"
+version = "0.8.22"
+source = "git+https://github.com/paritytech/polkadot?branch=cumulus-branch#0674ba962c7494ec88cd06dd1ae0d6f6edf97975"
 dependencies = [
  "frame-benchmarking-cli",
  "futures 0.3.5",
@@ -4509,6 +4508,7 @@ dependencies = [
  "sp-api",
  "sp-core",
  "sp-runtime",
+ "sp-trie",
  "structopt",
  "substrate-build-script-utils",
  "tokio 0.2.22",
@@ -4516,8 +4516,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-collator"
-version = "0.8.19"
-source = "git+https://github.com/paritytech/polkadot?branch=cumulus-branch#589bad99550989a793351dca05b88a34bbf0dbbf"
+version = "0.8.22"
+source = "git+https://github.com/paritytech/polkadot?branch=cumulus-branch#0674ba962c7494ec88cd06dd1ae0d6f6edf97975"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 2.0.2",
@@ -4544,7 +4544,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "0.7.30"
-source = "git+https://github.com/paritytech/polkadot?branch=cumulus-branch#589bad99550989a793351dca05b88a34bbf0dbbf"
+source = "git+https://github.com/paritytech/polkadot?branch=cumulus-branch#0674ba962c7494ec88cd06dd1ae0d6f6edf97975"
 dependencies = [
  "parity-scale-codec",
  "sp-core",
@@ -4554,8 +4554,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-erasure-coding"
-version = "0.8.19"
-source = "git+https://github.com/paritytech/polkadot?branch=cumulus-branch#589bad99550989a793351dca05b88a34bbf0dbbf"
+version = "0.8.22"
+source = "git+https://github.com/paritytech/polkadot?branch=cumulus-branch#0674ba962c7494ec88cd06dd1ae0d6f6edf97975"
 dependencies = [
  "derive_more 0.15.0",
  "parity-scale-codec",
@@ -4567,8 +4567,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-network"
-version = "0.8.19"
-source = "git+https://github.com/paritytech/polkadot?branch=cumulus-branch#589bad99550989a793351dca05b88a34bbf0dbbf"
+version = "0.8.22"
+source = "git+https://github.com/paritytech/polkadot?branch=cumulus-branch#0674ba962c7494ec88cd06dd1ae0d6f6edf97975"
 dependencies = [
  "arrayvec 0.4.12",
  "bytes 0.5.6",
@@ -4595,8 +4595,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-parachain"
-version = "0.8.19"
-source = "git+https://github.com/paritytech/polkadot?branch=cumulus-branch#589bad99550989a793351dca05b88a34bbf0dbbf"
+version = "0.8.22"
+source = "git+https://github.com/paritytech/polkadot?branch=cumulus-branch#0674ba962c7494ec88cd06dd1ae0d6f6edf97975"
 dependencies = [
  "derive_more 0.99.9",
  "futures 0.3.5",
@@ -4616,8 +4616,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-primitives"
-version = "0.8.19"
-source = "git+https://github.com/paritytech/polkadot?branch=cumulus-branch#589bad99550989a793351dca05b88a34bbf0dbbf"
+version = "0.8.22"
+source = "git+https://github.com/paritytech/polkadot?branch=cumulus-branch#0674ba962c7494ec88cd06dd1ae0d6f6edf97975"
 dependencies = [
  "bitvec",
  "frame-system",
@@ -4639,8 +4639,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-rpc"
-version = "0.8.19"
-source = "git+https://github.com/paritytech/polkadot?branch=cumulus-branch#589bad99550989a793351dca05b88a34bbf0dbbf"
+version = "0.8.22"
+source = "git+https://github.com/paritytech/polkadot?branch=cumulus-branch#0674ba962c7494ec88cd06dd1ae0d6f6edf97975"
 dependencies = [
  "jsonrpc-core",
  "pallet-transaction-payment-rpc",
@@ -4666,8 +4666,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-runtime"
-version = "0.8.19"
-source = "git+https://github.com/paritytech/polkadot?branch=cumulus-branch#589bad99550989a793351dca05b88a34bbf0dbbf"
+version = "0.8.22"
+source = "git+https://github.com/paritytech/polkadot?branch=cumulus-branch#0674ba962c7494ec88cd06dd1ae0d6f6edf97975"
 dependencies = [
  "bitvec",
  "frame-executive",
@@ -4731,8 +4731,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-runtime-common"
-version = "0.8.19"
-source = "git+https://github.com/paritytech/polkadot?branch=cumulus-branch#589bad99550989a793351dca05b88a34bbf0dbbf"
+version = "0.8.22"
+source = "git+https://github.com/paritytech/polkadot?branch=cumulus-branch#0674ba962c7494ec88cd06dd1ae0d6f6edf97975"
 dependencies = [
  "bitvec",
  "frame-support",
@@ -4748,6 +4748,7 @@ dependencies = [
  "pallet-vesting",
  "parity-scale-codec",
  "polkadot-primitives",
+ "polkadot-runtime-parachains",
  "rustc-hex",
  "serde",
  "serde_derive",
@@ -4763,9 +4764,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "polkadot-runtime-parachains"
+version = "0.8.0"
+source = "git+https://github.com/paritytech/polkadot?branch=cumulus-branch#0674ba962c7494ec88cd06dd1ae0d6f6edf97975"
+dependencies = [
+ "bitvec",
+ "frame-support",
+ "frame-system",
+ "pallet-authorship",
+ "pallet-balances",
+ "pallet-offences",
+ "pallet-session",
+ "pallet-staking",
+ "pallet-timestamp",
+ "pallet-vesting",
+ "parity-scale-codec",
+ "polkadot-primitives",
+ "rand 0.7.3",
+ "rand_chacha 0.2.2",
+ "rustc-hex",
+ "serde",
+ "sp-api",
+ "sp-core",
+ "sp-inherents",
+ "sp-io",
+ "sp-runtime",
+ "sp-session",
+ "sp-staking",
+ "sp-std",
+]
+
+[[package]]
 name = "polkadot-service"
-version = "0.8.19"
-source = "git+https://github.com/paritytech/polkadot?branch=cumulus-branch#589bad99550989a793351dca05b88a34bbf0dbbf"
+version = "0.8.22"
+source = "git+https://github.com/paritytech/polkadot?branch=cumulus-branch#0674ba962c7494ec88cd06dd1ae0d6f6edf97975"
 dependencies = [
  "frame-benchmarking",
  "frame-system-rpc-runtime-api",
@@ -4786,6 +4818,7 @@ dependencies = [
  "polkadot-rpc",
  "polkadot-runtime",
  "polkadot-validation",
+ "rococo-runtime",
  "sc-authority-discovery",
  "sc-block-builder",
  "sc-chain-spec",
@@ -4823,8 +4856,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-statement-table"
-version = "0.8.19"
-source = "git+https://github.com/paritytech/polkadot?branch=cumulus-branch#589bad99550989a793351dca05b88a34bbf0dbbf"
+version = "0.8.22"
+source = "git+https://github.com/paritytech/polkadot?branch=cumulus-branch#0674ba962c7494ec88cd06dd1ae0d6f6edf97975"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -4833,8 +4866,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-test-runtime"
-version = "0.8.19"
-source = "git+https://github.com/paritytech/polkadot?branch=cumulus-branch#589bad99550989a793351dca05b88a34bbf0dbbf"
+version = "0.8.22"
+source = "git+https://github.com/paritytech/polkadot?branch=cumulus-branch#0674ba962c7494ec88cd06dd1ae0d6f6edf97975"
 dependencies = [
  "bitvec",
  "frame-executive",
@@ -4888,7 +4921,7 @@ dependencies = [
 [[package]]
 name = "polkadot-test-runtime-client"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/polkadot?branch=cumulus-branch#589bad99550989a793351dca05b88a34bbf0dbbf"
+source = "git+https://github.com/paritytech/polkadot?branch=cumulus-branch#0674ba962c7494ec88cd06dd1ae0d6f6edf97975"
 dependencies = [
  "futures 0.3.5",
  "pallet-timestamp",
@@ -4912,7 +4945,7 @@ dependencies = [
 [[package]]
 name = "polkadot-test-service"
 version = "0.8.2"
-source = "git+https://github.com/paritytech/polkadot?branch=cumulus-branch#589bad99550989a793351dca05b88a34bbf0dbbf"
+source = "git+https://github.com/paritytech/polkadot?branch=cumulus-branch#0674ba962c7494ec88cd06dd1ae0d6f6edf97975"
 dependencies = [
  "frame-benchmarking",
  "frame-system",
@@ -4958,8 +4991,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-validation"
-version = "0.8.19"
-source = "git+https://github.com/paritytech/polkadot?branch=cumulus-branch#589bad99550989a793351dca05b88a34bbf0dbbf"
+version = "0.8.22"
+source = "git+https://github.com/paritytech/polkadot?branch=cumulus-branch#0674ba962c7494ec88cd06dd1ae0d6f6edf97975"
 dependencies = [
  "ansi_term 0.12.1",
  "bitvec",
@@ -5648,6 +5681,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "rococo-runtime"
+version = "0.8.22"
+source = "git+https://github.com/paritytech/polkadot?branch=cumulus-branch#0674ba962c7494ec88cd06dd1ae0d6f6edf97975"
+dependencies = [
+ "bitvec",
+ "frame-executive",
+ "frame-support",
+ "frame-system",
+ "frame-system-rpc-runtime-api",
+ "hex-literal",
+ "log 0.3.9",
+ "pallet-authority-discovery",
+ "pallet-authorship",
+ "pallet-babe",
+ "pallet-balances",
+ "pallet-collective",
+ "pallet-democracy",
+ "pallet-elections-phragmen",
+ "pallet-finality-tracker",
+ "pallet-grandpa",
+ "pallet-identity",
+ "pallet-im-online",
+ "pallet-indices",
+ "pallet-membership",
+ "pallet-multisig",
+ "pallet-nicks",
+ "pallet-offences",
+ "pallet-proxy",
+ "pallet-randomness-collective-flip",
+ "pallet-recovery",
+ "pallet-scheduler",
+ "pallet-session",
+ "pallet-society",
+ "pallet-staking",
+ "pallet-staking-reward-curve",
+ "pallet-sudo",
+ "pallet-timestamp",
+ "pallet-transaction-payment",
+ "pallet-transaction-payment-rpc-runtime-api",
+ "pallet-treasury",
+ "pallet-utility",
+ "pallet-vesting",
+ "parity-scale-codec",
+ "polkadot-parachain",
+ "polkadot-primitives",
+ "polkadot-runtime-common",
+ "rustc-hex",
+ "serde",
+ "serde_derive",
+ "smallvec 1.4.1",
+ "sp-api",
+ "sp-authority-discovery",
+ "sp-block-builder",
+ "sp-consensus-babe",
+ "sp-core",
+ "sp-inherents",
+ "sp-io",
+ "sp-offchain",
+ "sp-runtime",
+ "sp-session",
+ "sp-std",
+ "sp-transaction-pool",
+ "sp-version",
+ "static_assertions",
+ "substrate-wasm-builder-runner 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rpassword"
 version = "4.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5756,7 +5857,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "bytes 0.5.6",
  "derive_more 0.99.9",
@@ -5783,7 +5884,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -5807,7 +5908,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -5824,7 +5925,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "impl-trait-for-tuples",
  "sc-chain-spec-derive",
@@ -5840,7 +5941,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.19",
@@ -5851,7 +5952,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
@@ -5892,7 +5993,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "derive_more 0.99.9",
  "fnv",
@@ -5928,7 +6029,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "blake2-rfc",
  "hash-db",
@@ -5944,6 +6045,7 @@ dependencies = [
  "sc-client-api",
  "sc-executor",
  "sc-state-db",
+ "sp-arithmetic",
  "sp-blockchain",
  "sp-consensus",
  "sp-core",
@@ -5957,7 +6059,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "sc-client-api",
  "sp-blockchain",
@@ -5968,7 +6070,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "derive_more 0.99.9",
  "fork-tree",
@@ -5983,6 +6085,7 @@ dependencies = [
  "parking_lot 0.10.2",
  "pdqselect",
  "rand 0.7.3",
+ "retain_mut",
  "sc-client-api",
  "sc-consensus-epochs",
  "sc-consensus-slots",
@@ -6003,6 +6106,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-timestamp",
+ "sp-utils",
  "sp-version",
  "substrate-prometheus-endpoint",
 ]
@@ -6010,7 +6114,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "derive_more 0.99.9",
  "futures 0.3.5",
@@ -6034,7 +6138,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -6047,7 +6151,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -6070,7 +6174,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-uncles"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "log 0.4.11",
  "sc-client-api",
@@ -6084,7 +6188,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "derive_more 0.99.9",
  "lazy_static",
@@ -6112,7 +6216,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "derive_more 0.99.9",
  "log 0.4.11",
@@ -6129,7 +6233,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "log 0.4.11",
  "parity-scale-codec",
@@ -6144,7 +6248,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "cranelift-codegen",
  "cranelift-wasm",
@@ -6165,7 +6269,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "assert_matches",
  "derive_more 0.99.9",
@@ -6203,7 +6307,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa-rpc"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "derive_more 0.99.9",
  "finality-grandpa",
@@ -6220,7 +6324,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "ansi_term 0.12.1",
  "futures 0.3.5",
@@ -6238,7 +6342,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "derive_more 0.99.9",
  "hex",
@@ -6254,7 +6358,7 @@ dependencies = [
 [[package]]
 name = "sc-light"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "hash-db",
  "lazy_static",
@@ -6273,7 +6377,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "bitflags",
  "bs58",
@@ -6325,7 +6429,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -6340,7 +6444,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "bytes 0.5.6",
  "fnv",
@@ -6367,7 +6471,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "futures 0.3.5",
  "libp2p",
@@ -6380,7 +6484,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "log 0.4.11",
  "substrate-prometheus-endpoint",
@@ -6389,7 +6493,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "futures 0.3.5",
  "hash-db",
@@ -6421,7 +6525,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "derive_more 0.99.9",
  "futures 0.3.5",
@@ -6445,7 +6549,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-http-server",
@@ -6461,7 +6565,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "derive_more 0.99.9",
  "directories",
@@ -6524,7 +6628,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "log 0.4.11",
  "parity-scale-codec",
@@ -6538,7 +6642,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -6559,7 +6663,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "erased-serde",
  "log 0.4.11",
@@ -6576,7 +6680,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-graph"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "derive_more 0.99.9",
  "futures 0.3.5",
@@ -6597,7 +6701,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "derive_more 0.99.9",
  "futures 0.3.5",
@@ -7023,7 +7127,7 @@ dependencies = [
 [[package]]
 name = "sp-allocator"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "derive_more 0.99.9",
  "log 0.4.11",
@@ -7035,7 +7139,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -7050,7 +7154,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
@@ -7062,7 +7166,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -7074,7 +7178,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "integer-sqrt",
  "num-traits 0.2.12",
@@ -7087,7 +7191,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7099,7 +7203,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -7110,7 +7214,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7122,7 +7226,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "derive_more 0.99.9",
  "log 0.4.11",
@@ -7139,7 +7243,7 @@ dependencies = [
 [[package]]
 name = "sp-chain-spec"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "serde",
  "serde_json",
@@ -7148,7 +7252,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "derive_more 0.99.9",
  "futures 0.3.5",
@@ -7158,6 +7262,7 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.10.2",
  "serde",
+ "sp-api",
  "sp-core",
  "sp-inherents",
  "sp-runtime",
@@ -7173,7 +7278,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7187,7 +7292,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "merlin",
  "parity-scale-codec",
@@ -7206,7 +7311,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -7215,7 +7320,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",
@@ -7227,7 +7332,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -7271,7 +7376,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "kvdb",
  "parking_lot 0.10.2",
@@ -7280,7 +7385,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "proc-macro2 1.0.19",
  "quote 1.0.7",
@@ -7290,7 +7395,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -7301,7 +7406,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "finality-grandpa",
  "log 0.4.11",
@@ -7317,7 +7422,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-tracker"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -7327,7 +7432,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "derive_more 0.99.9",
  "parity-scale-codec",
@@ -7339,7 +7444,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "futures 0.3.5",
  "hash-db",
@@ -7360,7 +7465,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -7371,7 +7476,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -7383,7 +7488,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections-compact"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.19",
@@ -7394,7 +7499,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -7404,7 +7509,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "backtrace",
  "log 0.4.11",
@@ -7413,7 +7518,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "serde",
  "sp-core",
@@ -7422,7 +7527,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -7444,7 +7549,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "parity-scale-codec",
  "primitive-types",
@@ -7459,7 +7564,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -7471,7 +7576,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "serde",
  "serde_json",
@@ -7480,7 +7585,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7493,7 +7598,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -7503,7 +7608,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "hash-db",
  "itertools 0.9.0",
@@ -7524,12 +7629,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 
 [[package]]
 name = "sp-storage"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "impl-serde 0.2.3",
  "ref-cast",
@@ -7541,7 +7646,7 @@ dependencies = [
 [[package]]
 name = "sp-test-primitives"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "parity-scale-codec",
  "parity-util-mem",
@@ -7554,7 +7659,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -7568,7 +7673,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "log 0.4.11",
  "rental",
@@ -7578,7 +7683,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "derive_more 0.99.9",
  "futures 0.3.5",
@@ -7593,7 +7698,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -7607,7 +7712,7 @@ dependencies = [
 [[package]]
 name = "sp-utils"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "futures 0.3.5",
  "futures-core",
@@ -7619,7 +7724,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "impl-serde 0.2.3",
  "parity-scale-codec",
@@ -7631,7 +7736,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -7750,7 +7855,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "platforms",
 ]
@@ -7758,7 +7863,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.5",
@@ -7781,7 +7886,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "async-std",
  "derive_more 0.99.9",
@@ -7795,7 +7900,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "futures 0.1.29",
  "futures 0.3.5",
@@ -7821,7 +7926,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "cfg-if",
  "frame-executive",
@@ -7861,7 +7966,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime-client"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 dependencies = [
  "futures 0.3.5",
  "parity-scale-codec",
@@ -7882,7 +7987,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder-runner"
 version = "1.0.6"
-source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#b066029a23fdc0e6b7224a3c241c16f5122dd31b"
+source = "git+https://github.com/paritytech/substrate?branch=cumulus-branch#270a992bf299cd41b2ed4e211814d2a958e3bfc8"
 
 [[package]]
 name = "substrate-wasm-builder-runner"
@@ -9048,8 +9153,8 @@ dependencies = [
 
 [[package]]
 name = "westend-runtime"
-version = "0.8.19"
-source = "git+https://github.com/paritytech/polkadot?branch=cumulus-branch#589bad99550989a793351dca05b88a34bbf0dbbf"
+version = "0.8.22"
+source = "git+https://github.com/paritytech/polkadot?branch=cumulus-branch#0674ba962c7494ec88cd06dd1ae0d6f6edf97975"
 dependencies = [
  "bitvec",
  "frame-executive",

--- a/collator/src/lib.rs
+++ b/collator/src/lib.rs
@@ -29,9 +29,9 @@ use cumulus_primitives::{
 };
 use cumulus_runtime::ParachainBlockData;
 
-use sc_client_api::{BlockBackend, BlockchainEvents, Finalizer, StateBackend, UsageProvider};
+use sc_client_api::{BlockBackend, Finalizer, StateBackend, UsageProvider};
 use sc_service::Configuration;
-use sp_api::{ApiExt, ProvideRuntimeApi};
+use sp_api::ApiExt;
 use sp_blockchain::HeaderBackend;
 use sp_consensus::{
 	BlockImport, BlockImportParams, BlockOrigin, BlockStatus, Environment, Error as ConsensusError,
@@ -41,15 +41,15 @@ use sp_core::traits::SpawnNamed;
 use sp_inherents::{InherentData, InherentDataProviders};
 use sp_runtime::{
 	generic::BlockId,
-	traits::{Block as BlockT, HashFor, Header as HeaderT},
+	traits::{BlakeTwo256, Block as BlockT, Header as HeaderT},
 };
 
 use polkadot_collator::{
 	BuildParachainContext, Network as CollatorNetwork, ParachainContext, RuntimeApiCollection,
 };
 use polkadot_primitives::v0::{
-	self as parachain, BlockData, GlobalValidationData, Id as ParaId, LocalValidationData,
-	Block as PBlock, DownwardMessage, Hash as PHash,
+	self as parachain, Block as PBlock, BlockData, DownwardMessage, GlobalValidationData,
+	Hash as PHash, Id as ParaId, LocalValidationData,
 };
 
 use codec::{Decode, Encode};
@@ -321,11 +321,7 @@ where
 			let (header, extrinsics) = block.deconstruct();
 
 			// Create the parachain block data for the validators.
-			let b = ParachainBlockData::<Block>::new(
-				header.clone(),
-				extrinsics,
-				proof,
-			);
+			let b = ParachainBlockData::<Block>::new(header.clone(), extrinsics, proof);
 
 			let mut block_import_params = BlockImportParams::new(BlockOrigin::Own, header);
 			block_import_params.body = Some(b.extrinsics().to_vec());
@@ -431,23 +427,90 @@ where
 {
 	type ParachainContext = Collator<Block, PF, BI, BS>;
 
-	fn build<PClient, Spawner, Extrinsic>(
+	fn build<Spawner>(
 		self,
-		polkadot_client: Arc<PClient>,
+		polkadot_client: polkadot_collator::Client,
 		spawner: Spawner,
 		polkadot_network: impl CollatorNetwork + Clone + 'static,
 	) -> Result<Self::ParachainContext, ()>
 	where
-		PClient: ProvideRuntimeApi<PBlock>
-			+ BlockchainEvents<PBlock>
-			+ HeaderBackend<PBlock>
-			+ Send
-			+ Sync
-			+ 'static,
-		PClient::Api: RuntimeApiCollection<Extrinsic>,
-		<PClient::Api as ApiExt<PBlock>>::StateBackend: StateBackend<HashFor<PBlock>>,
 		Spawner: SpawnNamed + Clone + Send + Sync + 'static,
-		Extrinsic: codec::Codec + Send + Sync + 'static,
+	{
+		let CollatorBuilder {
+			proposer_factory,
+			inherent_data_providers,
+			block_import,
+			block_status,
+			para_id,
+			client,
+			announce_block,
+			delayed_block_announce_validator,
+			_marker,
+		} = self;
+		polkadot_client.execute(CollatorBuilderWithClient {
+			spawner,
+			polkadot_network,
+			proposer_factory,
+			inherent_data_providers,
+			block_import,
+			block_status,
+			para_id,
+			client,
+			announce_block,
+			delayed_block_announce_validator,
+			_marker,
+		})
+	}
+}
+
+pub struct CollatorBuilderWithClient<Block: BlockT, PF, BI, Backend, Client, BS, Spawner, Network> {
+	proposer_factory: PF,
+	inherent_data_providers: InherentDataProviders,
+	block_import: BI,
+	block_status: Arc<BS>,
+	para_id: ParaId,
+	client: Arc<Client>,
+	announce_block: Arc<dyn Fn(Block::Hash, Vec<u8>) + Send + Sync>,
+	delayed_block_announce_validator: DelayedBlockAnnounceValidator<Block>,
+	_marker: PhantomData<(Block, Backend)>,
+	spawner: Spawner,
+	polkadot_network: Network,
+}
+
+impl<Block: BlockT, PF, BI, Backend, Client, BS, Spawner, Network>
+	polkadot_service::ExecuteWithClient
+	for CollatorBuilderWithClient<Block, PF, BI, Backend, Client, BS, Spawner, Network>
+where
+	PF: Environment<Block> + Send + 'static,
+	BI: BlockImport<Block, Error = sp_consensus::Error, Transaction = TransactionFor<PF, Block>>
+		+ Send
+		+ Sync
+		+ 'static,
+	Backend: sc_client_api::Backend<Block> + 'static,
+	Client: Finalizer<Block, Backend>
+		+ UsageProvider<Block>
+		+ HeaderBackend<Block>
+		+ Send
+		+ Sync
+		+ BlockBackend<Block>
+		+ 'static,
+	for<'a> &'a Client: BlockImport<Block>,
+	BS: BlockBackend<Block>,
+	Spawner: SpawnNamed + Clone + Send + Sync + 'static,
+	Network: CollatorNetwork + Clone + 'static,
+{
+	type Output = Result<Collator<Block, PF, BI, BS>, ()>;
+
+	fn execute_with_client<PClient, Api, PBackend>(
+		self,
+		polkadot_client: Arc<PClient>,
+	) -> Self::Output
+	where
+		<Api as ApiExt<PBlock>>::StateBackend: sp_api::StateBackend<BlakeTwo256>,
+		PBackend: sc_client_api::Backend<PBlock>,
+		PBackend::State: StateBackend<BlakeTwo256>,
+		Api: RuntimeApiCollection<StateBackend = PBackend::State>,
+		PClient: polkadot_service::PolkadotClient<PBlock, PBackend, Api = Api> + 'static,
 	{
 		self.delayed_block_announce_validator
 			.set(Box::new(JustifiedBlockAnnounceValidator::new(
@@ -463,15 +526,16 @@ where
 				}
 			};
 
-		spawner.spawn("cumulus-follow-polkadot", follow.map(|_| ()).boxed());
+		self.spawner
+			.spawn("cumulus-follow-polkadot", follow.map(|_| ()).boxed());
 
 		Ok(Collator::new(
 			self.proposer_factory,
 			self.inherent_data_providers,
-			polkadot_network,
+			self.polkadot_network,
 			self.block_import,
 			self.block_status,
-			Arc::new(spawner),
+			Arc::new(self.spawner),
 			self.announce_block,
 		))
 	}
@@ -618,7 +682,7 @@ mod tests {
 		);
 		let context = builder
 			.build(
-				Arc::new(
+				polkadot_service::Client::Polkadot(Arc::new(
 					substrate_test_client::TestClientBuilder::<_, _, _, ()>::default()
 						.build_with_native_executor::<polkadot_service::polkadot_runtime::RuntimeApi, _>(
 							Some(NativeExecutor::<polkadot_service::PolkadotExecutor>::new(
@@ -628,7 +692,7 @@ mod tests {
 							)),
 						)
 						.0,
-				),
+				)),
 				spawner,
 				DummyCollatorNetwork,
 			)

--- a/collator/src/lib.rs
+++ b/collator/src/lib.rs
@@ -447,7 +447,7 @@ where
 			delayed_block_announce_validator,
 			_marker,
 		} = self;
-		polkadot_client.execute(CollatorBuilderWithClient {
+		polkadot_client.execute_with(CollatorBuilderWithClient {
 			spawner,
 			polkadot_network,
 			proposer_factory,
@@ -510,7 +510,7 @@ where
 		PBackend: sc_client_api::Backend<PBlock>,
 		PBackend::State: StateBackend<BlakeTwo256>,
 		Api: RuntimeApiCollection<StateBackend = PBackend::State>,
-		PClient: polkadot_service::PolkadotClient<PBlock, PBackend, Api = Api> + 'static,
+		PClient: polkadot_service::AbstractClient<PBlock, PBackend, Api = Api> + 'static,
 	{
 		self.delayed_block_announce_validator
 			.set(Box::new(JustifiedBlockAnnounceValidator::new(

--- a/runtime/src/validate_block/tests.rs
+++ b/runtime/src/validate_block/tests.rs
@@ -62,7 +62,7 @@ fn call_validate_block(
 
 	executor
 		.call_in_wasm(
-			&WASM_BINARY,
+			&WASM_BINARY.expect("You need to build the WASM binaries to run the tests!"),
 			None,
 			"validate_block",
 			&params,

--- a/test/parachain/Cargo.toml
+++ b/test/parachain/Cargo.toml
@@ -40,6 +40,7 @@ sc-network = { git = "https://github.com/paritytech/substrate", branch = "cumulu
 sc-basic-authorship = { git = "https://github.com/paritytech/substrate", branch = "cumulus-branch", version = "0.8.0-rc5" }
 sp-timestamp = { git = "https://github.com/paritytech/substrate", branch = "cumulus-branch" }
 sp-trie = { git = "https://github.com/paritytech/substrate", branch = "cumulus-branch" }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "cumulus-branch" }
 sc-finality-grandpa = { git = "https://github.com/paritytech/substrate", branch = "cumulus-branch" }
 sc-informant = { git = "https://github.com/paritytech/substrate", branch = "cumulus-branch" }
 sc-chain-spec = { git = "https://github.com/paritytech/substrate", branch = "cumulus-branch" }

--- a/test/parachain/build.rs
+++ b/test/parachain/build.rs
@@ -14,29 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::{env, path::PathBuf};
-
 use substrate_build_script_utils::{generate_cargo_keys, rerun_if_git_head_changed};
 
 fn main() {
 	generate_cargo_keys();
 	rerun_if_git_head_changed();
-
-	let mut manifest_dir = PathBuf::from(
-		env::var("CARGO_MANIFEST_DIR").expect("`CARGO_MANIFEST_DIR` is always set by cargo."),
-	);
-
-	while manifest_dir.parent().is_some() {
-		if manifest_dir.join(".git/HEAD").exists() {
-			println!(
-				"cargo:rerun-if-changed={}",
-				manifest_dir.join(".git/HEAD").display()
-			);
-			return;
-		}
-
-		manifest_dir.pop();
-	}
-
-	println!("cargo:warning=Could not find `.git/HEAD` from manifest dir!");
 }

--- a/test/parachain/runtime/build.rs
+++ b/test/parachain/runtime/build.rs
@@ -19,7 +19,7 @@ use wasm_builder_runner::WasmBuilder;
 fn main() {
 	WasmBuilder::new()
 		.with_current_project()
-		.with_wasm_builder_from_crates("1.0.11")
+		.with_wasm_builder_from_crates("2.0.0")
 		.export_heap_base()
 		.import_memory()
 		.build()

--- a/test/parachain/src/chain_spec.rs
+++ b/test/parachain/src/chain_spec.rs
@@ -83,7 +83,7 @@ fn testnet_genesis(
 ) -> GenesisConfig {
 	GenesisConfig {
 		frame_system: Some(SystemConfig {
-			code: WASM_BINARY.to_vec(),
+			code: WASM_BINARY.expect("WASM binary was not build, please build it!").to_vec(),
 			changes_trie_config: Default::default(),
 		}),
 		pallet_balances: Some(BalancesConfig {

--- a/test/parachain/src/integration_test.rs
+++ b/test/parachain/src/integration_test.rs
@@ -42,9 +42,7 @@ static INTEGRATION_TEST_ALLOWED_TIME: Option<&str> = option_env!("INTEGRATION_TE
 #[tokio::test]
 #[ignore]
 async fn integration_test() {
-	let task_executor: TaskExecutor = (|fut, _| {
-		spawn(fut).map(|_| ())
-	}).into();
+	let task_executor: TaskExecutor = (|fut, _| spawn(fut).map(|_| ())).into();
 
 	// start alice
 	let mut alice =
@@ -82,7 +80,10 @@ async fn integration_test() {
 				Info {
 					scheduling: Scheduling::Always,
 				},
-				parachain_runtime::WASM_BINARY.to_vec().into(),
+				parachain_runtime::WASM_BINARY
+					.expect("You need to build the WASM binary to run this test!")
+					.to_vec()
+					.into(),
 				genesis_state.into(),
 			)),
 		)));
@@ -104,7 +105,8 @@ async fn integration_test() {
 		let parachain_config =
 			parachain_config(task_executor.clone(), Charlie, vec![], para_id).unwrap();
 		let (_service, charlie_client) =
-			crate::service::run_collator(parachain_config, key, polkadot_config, para_id, true).unwrap();
+			crate::service::run_collator(parachain_config, key, polkadot_config, para_id, true)
+				.unwrap();
 		sleep(Duration::from_secs(3)).await;
 		charlie_client.wait_for_blocks(4).await;
 

--- a/test/parachain/src/service.rs
+++ b/test/parachain/src/service.rs
@@ -27,7 +27,7 @@ use std::sync::Arc;
 use sp_core::crypto::Pair;
 use sp_trie::PrefixedMemoryDB;
 use sp_runtime::traits::{BlakeTwo256, Block as BlockT};
-use polkadot_service::{PolkadotClient, RuntimeApiCollection};
+use polkadot_service::{AbstractClient, RuntimeApiCollection};
 
 // Our native executor instance.
 native_executor_instance!(
@@ -222,7 +222,7 @@ pub fn run_collator(
 		let polkadot_future = async move {
 			polkadot_task_manager.future().await.expect("polkadot essential task failed");
 		};
-		client.execute(SetDelayedBlockAnnounceValidator { block_announce_validator, para_id: id });
+		client.execute_with(SetDelayedBlockAnnounceValidator { block_announce_validator, para_id: id });
 
 		task_manager
 			.spawn_essential_handle()
@@ -245,7 +245,7 @@ impl<B: BlockT> polkadot_service::ExecuteWithClient for SetDelayedBlockAnnounceV
 		Backend: sc_client_api::Backend<PBlock>,
 		Backend::State: sp_api::StateBackend<BlakeTwo256>,
 		Api: RuntimeApiCollection<StateBackend = Backend::State>,
-		Client: PolkadotClient<PBlock, Backend, Api = Api> + 'static
+		Client: AbstractClient<PBlock, Backend, Api = Api> + 'static
 	{
 		self.block_announce_validator.set(Box::new(JustifiedBlockAnnounceValidator::new(client, self.para_id)));
 	}

--- a/test/parachain/src/service.rs
+++ b/test/parachain/src/service.rs
@@ -16,9 +16,9 @@
 
 use ansi_term::Color;
 use cumulus_collator::{prepare_collator_config, CollatorBuilder};
-use cumulus_network::DelayedBlockAnnounceValidator;
+use cumulus_network::{DelayedBlockAnnounceValidator, JustifiedBlockAnnounceValidator};
 use futures::{future::ready, FutureExt};
-use polkadot_primitives::v0::CollatorPair;
+use polkadot_primitives::v0::{CollatorPair, Block as PBlock, Id as ParaId};
 use sc_executor::native_executor_instance;
 pub use sc_executor::NativeExecutor;
 use sc_informant::OutputFormat;
@@ -26,7 +26,8 @@ use sc_service::{Configuration, PartialComponents, TaskManager, TFullBackend, TF
 use std::sync::Arc;
 use sp_core::crypto::Pair;
 use sp_trie::PrefixedMemoryDB;
-use sp_runtime::traits::BlakeTwo256;
+use sp_runtime::traits::{BlakeTwo256, Block as BlockT};
+use polkadot_service::{PolkadotClient, RuntimeApiCollection};
 
 // Our native executor instance.
 native_executor_instance!(
@@ -206,11 +207,11 @@ pub fn run_collator(
 			.spawn("polkadot", polkadot_future);
 	} else {
 		let is_light = matches!(polkadot_config.role, Role::Light);
-		let builder = polkadot_service::NodeBuilder::new(polkadot_config);
-		let mut polkadot_task_manager = if is_light {
-			return Err("Light client not supported.".into());
+		let (mut polkadot_task_manager, client, _) = if is_light {
+			Err("Light client not supported.".into())
 		} else {
-			builder.build_full(
+			polkadot_service::build_full(
+				polkadot_config,
 				Some((key.public(), id)),
 				None,
 				false,
@@ -221,6 +222,7 @@ pub fn run_collator(
 		let polkadot_future = async move {
 			polkadot_task_manager.future().await.expect("polkadot essential task failed");
 		};
+		client.execute(SetDelayedBlockAnnounceValidator { block_announce_validator, para_id: id });
 
 		task_manager
 			.spawn_essential_handle()
@@ -228,4 +230,23 @@ pub fn run_collator(
 	}
 
 	Ok((task_manager, client))
+}
+
+struct SetDelayedBlockAnnounceValidator<B: BlockT> {
+	block_announce_validator: DelayedBlockAnnounceValidator<B>,
+	para_id: ParaId,
+}
+
+impl<B: BlockT> polkadot_service::ExecuteWithClient for SetDelayedBlockAnnounceValidator<B> {
+	type Output = ();
+
+	fn execute_with_client<Client, Api, Backend>(self, client: Arc<Client>) -> Self::Output
+		where<Api as sp_api::ApiExt<PBlock>>::StateBackend: sp_api::StateBackend<BlakeTwo256>,
+		Backend: sc_client_api::Backend<PBlock>,
+		Backend::State: sp_api::StateBackend<BlakeTwo256>,
+		Api: RuntimeApiCollection<StateBackend = Backend::State>,
+		Client: PolkadotClient<PBlock, Backend, Api = Api> + 'static
+	{
+		self.block_announce_validator.set(Box::new(JustifiedBlockAnnounceValidator::new(client, self.para_id)));
+	}
 }

--- a/test/runtime/build.rs
+++ b/test/runtime/build.rs
@@ -19,7 +19,7 @@ use wasm_builder_runner::WasmBuilder;
 fn main() {
 	WasmBuilder::new()
 		.with_current_project()
-		.with_wasm_builder_from_crates("1.0.11")
+		.with_wasm_builder_from_crates("2.0.0")
 		.export_heap_base()
 		.import_memory()
 		.build()


### PR DESCRIPTION
Just print a warning when the internal block announcement validation of the `DelayedBlockAnnounceValidator` is not yet set. 

This also sets the block announcement validator for normal nodes.