### PR TITLE
Update parachain registration script to new extrinsic

### DIFF
--- a/scripts/register_parachain.sh
+++ b/scripts/register_parachain.sh
@@ -2,7 +2,7 @@
 
 usage() {
     echo Usage:
-    echo "$0 <url> <seed> <wasm> <genesis> <parachain-id> <tokens> <account>"
+    echo "$0 <url> <seed> <wasm> <genesis> <parachain-id> <types>"
     exit 1
 }
 
@@ -11,24 +11,26 @@ seed=$2
 wasm=$3
 genesis=$4
 parachain_id=$5
-tokens=$6
-account=$7
+types=$6 # we can remove this once parachain types are included in polkadot-js-api
 
 [ -z "$url" ] && usage
 [ -z "$seed" ] && usage
 [ -z "$wasm" ] && usage
+[ -z "$types" ] && usage
 [ -z "$genesis" ] && usage
 [ -z "$parachain_id" ] && usage
-[ -z "$tokens" ] && usage
-[ -z "$account" ] && usage
 if ! [ -r "$wasm" ]; then
     echo "Could not read: $wasm"
+    exit 1
+fi
+if ! [ -r "$types" ]; then
+    echo "Could not read: $types"
     exit 1
 fi
 
 if ! which polkadot-js-api &> /dev/null; then
     echo 'command `polkadot-js-api` not in PATH'
-    echo "npm install -g @polkadot/api-cli"
+    echo "npm install -g @polkadot/api-cli@beta"
     exit 1
 fi
 
@@ -36,19 +38,13 @@ set -e -x
 
 test -f "$seed" && seed="$(cat "$seed")"
 
-polkadot-js-api \
-    --ws "${url?}" \
-    --sudo \
-    --seed "${seed?}" \
-    tx.parasSudoWrapper.sudoScheduleParaInitialize \
-        "${parachain_id?}" \
-        @"{ \"genesisHead\":\"${genesis?}\", \"validationCode\":\"${wasm?}\", \"parachain\": true }" \
+wasm=$(cat $wasm)
 
 polkadot-js-api \
     --ws "${url?}" \
     --sudo \
     --seed "${seed?}" \
-    tx.balances.setBalance \
-        "${account?}" \
-        $((tokens * 10 ** 12)) \
-        0
+    --types "${types?}" \
+    tx.parasSudoWrapper.sudoScheduleParaInitialize \
+        "${parachain_id?}" \
+        "{ \"genesisHead\":\"${genesis?}\", \"validationCode\":\"${wasm?}\", \"parachain\": true }" \

--- a/scripts/register_parachain.sh
+++ b/scripts/register_parachain.sh
@@ -40,11 +40,9 @@ polkadot-js-api \
     --ws "${url?}" \
     --sudo \
     --seed "${seed?}" \
-    tx.registrar.registerPara \
+    tx.parasSudoWrapper.sudoScheduleParaInitialize \
         "${parachain_id?}" \
-        '{"scheduling":"Always"}' \
-        @"${wasm?}" \
-        "${genesis?}"
+        @"{ \"genesisHead\":\"${genesis?}\", \"validationCode\":\"${wasm?}\", \"parachain\": true }" \
 
 polkadot-js-api \
     --ws "${url?}" \

--- a/scripts/temp_parachain_types.json
+++ b/scripts/temp_parachain_types.json
@@ -1,0 +1,64 @@
+{
+  "HrmpChannelId": {
+    "sender": "u32",
+    "receiver": "u32"
+  },
+  "SignedAvailabilityBitfield": {
+    "payload": "BitVec",
+    "validator_index": "u32",
+    "signature": "Signature"
+  },
+  "SignedAvailabilityBitfields": "Vec<SignedAvailabilityBitfield>",
+  "ValidatorSignature": "Signature",
+  "HeadData": "Vec<u8>",
+  "CandidateDescriptor": {
+    "para_id": "u32",
+    "relay_parent": "Hash",
+    "collator_id": "Hash",
+    "persisted_validation_data_hash": "Hash",
+    "pov_hash": "Hash",
+    "erasure_root": "Hash",
+    "signature": "Signature"
+  },
+  "CandidateReceipt": {
+    "descriptor": "CandidateDescriptor",
+    "commitments_hash": "Hash"
+  },
+  "UpwardMessage": "Vec<u8>",
+  "OutboundHrmpMessage": {
+    "recipient": "u32",
+    "data": "Vec<u8>"
+  },
+  "ValidationCode": "Vec<u8>",
+  "CandidateCommitments": {
+    "upward_messages": "Vec<UpwardMessage>",
+    "horizontal_messages": "Vec<OutboundHrmpMessage>",
+    "new_validation_code": "Option<ValidationCode>",
+    "head_data": "HeadData",
+    "processed_downward_messages": "u32",
+    "hrmp_watermark": "BlockNumber"
+  },
+  "CommittedCandidateReceipt": {
+    "descriptor": "CandidateDescriptor",
+    "commitments": "CandidateCommitments"
+  },
+  "ValidityAttestation": {
+    "_enum": {
+      "DummyOffsetBy1": "Raw",
+      "Implicit": "ValidatorSignature",
+      "Explicit": "ValidatorSignature"
+    }
+  },
+  "BackedCandidate": {
+    "candidate": "CommittedCandidateReceipt",
+    "validity_votes": "Vec<ValidityAttestation>",
+    "validator_indices": "BitVec"
+  },
+  "CandidatePendingAvailablility": {
+    "core": "u32",
+    "descriptor": "CandidateDescriptor",
+    "availability_votes": "BitVec",
+    "relay_parent_number": "BlockNumber",
+    "backed_in_number": "BlockNumber"
+  }
+}


### PR DESCRIPTION
Tested locally.

Usage: `{url} {wasm_file} {genesis_head} {para_id} {types_file}`

In practice: `scripts/register_parachain.sh ws://127.0.0.1:9944 "//Alice" ~/adder_genesis.wasm $(cat ~/adder_genesis.head) 100 scripts/temp_parachain_types.json`

I removed the balance setting thing as that's a separate concern and it didn't work for some reason.