### PR TITLE
Move `pub storage ParachainId` parameter type to the pallet

### DIFF
--- a/test/parachain/runtime/src/lib.rs
+++ b/test/parachain/runtime/src/lib.rs
@@ -36,6 +36,7 @@ use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
 
 mod message_example;
+use message_example::ParachainId;
 
 // A few exports that help ease life for downstream crates.
 pub use frame_support::{
@@ -241,10 +242,6 @@ impl pallet_sudo::Trait for Runtime {
 impl cumulus_parachain_upgrade::Trait for Runtime {
 	type Event = Event;
 	type OnValidationFunctionParams = ();
-}
-
-parameter_types! {
-	pub storage ParachainId: cumulus_primitives::ParaId = 100.into();
 }
 
 impl cumulus_message_broker::Trait for Runtime {

--- a/test/parachain/runtime/src/message_example.rs
+++ b/test/parachain/runtime/src/message_example.rs
@@ -18,7 +18,7 @@
 //! downward messages.
 
 use frame_support::{
-	decl_event, decl_module, decl_storage,
+	decl_event, decl_module, decl_storage, parameter_types,
 	traits::{Currency, ExistenceRequirement, WithdrawReason},
 };
 use frame_system::ensure_signed;
@@ -55,6 +55,10 @@ pub trait Trait: frame_system::Trait {
 	type XCMPMessageSender: XCMPMessageSender<XCMPMessage<Self::AccountId, BalanceOf<Self>>>;
 }
 
+parameter_types! {
+	pub storage ParachainId: cumulus_primitives::ParaId = 100.into();
+}
+
 // This pallet's storage items.
 decl_storage! {
 	trait Store for Module<T: Trait> as ParachainUpgrade {}
@@ -63,7 +67,7 @@ decl_storage! {
 		build(|config: &Self| {
 			// This is basically a hack to make the parachain id easily configurable.
 			// Could also be done differently, but yeah..
-			crate::ParachainId::set(&config.parachain_id);
+			ParachainId::set(&config.parachain_id);
 		});
 	}
 }


### PR DESCRIPTION
This PR moves the declaration of `ParachainId` into the `message_example` pallet. This is a stylistic improvement because the struct is defined in the same crate where it is modified. It is also a practical improvement because the pallet can now be moved to its own crate more easily.