### PR TITLE
Rework default values used by the RelayChainCli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -957,6 +957,9 @@ name = "cumulus-contracts-parachain-runtime"
 version = "0.1.0"
 dependencies = [
  "cumulus-message-broker",
+ "cumulus-pallet-contracts",
+ "cumulus-pallet-contracts-primitives",
+ "cumulus-pallet-contracts-rpc-runtime-api",
  "cumulus-parachain-upgrade",
  "cumulus-primitives",
  "cumulus-runtime",
@@ -966,9 +969,6 @@ dependencies = [
  "frame-support",
  "frame-system",
  "pallet-balances",
- "pallet-contracts",
- "pallet-contracts-primitives",
- "pallet-contracts-rpc-runtime-api",
  "pallet-randomness-collective-flip",
  "pallet-sudo",
  "pallet-timestamp",
@@ -1029,6 +1029,70 @@ dependencies = [
  "sp-core",
  "sp-keyring",
  "sp-runtime",
+]
+
+[[package]]
+name = "cumulus-pallet-contracts"
+version = "2.0.0-rc3"
+dependencies = [
+ "assert_matches",
+ "cumulus-pallet-contracts-primitives",
+ "frame-support",
+ "frame-system",
+ "hex-literal",
+ "pallet-balances",
+ "pallet-randomness-collective-flip",
+ "pallet-timestamp",
+ "parity-scale-codec",
+ "parity-wasm",
+ "pwasm-utils",
+ "serde",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-sandbox",
+ "sp-std",
+ "wabt",
+ "wasmi-validation",
+]
+
+[[package]]
+name = "cumulus-pallet-contracts-primitives"
+version = "2.0.0-rc3"
+dependencies = [
+ "parity-scale-codec",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "cumulus-pallet-contracts-rpc"
+version = "0.8.0-rc3"
+dependencies = [
+ "cumulus-pallet-contracts-primitives",
+ "cumulus-pallet-contracts-rpc-runtime-api",
+ "jsonrpc-core",
+ "jsonrpc-core-client",
+ "jsonrpc-derive",
+ "parity-scale-codec",
+ "serde",
+ "serde_json",
+ "sp-api",
+ "sp-blockchain",
+ "sp-core",
+ "sp-rpc",
+ "sp-runtime",
+]
+
+[[package]]
+name = "cumulus-pallet-contracts-rpc-runtime-api"
+version = "0.8.0-rc3"
+dependencies = [
+ "cumulus-pallet-contracts-primitives",
+ "parity-scale-codec",
+ "sp-api",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -1611,7 +1675,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -1619,7 +1683,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1636,7 +1700,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "frame-benchmarking",
  "parity-scale-codec",
@@ -1654,7 +1718,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1669,7 +1733,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata"
 version = "11.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -1680,7 +1744,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "bitmask",
  "frame-metadata",
@@ -1705,7 +1769,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "frame-support-procedural-tools",
  "proc-macro2 1.0.19",
@@ -1716,7 +1780,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -1728,7 +1792,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "proc-macro2 1.0.19",
  "quote 1.0.7",
@@ -1738,7 +1802,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -1754,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -3692,7 +3756,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3708,7 +3772,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3723,7 +3787,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3748,7 +3812,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3762,7 +3826,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3770,70 +3834,6 @@ dependencies = [
  "serde",
  "sp-core",
  "sp-io",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
-name = "pallet-contracts"
-version = "2.0.0-rc3"
-dependencies = [
- "assert_matches",
- "frame-support",
- "frame-system",
- "hex-literal",
- "pallet-balances",
- "pallet-contracts-primitives",
- "pallet-randomness-collective-flip",
- "pallet-timestamp",
- "parity-scale-codec",
- "parity-wasm",
- "pwasm-utils",
- "serde",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-sandbox",
- "sp-std",
- "wabt",
- "wasmi-validation",
-]
-
-[[package]]
-name = "pallet-contracts-primitives"
-version = "2.0.0-rc3"
-dependencies = [
- "parity-scale-codec",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
-name = "pallet-contracts-rpc"
-version = "0.8.0-rc3"
-dependencies = [
- "jsonrpc-core",
- "jsonrpc-core-client",
- "jsonrpc-derive",
- "pallet-contracts-primitives",
- "pallet-contracts-rpc-runtime-api",
- "parity-scale-codec",
- "serde",
- "serde_json",
- "sp-api",
- "sp-blockchain",
- "sp-core",
- "sp-rpc",
- "sp-runtime",
-]
-
-[[package]]
-name = "pallet-contracts-rpc-runtime-api"
-version = "0.8.0-rc3"
-dependencies = [
- "pallet-contracts-primitives",
- "parity-scale-codec",
- "sp-api",
  "sp-runtime",
  "sp-std",
 ]
@@ -3841,7 +3841,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3856,7 +3856,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3870,7 +3870,7 @@ dependencies = [
 [[package]]
 name = "pallet-finality-tracker"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3886,7 +3886,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3908,7 +3908,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -3924,7 +3924,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3943,7 +3943,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3959,7 +3959,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3973,7 +3973,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3988,7 +3988,7 @@ dependencies = [
 [[package]]
 name = "pallet-nicks"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4002,7 +4002,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4017,7 +4017,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4032,7 +4032,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4045,7 +4045,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "enumflags2",
  "frame-support",
@@ -4060,7 +4060,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4075,7 +4075,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4095,7 +4095,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4109,7 +4109,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4129,7 +4129,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.19",
@@ -4140,7 +4140,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4154,7 +4154,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4171,7 +4171,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4188,7 +4188,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -4206,7 +4206,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4219,7 +4219,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4233,7 +4233,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4248,7 +4248,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "enumflags2",
  "frame-support",
@@ -5807,6 +5807,7 @@ dependencies = [
  "cumulus-consensus",
  "cumulus-contracts-parachain-runtime",
  "cumulus-network",
+ "cumulus-pallet-contracts-rpc",
  "cumulus-primitives",
  "cumulus-service",
  "cumulus-test-parachain-runtime",
@@ -5817,7 +5818,6 @@ dependencies = [
  "jsonrpc-core",
  "log 0.4.11",
  "nix 0.17.0",
- "pallet-contracts-rpc",
  "pallet-sudo",
  "parity-scale-codec",
  "parking_lot 0.9.0",
@@ -6037,7 +6037,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "bytes 0.5.6",
  "derive_more 0.99.9",
@@ -6064,7 +6064,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -6088,7 +6088,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -6105,7 +6105,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "impl-trait-for-tuples",
  "sc-chain-spec-derive",
@@ -6121,7 +6121,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.19",
@@ -6132,7 +6132,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
@@ -6173,7 +6173,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "derive_more 0.99.9",
  "fnv",
@@ -6209,7 +6209,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "blake2-rfc",
  "hash-db",
@@ -6239,7 +6239,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "sc-client-api",
  "sp-blockchain",
@@ -6250,7 +6250,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "derive_more 0.99.9",
  "fork-tree",
@@ -6294,7 +6294,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "derive_more 0.99.9",
  "futures 0.3.5",
@@ -6318,7 +6318,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -6331,7 +6331,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -6354,7 +6354,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-uncles"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "log 0.4.11",
  "sc-client-api",
@@ -6368,7 +6368,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "derive_more 0.99.9",
  "lazy_static",
@@ -6396,7 +6396,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "derive_more 0.99.9",
  "log 0.4.11",
@@ -6413,7 +6413,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "log 0.4.11",
  "parity-scale-codec",
@@ -6428,7 +6428,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "cranelift-codegen",
  "cranelift-wasm",
@@ -6449,7 +6449,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "assert_matches",
  "derive_more 0.99.9",
@@ -6487,7 +6487,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa-rpc"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "derive_more 0.99.9",
  "finality-grandpa",
@@ -6504,7 +6504,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "ansi_term 0.12.1",
  "futures 0.3.5",
@@ -6522,7 +6522,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "derive_more 0.99.9",
  "hex",
@@ -6538,7 +6538,7 @@ dependencies = [
 [[package]]
 name = "sc-light"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "hash-db",
  "lazy_static",
@@ -6557,7 +6557,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "bitflags",
  "bs58",
@@ -6609,7 +6609,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -6624,7 +6624,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "bytes 0.5.6",
  "fnv",
@@ -6651,7 +6651,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "futures 0.3.5",
  "libp2p",
@@ -6664,7 +6664,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "log 0.4.11",
  "substrate-prometheus-endpoint",
@@ -6673,7 +6673,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "futures 0.3.5",
  "hash-db",
@@ -6705,7 +6705,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "derive_more 0.99.9",
  "futures 0.3.5",
@@ -6729,7 +6729,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-http-server",
@@ -6745,7 +6745,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "derive_more 0.99.9",
  "directories",
@@ -6808,7 +6808,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "log 0.4.11",
  "parity-scale-codec",
@@ -6822,7 +6822,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -6843,7 +6843,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "erased-serde",
  "log 0.4.11",
@@ -6860,7 +6860,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-graph"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "derive_more 0.99.9",
  "futures 0.3.5",
@@ -6881,7 +6881,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "derive_more 0.99.9",
  "futures 0.3.5",
@@ -7307,7 +7307,7 @@ dependencies = [
 [[package]]
 name = "sp-allocator"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "derive_more 0.99.9",
  "log 0.4.11",
@@ -7319,7 +7319,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -7334,7 +7334,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
@@ -7346,7 +7346,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -7358,7 +7358,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "integer-sqrt",
  "num-traits 0.2.12",
@@ -7371,7 +7371,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7383,7 +7383,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -7394,7 +7394,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7406,7 +7406,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "derive_more 0.99.9",
  "log 0.4.11",
@@ -7423,7 +7423,7 @@ dependencies = [
 [[package]]
 name = "sp-chain-spec"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "serde",
  "serde_json",
@@ -7432,7 +7432,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "derive_more 0.99.9",
  "futures 0.3.5",
@@ -7458,7 +7458,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7472,7 +7472,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "merlin",
  "parity-scale-codec",
@@ -7491,7 +7491,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -7500,7 +7500,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",
@@ -7512,7 +7512,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -7556,7 +7556,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "kvdb",
  "parking_lot 0.10.2",
@@ -7565,7 +7565,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "proc-macro2 1.0.19",
  "quote 1.0.7",
@@ -7575,7 +7575,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -7586,7 +7586,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "finality-grandpa",
  "log 0.4.11",
@@ -7602,7 +7602,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-tracker"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -7612,7 +7612,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "derive_more 0.99.9",
  "parity-scale-codec",
@@ -7624,7 +7624,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "futures 0.3.5",
  "hash-db",
@@ -7645,7 +7645,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -7656,7 +7656,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -7668,7 +7668,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections-compact"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2 1.0.19",
@@ -7679,7 +7679,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -7689,7 +7689,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "backtrace",
  "log 0.4.11",
@@ -7698,7 +7698,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "serde",
  "sp-core",
@@ -7707,7 +7707,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -7729,7 +7729,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "parity-scale-codec",
  "primitive-types",
@@ -7744,7 +7744,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -7756,7 +7756,7 @@ dependencies = [
 [[package]]
 name = "sp-sandbox"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "parity-scale-codec",
  "sp-core",
@@ -7769,7 +7769,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "serde",
  "serde_json",
@@ -7778,7 +7778,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7791,7 +7791,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -7801,7 +7801,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "hash-db",
  "itertools 0.9.0",
@@ -7822,12 +7822,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 
 [[package]]
 name = "sp-storage"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "impl-serde 0.2.3",
  "ref-cast",
@@ -7839,7 +7839,7 @@ dependencies = [
 [[package]]
 name = "sp-test-primitives"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "parity-scale-codec",
  "parity-util-mem",
@@ -7852,7 +7852,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -7866,7 +7866,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "log 0.4.11",
  "rental",
@@ -7876,7 +7876,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "derive_more 0.99.9",
  "futures 0.3.5",
@@ -7891,7 +7891,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -7905,7 +7905,7 @@ dependencies = [
 [[package]]
 name = "sp-utils"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "futures 0.3.5",
  "futures-core",
@@ -7917,7 +7917,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "impl-serde 0.2.3",
  "parity-scale-codec",
@@ -7929,7 +7929,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -8048,7 +8048,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "platforms",
 ]
@@ -8056,7 +8056,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.5",
@@ -8079,7 +8079,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.8.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "async-std",
  "derive_more 0.99.9",
@@ -8093,7 +8093,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "futures 0.1.29",
  "futures 0.3.5",
@@ -8119,7 +8119,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "cfg-if",
  "frame-executive",
@@ -8159,7 +8159,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime-client"
 version = "2.0.0-rc5"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 dependencies = [
  "futures 0.3.5",
  "parity-scale-codec",
@@ -8180,7 +8180,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder-runner"
 version = "1.0.6"
-source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#d15f420bd14fb1cb3b8789d7949276b97dada9b0"
+source = "git+https://github.com/paritytech/substrate?branch=rococo-branch#f397f246fd0a0c8c2ef2f0b7576ecbed133ed78d"
 
 [[package]]
 name = "substrate-wasm-builder-runner"

--- a/rococo-parachains/Cargo.toml
+++ b/rococo-parachains/Cargo.toml
@@ -49,7 +49,7 @@ sc-informant = { git = "https://github.com/paritytech/substrate", branch = "roco
 sc-chain-spec = { git = "https://github.com/paritytech/substrate", branch = "rococo-branch" }
 
 # RPC related dependencies
-pallet-contracts-rpc = { path = "./pallets/contracts/rpc" }
+cumulus-pallet-contracts-rpc = { path = "./pallets/contracts/rpc" }
 jsonrpc-core = "14.2.0"
 
 # Cumulus dependencies

--- a/rococo-parachains/contracts-runtime/Cargo.toml
+++ b/rococo-parachains/contracts-runtime/Cargo.toml
@@ -34,9 +34,9 @@ pallet-sudo = { git = "https://github.com/paritytech/substrate", default-feature
 pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "rococo-branch" }
 
 # In-Tree Fork of seal that does not use child trie nor storage transactions
-pallet-contracts = { path = "../pallets/contracts", default-features = false }
-pallet-contracts-primitives = {  path = "../pallets/contracts/common", default-features = false }
-pallet-contracts-rpc-runtime-api = { path = "../pallets/contracts/rpc/runtime-api", default-features = false }
+cumulus-pallet-contracts = { path = "../pallets/contracts", default-features = false }
+cumulus-pallet-contracts-primitives = {  path = "../pallets/contracts/common", default-features = false }
+cumulus-pallet-contracts-rpc-runtime-api = { path = "../pallets/contracts/rpc/runtime-api", default-features = false }
 
 # Cumulus dependencies
 cumulus-runtime = { path = "../../runtime", default-features = false }
@@ -71,9 +71,9 @@ std = [
 	"frame-executive/std",
 	"frame-system/std",
 	"pallet-balances/std",
-	"pallet-contracts/std",
-	"pallet-contracts-primitives/std",
-	"pallet-contracts-rpc-runtime-api/std",
+	"cumulus-pallet-contracts/std",
+	"cumulus-pallet-contracts-primitives/std",
+	"cumulus-pallet-contracts-rpc-runtime-api/std",
 	"pallet-randomness-collective-flip/std",
 	"pallet-timestamp/std",
 	"pallet-sudo/std",

--- a/rococo-parachains/contracts-runtime/src/lib.rs
+++ b/rococo-parachains/contracts-runtime/src/lib.rs
@@ -22,7 +22,7 @@
 #[cfg(feature = "std")]
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
-use pallet_contracts_rpc_runtime_api::ContractExecResult;
+use cumulus_pallet_contracts_rpc_runtime_api::ContractExecResult;
 use sp_api::impl_runtime_apis;
 use sp_core::OpaqueMetadata;
 use sp_runtime::{
@@ -269,23 +269,23 @@ parameter_types! {
 	pub const SurchargeReward: Balance = 0;
 }
 
-impl pallet_contracts::Trait for Runtime {
+impl cumulus_pallet_contracts::Trait for Runtime {
 	type Time = Timestamp;
 	type Randomness = RandomnessCollectiveFlip;
 	type Currency = Balances;
 	type Call = Call;
 	type Event = Event;
-	type DetermineContractAddress = pallet_contracts::SimpleAddressDeterminer<Runtime>;
-	type TrieIdGenerator = pallet_contracts::TrieIdFromParentCounter<Runtime>;
+	type DetermineContractAddress = cumulus_pallet_contracts::SimpleAddressDeterminer<Runtime>;
+	type TrieIdGenerator = cumulus_pallet_contracts::TrieIdFromParentCounter<Runtime>;
 	type RentPayment = ();
-	type SignedClaimHandicap = pallet_contracts::DefaultSignedClaimHandicap;
+	type SignedClaimHandicap = cumulus_pallet_contracts::DefaultSignedClaimHandicap;
 	type TombstoneDeposit = TombstoneDeposit;
-	type StorageSizeOffset = pallet_contracts::DefaultStorageSizeOffset;
+	type StorageSizeOffset = cumulus_pallet_contracts::DefaultStorageSizeOffset;
 	type RentByteFee = RentByteFee;
 	type RentDepositOffset = RentDepositOffset;
 	type SurchargeReward = SurchargeReward;
-	type MaxDepth = pallet_contracts::DefaultMaxDepth;
-	type MaxValueSize = pallet_contracts::DefaultMaxValueSize;
+	type MaxDepth = cumulus_pallet_contracts::DefaultMaxDepth;
+	type MaxValueSize = cumulus_pallet_contracts::DefaultMaxValueSize;
 	type WeightPrice = pallet_transaction_payment::Module<Self>;
 }
 
@@ -298,7 +298,7 @@ construct_runtime! {
 		System: frame_system::{Module, Call, Storage, Config, Event<T>},
 		Timestamp: pallet_timestamp::{Module, Call, Storage, Inherent},
 		Balances: pallet_balances::{Module, Call, Storage, Config<T>, Event<T>},
-		Contracts: pallet_contracts::{Module, Call, Config, Storage, Event<T>},
+		Contracts: cumulus_pallet_contracts::{Module, Call, Config, Storage, Event<T>},
 		Sudo: pallet_sudo::{Module, Call, Storage, Config<T>, Event<T>},
 		RandomnessCollectiveFlip: pallet_randomness_collective_flip::{Module, Call, Storage},
 		ParachainUpgrade: cumulus_parachain_upgrade::{Module, Call, Storage, Inherent, Event},
@@ -413,7 +413,7 @@ impl_runtime_apis! {
 		}
 	}
 
-	impl pallet_contracts_rpc_runtime_api::ContractsApi<Block, AccountId, Balance, BlockNumber>
+	impl cumulus_pallet_contracts_rpc_runtime_api::ContractsApi<Block, AccountId, Balance, BlockNumber>
 		for Runtime
 	{
 		fn call(
@@ -438,13 +438,13 @@ impl_runtime_apis! {
 		fn get_storage(
 			address: AccountId,
 			key: [u8; 32],
-		) -> pallet_contracts_primitives::GetStorageResult {
+		) -> cumulus_pallet_contracts_primitives::GetStorageResult {
 			Contracts::get_storage(address, key)
 		}
 
 		fn rent_projection(
 			address: AccountId,
-		) -> pallet_contracts_primitives::RentProjectionResult<BlockNumber> {
+		) -> cumulus_pallet_contracts_primitives::RentProjectionResult<BlockNumber> {
 			Contracts::rent_projection(address)
 		}
 	}

--- a/rococo-parachains/pallets/contracts/Cargo.toml
+++ b/rococo-parachains/pallets/contracts/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "pallet-contracts"
+name = "cumulus-pallet-contracts"
 version = "2.0.0-rc3"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
@@ -24,7 +24,7 @@ sp-std = { git = "https://github.com/paritytech/substrate", default-features = f
 sp-sandbox = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "rococo-branch" }
 frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "rococo-branch" }
 frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "rococo-branch" }
-pallet-contracts-primitives = { path = "./common", default-features = false }
+cumulus-pallet-contracts-primitives = { path = "./common", default-features = false }
 
 [dev-dependencies]
 wabt = "0.10"
@@ -49,5 +49,5 @@ std = [
 	"parity-wasm/std",
 	"pwasm-utils/std",
 	"wasmi-validation/std",
-	"pallet-contracts-primitives/std",
+	"cumulus-pallet-contracts-primitives/std",
 ]

--- a/rococo-parachains/pallets/contracts/common/Cargo.toml
+++ b/rococo-parachains/pallets/contracts/common/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "pallet-contracts-primitives"
+name = "cumulus-pallet-contracts-primitives"
 version = "2.0.0-rc3"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"

--- a/rococo-parachains/pallets/contracts/rpc/Cargo.toml
+++ b/rococo-parachains/pallets/contracts/rpc/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "pallet-contracts-rpc"
+name = "cumulus-pallet-contracts-rpc"
 version = "0.8.0-rc3"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
@@ -22,8 +22,8 @@ sp-rpc = { git = "https://github.com/paritytech/substrate", default-features = f
 serde = { version = "1.0.101", features = ["derive"] }
 sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "rococo-branch" }
 sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "rococo-branch" }
-pallet-contracts-primitives = { path = "../common" }
-pallet-contracts-rpc-runtime-api = { path = "./runtime-api" }
+cumulus-pallet-contracts-primitives = { path = "../common" }
+cumulus-pallet-contracts-rpc-runtime-api = { path = "./runtime-api" }
 
 [dev-dependencies]
 serde_json = "1.0.41"

--- a/rococo-parachains/pallets/contracts/rpc/runtime-api/Cargo.toml
+++ b/rococo-parachains/pallets/contracts/rpc/runtime-api/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "pallet-contracts-rpc-runtime-api"
+name = "cumulus-pallet-contracts-rpc-runtime-api"
 version = "0.8.0-rc3"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
@@ -16,7 +16,7 @@ sp-api = { git = "https://github.com/paritytech/substrate", default-features = f
 codec = { package = "parity-scale-codec", version = "1.3.1", default-features = false, features = ["derive"] }
 sp-std = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "rococo-branch" }
 sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "rococo-branch" }
-pallet-contracts-primitives = { path = "../../common", default-features = false }
+cumulus-pallet-contracts-primitives = { path = "../../common", default-features = false }
 
 [features]
 default = ["std"]
@@ -25,5 +25,5 @@ std = [
 	"codec/std",
 	"sp-std/std",
 	"sp-runtime/std",
-	"pallet-contracts-primitives/std",
+	"cumulus-pallet-contracts-primitives/std",
 ]

--- a/rococo-parachains/pallets/contracts/rpc/runtime-api/src/lib.rs
+++ b/rococo-parachains/pallets/contracts/rpc/runtime-api/src/lib.rs
@@ -24,7 +24,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use codec::{Codec, Decode, Encode};
-use pallet_contracts_primitives::{GetStorageResult, RentProjectionResult};
+use cumulus_pallet_contracts_primitives::{GetStorageResult, RentProjectionResult};
 use sp_runtime::RuntimeDebug;
 use sp_std::vec::Vec;
 

--- a/rococo-parachains/pallets/contracts/rpc/src/lib.rs
+++ b/rococo-parachains/pallets/contracts/rpc/src/lib.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 use codec::Codec;
 use jsonrpc_core::{Error, ErrorCode, Result};
 use jsonrpc_derive::rpc;
-use pallet_contracts_primitives::RentProjection;
+use cumulus_pallet_contracts_primitives::RentProjection;
 use serde::{Deserialize, Serialize};
 use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
@@ -35,7 +35,7 @@ use sp_runtime::{
 use std::convert::TryInto;
 
 pub use self::gen_client::Client as ContractsClient;
-pub use pallet_contracts_rpc_runtime_api::{
+pub use cumulus_pallet_contracts_rpc_runtime_api::{
 	self as runtime_api, ContractExecResult, ContractsApi as ContractsRuntimeApi,
 };
 
@@ -54,10 +54,10 @@ const CONTRACT_IS_A_TOMBSTONE: i64 = 3;
 const GAS_PER_SECOND: u64 = 1_000_000_000_000;
 
 /// A private newtype for converting `ContractAccessError` into an RPC error.
-struct ContractAccessError(pallet_contracts_primitives::ContractAccessError);
+struct ContractAccessError(cumulus_pallet_contracts_primitives::ContractAccessError);
 impl From<ContractAccessError> for Error {
 	fn from(e: ContractAccessError) -> Error {
-		use pallet_contracts_primitives::ContractAccessError::*;
+		use cumulus_pallet_contracts_primitives::ContractAccessError::*;
 		match e.0 {
 			DoesntExist => Error {
 				code: ErrorCode::ServerError(CONTRACT_DOESNT_EXIST),

--- a/rococo-parachains/pallets/contracts/src/lib.rs
+++ b/rococo-parachains/pallets/contracts/src/lib.rs
@@ -118,7 +118,7 @@ use frame_support::{
 use frame_support::traits::{OnUnbalanced, Currency, Get, Time, Randomness};
 use frame_support::weights::GetDispatchInfo;
 use frame_system::{ensure_signed, RawOrigin, ensure_root};
-use pallet_contracts_primitives::{RentProjection, ContractAccessError};
+use cumulus_pallet_contracts_primitives::{RentProjection, ContractAccessError};
 use frame_support::weights::Weight;
 
 pub type CodeHash<T> = <T as frame_system::Trait>::Hash;

--- a/rococo-parachains/pallets/contracts/src/rent.rs
+++ b/rococo-parachains/pallets/contracts/src/rent.rs
@@ -23,7 +23,7 @@ use crate::{
 use frame_support::storage::unhashed as storage;
 use frame_support::traits::{Currency, ExistenceRequirement, Get, OnUnbalanced, WithdrawReason};
 use frame_support::StorageMap;
-use pallet_contracts_primitives::{ContractAccessError, RentProjection, RentProjectionResult};
+use cumulus_pallet_contracts_primitives::{ContractAccessError, RentProjection, RentProjectionResult};
 use sp_runtime::traits::{Bounded, CheckedDiv, CheckedMul, SaturatedConversion, Saturating, Zero};
 
 /// The amount to charge.


### PR DESCRIPTION
This reworks the default values used by the RelayChainCli for stuff like
the listen port etc.

This also renames all the contracts related stuff to `cumulus-*` to
support `.cargo/config` overrides.