### PR TITLE
Bump release notes github action version

### DIFF
--- a/.github/workflows/release-bot.yml
+++ b/.github/workflows/release-bot.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: send message
-        uses: s3krit/matrix-message-action@v0.0.2
+        uses: s3krit/matrix-message-action@v0.0.3
         with:
           room_id: ${{ secrets.MATRIX_ROOM_ID }}
           access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}


### PR DESCRIPTION
This should be using the most recent version of s3krit's github action otherwise it will fail.