### PR TITLE
feature flag relaychain runtimes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -939,7 +939,6 @@ dependencies = [
  "log 0.4.11",
  "parity-scale-codec",
  "polkadot-primitives",
- "polkadot-runtime",
  "sc-client-api",
  "sp-api",
  "sp-block-builder",

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -19,7 +19,6 @@ substrate-prometheus-endpoint = { git = "https://github.com/paritytech/substrate
 
 # polkadot deps
 polkadot-primitives = { git = "https://github.com/paritytech/polkadot", branch = "rococo-branch" }
-polkadot-runtime = { git = "https://github.com/paritytech/polkadot", branch = "rococo-branch" }
 
 # other deps
 futures = { version = "0.3.1", features = ["compat"] }

--- a/rococo-parachains/contracts-runtime/Cargo.toml
+++ b/rococo-parachains/contracts-runtime/Cargo.toml
@@ -43,7 +43,7 @@ cumulus-pallet-contracts-rpc-runtime-api = { path = "../pallets/contracts/rpc/ru
 cumulus-runtime = { path = "../../runtime", default-features = false }
 cumulus-parachain-upgrade = { path = "../../parachain-upgrade", default-features = false }
 cumulus-message-broker = { path = "../../message-broker", default-features = false }
-cumulus-upward-message = { path = "../../upward-message", default-features = false, features = ["rococo"] }
+cumulus-upward-message = { path = "../../upward-message", default-features = false, features = ["rococo-runtime"] }
 cumulus-primitives = { path = "../../primitives", default-features = false }
 
 # Polkadot dependencies
@@ -88,4 +88,9 @@ std = [
 	"cumulus-primitives/std",
 	"polkadot-parachain/std",
 	"cumulus-token-dealer/std",
+]
+
+# Will be enabled by the `wasm-builder` when building the runtime for WASM.
+runtime-wasm = [
+	"cumulus-upward-message/disable-rococo-runtime-api",
 ]

--- a/rococo-parachains/contracts-runtime/Cargo.toml
+++ b/rococo-parachains/contracts-runtime/Cargo.toml
@@ -43,7 +43,7 @@ cumulus-pallet-contracts-rpc-runtime-api = { path = "../pallets/contracts/rpc/ru
 cumulus-runtime = { path = "../../runtime", default-features = false }
 cumulus-parachain-upgrade = { path = "../../parachain-upgrade", default-features = false }
 cumulus-message-broker = { path = "../../message-broker", default-features = false }
-cumulus-upward-message = { path = "../../upward-message", default-features = false }
+cumulus-upward-message = { path = "../../upward-message", default-features = false, features = ["rococo"] }
 cumulus-primitives = { path = "../../primitives", default-features = false }
 
 # Polkadot dependencies
@@ -88,8 +88,4 @@ std = [
 	"cumulus-primitives/std",
 	"polkadot-parachain/std",
 	"cumulus-token-dealer/std",
-]
-# Will be enabled by the `wasm-builder` when building the runtime for WASM.
-runtime-wasm = [
-	"cumulus-upward-message/runtime-wasm",
 ]

--- a/rococo-parachains/pallets/token-dealer/Cargo.toml
+++ b/rococo-parachains/pallets/token-dealer/Cargo.toml
@@ -11,7 +11,7 @@ frame-support = { git = "https://github.com/paritytech/substrate", default-featu
 frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "rococo-branch" }
 
 # Cumulus dependencies
-cumulus-upward-message = { path = "../../../upward-message", default-features = false, features = ["rococo"] }
+cumulus-upward-message = { path = "../../../upward-message", default-features = false, features = ["rococo-runtime"] }
 cumulus-primitives = { path = "../../../primitives", default-features = false }
 
 # Polkadot dependencies

--- a/rococo-parachains/pallets/token-dealer/Cargo.toml
+++ b/rococo-parachains/pallets/token-dealer/Cargo.toml
@@ -11,7 +11,7 @@ frame-support = { git = "https://github.com/paritytech/substrate", default-featu
 frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "rococo-branch" }
 
 # Cumulus dependencies
-cumulus-upward-message = { path = "../../../upward-message", default-features = false }
+cumulus-upward-message = { path = "../../../upward-message", default-features = false, features = ["rococo"] }
 cumulus-primitives = { path = "../../../primitives", default-features = false }
 
 # Polkadot dependencies

--- a/rococo-parachains/runtime/Cargo.toml
+++ b/rococo-parachains/runtime/Cargo.toml
@@ -38,7 +38,7 @@ pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", 
 cumulus-runtime = { path = "../../runtime", default-features = false }
 cumulus-parachain-upgrade = { path = "../../parachain-upgrade", default-features = false }
 cumulus-message-broker = { path = "../../message-broker", default-features = false }
-cumulus-upward-message = { path = "../../upward-message", default-features = false, features = ["rococo"] }
+cumulus-upward-message = { path = "../../upward-message", default-features = false, features = ["rococo-runtime"] }
 cumulus-primitives = { path = "../../primitives", default-features = false }
 
 # Polkadot dependencies
@@ -79,4 +79,9 @@ std = [
 	"cumulus-upward-message/std",
 	"cumulus-primitives/std",
 	"cumulus-token-dealer/std",
+]
+
+# Will be enabled by the `wasm-builder` when building the runtime for WASM.
+runtime-wasm = [
+	"cumulus-upward-message/disable-rococo-runtime-api",
 ]

--- a/rococo-parachains/runtime/Cargo.toml
+++ b/rococo-parachains/runtime/Cargo.toml
@@ -38,7 +38,7 @@ pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", 
 cumulus-runtime = { path = "../../runtime", default-features = false }
 cumulus-parachain-upgrade = { path = "../../parachain-upgrade", default-features = false }
 cumulus-message-broker = { path = "../../message-broker", default-features = false }
-cumulus-upward-message = { path = "../../upward-message", default-features = false }
+cumulus-upward-message = { path = "../../upward-message", default-features = false, features = ["rococo"] }
 cumulus-primitives = { path = "../../primitives", default-features = false }
 
 # Polkadot dependencies
@@ -79,8 +79,4 @@ std = [
 	"cumulus-upward-message/std",
 	"cumulus-primitives/std",
 	"cumulus-token-dealer/std",
-]
-# Will be enabled by the `wasm-builder` when building the runtime for WASM.
-runtime-wasm = [
-	"cumulus-upward-message/runtime-wasm",
 ]

--- a/upward-message/Cargo.toml
+++ b/upward-message/Cargo.toml
@@ -13,30 +13,31 @@ polkadot-core-primitives = { git = "https://github.com/paritytech/polkadot", bra
 polkadot-parachain = { git = "https://github.com/paritytech/polkadot", branch = "rococo-branch", default-features = false }
 
 # All these should be optional dependenices, but given the perfect Cargo, it is not possible.
-polkadot-runtime = { git = "https://github.com/paritytech/polkadot", branch = "rococo-branch", default-features = false }
-kusama-runtime = { git = "https://github.com/paritytech/polkadot", branch = "rococo-branch", default-features = false }
-westend-runtime = { git = "https://github.com/paritytech/polkadot", branch = "rococo-branch", default-features = false }
-rococo-runtime = { git = "https://github.com/paritytech/polkadot", branch = "rococo-branch", default-features = false }
+polkadot-runtime = { git = "https://github.com/paritytech/polkadot", branch = "rococo-branch", default-features = false, optional = true }
+kusama-runtime = { git = "https://github.com/paritytech/polkadot", branch = "rococo-branch", default-features = false, optional = true }
+westend-runtime = { git = "https://github.com/paritytech/polkadot", branch = "rococo-branch", default-features = false, optional = true }
+rococo-runtime = { git = "https://github.com/paritytech/polkadot", branch = "rococo-branch", default-features = false, optional = true }
 
 [features]
 default = [ "std" ]
 std = [
 	"sp-std/std",
-	"polkadot-runtime/std",
-	"kusama-runtime/std",
-	"westend-runtime/std",
-	"rococo-runtime/std",
 	"polkadot-core-primitives/std",
 	"polkadot-parachain/std",
 ]
-# Should be enabled by when compiling the runtime for WASM.
-#
-# This disables the runtime api of the Polkadot/Kusama/Westend
-# runtimes to not clash with the runtime api of the Parachain when building
-# for WASM.
-runtime-wasm = [
-	"polkadot-runtime/disable-runtime-api",
-	"westend-runtime/disable-runtime-api",
-	"rococo-runtime/disable-runtime-api",
+kusama = [
+	"kusama-runtime",
 	"kusama-runtime/disable-runtime-api",
+]
+polkadot = [
+	"polkadot-runtime",
+	"polkadot-runtime/disable-runtime-api",
+]
+rococo = [
+	"rococo-runtime",
+	"rococo-runtime/disable-runtime-api",
+]
+westend = [
+	"westend-runtime",
+	"westend-runtime/disable-runtime-api",
 ]

--- a/upward-message/Cargo.toml
+++ b/upward-message/Cargo.toml
@@ -25,19 +25,15 @@ std = [
 	"polkadot-core-primitives/std",
 	"polkadot-parachain/std",
 ]
-kusama = [
-	"kusama-runtime",
+disable-kusama-runtime-api = [
 	"kusama-runtime/disable-runtime-api",
 ]
-polkadot = [
-	"polkadot-runtime",
+disable-polkadot-runtime-api = [
 	"polkadot-runtime/disable-runtime-api",
 ]
-rococo = [
-	"rococo-runtime",
+disable-rococo-runtime-api = [
 	"rococo-runtime/disable-runtime-api",
 ]
-westend = [
-	"westend-runtime",
+disable-westend-runtime-api = [
 	"westend-runtime/disable-runtime-api",
 ]

--- a/upward-message/src/lib.rs
+++ b/upward-message/src/lib.rs
@@ -25,14 +25,22 @@
 use polkadot_parachain::primitives::Id as ParaId;
 use sp_std::vec::Vec;
 
+#[cfg(feature = "kusama")]
 mod kusama;
+#[cfg(feature = "polkadot")]
 mod polkadot;
+#[cfg(feature = "rococo")]
 mod rococo;
+#[cfg(feature = "westend")]
 mod westend;
 
+#[cfg(feature = "kusama")]
 pub use kusama::UpwardMessage as KusamaUpwardMessage;
+#[cfg(feature = "polkadot")]
 pub use polkadot::UpwardMessage as PolkadotUpwardMessage;
+#[cfg(feature = "rococo")]
 pub use rococo::UpwardMessage as RococoUpwardMessage;
+#[cfg(feature = "westend")]
 pub use westend::UpwardMessage as WestendUpwardMessage;
 
 /// A `Balances` related upward message.

--- a/upward-message/src/lib.rs
+++ b/upward-message/src/lib.rs
@@ -25,22 +25,22 @@
 use polkadot_parachain::primitives::Id as ParaId;
 use sp_std::vec::Vec;
 
-#[cfg(feature = "kusama")]
+#[cfg(feature = "kusama-runtime")]
 mod kusama;
-#[cfg(feature = "polkadot")]
+#[cfg(feature = "polkadot-runtime")]
 mod polkadot;
-#[cfg(feature = "rococo")]
+#[cfg(feature = "rococo-runtime")]
 mod rococo;
-#[cfg(feature = "westend")]
+#[cfg(feature = "westend-runtime")]
 mod westend;
 
-#[cfg(feature = "kusama")]
+#[cfg(feature = "kusama-runtime")]
 pub use kusama::UpwardMessage as KusamaUpwardMessage;
-#[cfg(feature = "polkadot")]
+#[cfg(feature = "polkadot-runtime")]
 pub use polkadot::UpwardMessage as PolkadotUpwardMessage;
-#[cfg(feature = "rococo")]
+#[cfg(feature = "rococo-runtime")]
 pub use rococo::UpwardMessage as RococoUpwardMessage;
-#[cfg(feature = "westend")]
+#[cfg(feature = "westend-runtime")]
 pub use westend::UpwardMessage as WestendUpwardMessage;
 
 /// A `Balances` related upward message.


### PR DESCRIPTION
Closes #175

The compiling time of building 5 runtimes (4 relaychain + 1 parachain, maybe twice wasm & native?) is literally killing my life.

Also relay chain runtime std feature is currently not enabled even in std because cargo. The dependent package can however depends on runtime directly and enable it.