### PR TITLE
Make export-genesis-wasm output hex

### DIFF
--- a/rococo-parachains/src/cli.rs
+++ b/rococo-parachains/src/cli.rs
@@ -79,6 +79,10 @@ pub struct ExportGenesisWasmCommand {
 	#[structopt(parse(from_os_str))]
 	pub output: Option<PathBuf>,
 
+	/// Write output in binary. Default is to write in hex.
+	#[structopt(short, long)]
+	pub raw: bool,
+
 	/// The name of the chain for that the genesis wasm file should be exported.
 	#[structopt(long)]
 	pub chain: Option<String>,

--- a/rococo-parachains/src/cli.rs
+++ b/rococo-parachains/src/cli.rs
@@ -63,6 +63,10 @@ pub struct ExportGenesisStateCommand {
 	#[structopt(long, default_value = "100")]
 	pub parachain_id: u32,
 
+	/// Write output in binary. Default is to write in hex.
+	#[structopt(short, long)]
+	pub raw: bool,
+
 	/// The name of the chain for that the genesis state should be exported.
 	#[structopt(long)]
 	pub chain: Option<String>,

--- a/rococo-parachains/src/command.rs
+++ b/rococo-parachains/src/command.rs
@@ -223,12 +223,17 @@ pub fn run() -> Result<()> {
 				&params.chain.clone().unwrap_or_default(),
 				params.parachain_id.into(),
 			)?)?;
-			let header_hex = format!("0x{:?}", HexDisplay::from(&block.header().encode()));
+			let raw_header = block.header().encode();
+			let output_buf = if params.raw {
+				raw_header
+			} else {
+				format!("0x{:?}", HexDisplay::from(&block.header().encode())).into_bytes()
+			};
 
 			if let Some(output) = &params.output {
-				std::fs::write(output, header_hex)?;
+				std::fs::write(output, output_buf)?;
 			} else {
-				print!("{}", header_hex);
+				std::io::stdout().write_all(&output_buf)?;
 			}
 
 			Ok(())

--- a/rococo-parachains/src/command.rs
+++ b/rococo-parachains/src/command.rs
@@ -241,13 +241,18 @@ pub fn run() -> Result<()> {
 		Some(Subcommand::ExportGenesisWasm(params)) => {
 			sc_cli::init_logger("", sc_tracing::TracingReceiver::Log, None)?;
 
-			let wasm_file =
+			let raw_wasm_blob =
 				extract_genesis_wasm(&cli.load_spec(&params.chain.clone().unwrap_or_default())?)?;
+			let output_buf = if params.raw {
+				raw_wasm_blob
+			} else {
+				format!("0x{:?}", HexDisplay::from(&raw_wasm_blob)).into_bytes()
+			};
 
 			if let Some(output) = &params.output {
-				std::fs::write(output, wasm_file)?;
+				std::fs::write(output, output_buf)?;
 			} else {
-				std::io::stdout().write_all(&wasm_file)?;
+				std::io::stdout().write_all(&output_buf)?;
 			}
 
 			Ok(())


### PR DESCRIPTION
Two commits:

1. Add a --raw flag to export-genesis-state
2. Switch `export-genesis-wasm` to output hex by default and also add `--raw` to get the previous functionality

This basically makes the behavior of `export-genesis-state` and `export-genesis-wasm` consistent and friendly when working with polkadot.js.api

That perhaps will break scripts and all, but we will have to do that anyway if we want them to be consistent and I think now is a good time.