### PR TITLE
Plumb polkadot backend into cumulus-collator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1159,6 +1159,7 @@ dependencies = [
  "sp-inherents",
  "sp-runtime",
  "sp-std",
+ "sp-trie",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1140,6 +1140,7 @@ dependencies = [
  "sp-inherents",
  "sp-io",
  "sp-runtime",
+ "sp-state-machine",
  "sp-std",
  "sp-version",
  "substrate-test-runtime-client",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1234,6 +1234,7 @@ dependencies = [
  "sp-inherents",
  "sp-keyring",
  "sp-runtime",
+ "sp-state-machine",
  "sp-test-primitives",
  "sp-timestamp",
  "substrate-test-client",

--- a/collator/src/lib.rs
+++ b/collator/src/lib.rs
@@ -215,7 +215,7 @@ where
 			.ok()?;
 
 		let validation_data = {
-			// TODO:
+			// TODO: Actual proof is to be created in the upcoming PRs.
 			let relay_chain_state = sp_state_machine::StorageProof::empty();
 			inherents::ValidationDataType {
 				validation_data: validation_data.clone(),

--- a/collator/src/lib.rs
+++ b/collator/src/lib.rs
@@ -71,6 +71,7 @@ pub struct Collator<Block: BlockT, PF, BI, BS, Backend, PBackend, PClient> {
 	wait_to_announce: Arc<Mutex<WaitToAnnounce<Block>>>,
 	backend: Arc<Backend>,
 	polkadot_client: Arc<PClient>,
+	polkadot_backend: Arc<PBackend>,
 }
 
 impl<Block: BlockT, PF, BI, BS, Backend, PBackend, PClient> Clone
@@ -87,6 +88,7 @@ impl<Block: BlockT, PF, BI, BS, Backend, PBackend, PClient> Clone
 			wait_to_announce: self.wait_to_announce.clone(),
 			backend: self.backend.clone(),
 			polkadot_client: self.polkadot_client.clone(),
+			polkadot_backend: self.polkadot_backend.clone(),
 		}
 	}
 }
@@ -123,6 +125,7 @@ where
 		announce_block: Arc<dyn Fn(Block::Hash, Vec<u8>) + Send + Sync>,
 		backend: Arc<Backend>,
 		polkadot_client: Arc<PClient>,
+		polkadot_backend: Arc<PBackend>,
 	) -> Self {
 		let wait_to_announce = Arc::new(Mutex::new(WaitToAnnounce::new(
 			spawner,
@@ -140,6 +143,7 @@ where
 			wait_to_announce,
 			backend,
 			polkadot_client,
+			polkadot_backend,
 		}
 	}
 
@@ -208,8 +212,17 @@ where
 			})
 			.ok()?;
 
+		let validation_data = {
+			// TODO:
+			let relay_chain_state = sp_state_machine::StorageProof::empty();
+			inherents::ValidationDataType {
+				validation_data: validation_data.clone(),
+				relay_chain_state,
+			}
+		};
+
 		inherent_data
-			.put_data(VALIDATION_DATA_IDENTIFIER, validation_data)
+			.put_data(VALIDATION_DATA_IDENTIFIER, &validation_data)
 			.map_err(|e| {
 				error!(
 					target: "cumulus-collator",
@@ -507,7 +520,7 @@ where
 }
 
 /// Parameters for [`start_collator`].
-pub struct StartCollatorParams<Block: BlockT, PF, BI, Backend, Client, BS, Spawner, PClient> {
+pub struct StartCollatorParams<Block: BlockT, PF, BI, Backend, Client, BS, Spawner, PClient, PBackend> {
 	pub proposer_factory: PF,
 	pub inherent_data_providers: InherentDataProviders,
 	pub backend: Arc<Backend>,
@@ -520,6 +533,7 @@ pub struct StartCollatorParams<Block: BlockT, PF, BI, Backend, Client, BS, Spawn
 	pub para_id: ParaId,
 	pub key: CollatorPair,
 	pub polkadot_client: Arc<PClient>,
+	pub polkadot_backend: Arc<PBackend>,
 }
 
 pub async fn start_collator<
@@ -547,7 +561,8 @@ pub async fn start_collator<
 		para_id,
 		key,
 		polkadot_client,
-	}: StartCollatorParams<Block, PF, BI, Backend, Client, BS, Spawner, PClient>,
+		polkadot_backend,
+	}: StartCollatorParams<Block, PF, BI, Backend, Client, BS, Spawner, PClient, PBackend>,
 ) -> Result<(), String>
 where
 	PF: Environment<Block> + Send + 'static,
@@ -594,6 +609,7 @@ where
 		announce_block,
 		backend,
 		polkadot_client,
+		polkadot_backend,
 	);
 
 	let config = CollationGenerationConfig {

--- a/parachain-upgrade/Cargo.toml
+++ b/parachain-upgrade/Cargo.toml
@@ -23,6 +23,7 @@ sp-std = { git = "https://github.com/paritytech/substrate", default-features = f
 sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "master" }
 sp-version = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "master" }
 frame-system = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "master" }
+sp-state-machine = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "master" }
 
 # Other Dependencies
 codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"]}
@@ -45,6 +46,7 @@ std = [
 	'sp-runtime/std',
 	'sp-io/std',
 	'sp-std/std',
+	'sp-state-machine/std',
 	'frame-system/std',
 	'cumulus-primitives/std',
 ]

--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -11,6 +11,7 @@ sp-std = { git = "https://github.com/paritytech/substrate", default-features = f
 sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
 sc-chain-spec = { git = "https://github.com/paritytech/substrate", optional = true, branch = "master" }
 sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
+sp-trie = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
 
 # Polkadot dependencies
 polkadot-parachain = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "master" }
@@ -35,4 +36,5 @@ std = [
 	"polkadot-core-primitives/std",
 	"sp-runtime/std",
 	"sp-core/std",
+	"sp-trie/std",
 ]

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -57,7 +57,14 @@ pub mod inherents {
 	/// The identifier for the `set_validation_data` inherent.
 	pub const VALIDATION_DATA_IDENTIFIER: InherentIdentifier = *b"valfunp0";
 	/// The type of the inherent.
-	pub type ValidationDataType = crate::ValidationData;
+	#[derive(codec::Encode, codec::Decode, sp_core::RuntimeDebug, Clone, PartialEq)]
+	pub struct ValidationDataType {
+		pub validation_data: crate::ValidationData,
+		/// A storage proof of a predefined set of keys from the relay-chain.
+		///
+		/// The set of keys is TBD
+		pub relay_chain_state: sp_trie::StorageProof,
+	}
 }
 
 /// Well known keys for values in the storage.

--- a/rococo-parachains/src/service.rs
+++ b/rococo-parachains/src/service.rs
@@ -187,6 +187,8 @@ where
 		);
 		let spawner = task_manager.spawn_handle();
 
+		let polkadot_backend = polkadot_full_node.backend.clone();
+
 		let params = StartCollatorParams {
 			para_id: id,
 			block_import: client.clone(),
@@ -200,7 +202,7 @@ where
 			polkadot_full_node,
 			spawner,
 			backend,
-			polkadot_backend: polkadot_full_node.backend.clone(),
+			polkadot_backend,
 		};
 
 		start_collator(params).await?;

--- a/rococo-parachains/src/service.rs
+++ b/rococo-parachains/src/service.rs
@@ -200,6 +200,7 @@ where
 			polkadot_full_node,
 			spawner,
 			backend,
+			polkadot_backend: polkadot_full_node.backend.clone(),
 		};
 
 		start_collator(params).await?;

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -36,7 +36,7 @@ use std::{marker::PhantomData, sync::Arc};
 type PFullNode<C> = polkadot_service::NewFull<C>;
 
 /// Parameters given to [`start_collator`].
-pub struct StartCollatorParams<'a, Block: BlockT, PF, BI, BS, Client, Backend, Spawner, PClient> {
+pub struct StartCollatorParams<'a, Block: BlockT, PF, BI, BS, Client, Backend, Spawner, PClient, PBackend> {
 	pub proposer_factory: PF,
 	pub inherent_data_providers: InherentDataProviders,
 	pub backend: Arc<Backend>,
@@ -49,6 +49,7 @@ pub struct StartCollatorParams<'a, Block: BlockT, PF, BI, BS, Client, Backend, S
 	pub collator_key: CollatorPair,
 	pub polkadot_full_node: PFullNode<PClient>,
 	pub task_manager: &'a mut TaskManager,
+	pub polkadot_backend: Arc<PBackend>,
 }
 
 /// Start a collator node for a parachain.
@@ -56,7 +57,7 @@ pub struct StartCollatorParams<'a, Block: BlockT, PF, BI, BS, Client, Backend, S
 /// A collator is similar to a validator in a normal blockchain.
 /// It is responsible for producing blocks and sending the blocks to a
 /// parachain validator for validation and inclusion into the relay chain.
-pub async fn start_collator<'a, Block, PF, BI, BS, Client, Backend, Spawner, PClient>(
+pub async fn start_collator<'a, Block, PF, BI, BS, Client, Backend, Spawner, PClient, PBackend>(
 	StartCollatorParams {
 		proposer_factory,
 		inherent_data_providers,
@@ -70,7 +71,8 @@ pub async fn start_collator<'a, Block, PF, BI, BS, Client, Backend, Spawner, PCl
 		collator_key,
 		polkadot_full_node,
 		task_manager,
-	}: StartCollatorParams<'a, Block, PF, BI, BS, Client, Backend, Spawner, PClient>,
+		polkadot_backend,
+	}: StartCollatorParams<'a, Block, PF, BI, BS, Client, Backend, Spawner, PClient, PBackend>,
 ) -> sc_service::error::Result<()>
 where
 	Block: BlockT,
@@ -111,6 +113,7 @@ where
 			collator_key,
 			block_import,
 			block_status,
+			polkadot_backend,
 		})
 		.await?;
 
@@ -119,7 +122,7 @@ where
 	Ok(())
 }
 
-struct StartCollator<Block: BlockT, Client, Backend, PF, BI, BS, Spawner> {
+struct StartCollator<Block: BlockT, Client, Backend, PF, BI, BS, Spawner, PBackend> {
 	proposer_factory: PF,
 	inherent_data_providers: InherentDataProviders,
 	backend: Arc<Backend>,
@@ -131,10 +134,11 @@ struct StartCollator<Block: BlockT, Client, Backend, PF, BI, BS, Spawner> {
 	spawner: Spawner,
 	para_id: ParaId,
 	collator_key: CollatorPair,
+	polkadot_backend: Arc<PBackend>,
 }
 
-impl<Block, Client, Backend, PF, BI, BS, Spawner> polkadot_service::ExecuteWithClient
-	for StartCollator<Block, Client, Backend, PF, BI, BS, Spawner>
+impl<Block, Client, Backend, PF, BI, BS, Spawner, PBackend2> polkadot_service::ExecuteWithClient
+	for StartCollator<Block, Client, Backend, PF, BI, BS, Spawner, PBackend2>
 where
 	Block: BlockT,
 	PF: Environment<Block> + Send + 'static,
@@ -156,6 +160,8 @@ where
 	for<'b> &'b Client: BlockImport<Block>,
 	Backend: BackendT<Block> + 'static,
 	Spawner: SpawnNamed + Clone + Send + Sync + 'static,
+	PBackend2: sc_client_api::Backend<PBlock> + 'static,
+	PBackend2::State: sp_api::StateBackend<BlakeTwo256>,
 {
 	type Output = std::pin::Pin<Box<dyn Future<Output = ServiceResult<()>>>>;
 
@@ -181,6 +187,7 @@ where
 				para_id: self.para_id,
 				key: self.collator_key,
 				polkadot_client: client,
+				polkadot_backend: self.polkadot_backend,
 			})
 			.await
 			.map_err(Into::into)

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -23,7 +23,7 @@ use futures::{Future, FutureExt};
 use polkadot_overseer::OverseerHandler;
 use polkadot_primitives::v1::{Block as PBlock, CollatorId, CollatorPair};
 use polkadot_service::{AbstractClient, Client as PClient, ClientHandle, RuntimeApiCollection};
-use sc_client_api::{Backend as BackendT, BlockBackend, Finalizer, UsageProvider};
+use sc_client_api::{Backend as BackendT, BlockBackend, Finalizer, UsageProvider, StateBackend};
 use sc_service::{error::Result as ServiceResult, Configuration, Role, TaskManager};
 use sp_blockchain::HeaderBackend;
 use sp_consensus::{BlockImport, Environment, Error as ConsensusError, Proposer};
@@ -96,6 +96,8 @@ where
 	Backend: BackendT<Block> + 'static,
 	Spawner: SpawnNamed + Clone + Send + Sync + 'static,
 	PClient: ClientHandle,
+	PBackend: BackendT<PBlock> + 'static,
+	PBackend::State: StateBackend<BlakeTwo256>,
 {
 	polkadot_full_node
 		.client

--- a/test/client/Cargo.toml
+++ b/test/client/Cargo.toml
@@ -17,6 +17,7 @@ sp-test-primitives = { git = "https://github.com/paritytech/substrate", branch =
 sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sp-inherents = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sp-timestamp = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-state-machine = { git = "https://github.com/paritytech/substrate", branch = "master" }
 frame-system = { git = "https://github.com/paritytech/substrate", branch = "master" }
 pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", branch = "master" }
 pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "master" }

--- a/test/client/src/block_builder.rs
+++ b/test/client/src/block_builder.rs
@@ -15,7 +15,7 @@
 // along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
 
 use crate::Client;
-use cumulus_primitives::{inherents::VALIDATION_DATA_IDENTIFIER, ValidationData};
+use cumulus_primitives::{inherents::{VALIDATION_DATA_IDENTIFIER, ValidationDataType}, ValidationData};
 use cumulus_test_runtime::GetLastTimestamp;
 use polkadot_primitives::v1::BlockNumber as PBlockNumber;
 use sc_block_builder::BlockBuilderApi;
@@ -47,7 +47,10 @@ pub fn generate_block_inherents(
 	inherent_data
 		.put_data(
 			VALIDATION_DATA_IDENTIFIER,
-			&validation_data.unwrap_or_default(),
+			&ValidationDataType {
+				validation_data: validation_data.unwrap_or_default(),
+				relay_chain_state: sp_state_machine::StorageProof::empty(),
+			},
 		)
 		.expect("Put validation function params failed");
 

--- a/test/service/src/lib.rs
+++ b/test/service/src/lib.rs
@@ -223,6 +223,7 @@ where
 			prometheus_registry.as_ref(),
 		);
 
+		let polkadot_backend = polkadot_full_node.backend.clone();
 		let params = StartCollatorParams {
 			proposer_factory,
 			inherent_data_providers: params.inherent_data_providers,
@@ -236,6 +237,7 @@ where
 			para_id,
 			collator_key,
 			polkadot_full_node,
+			polkadot_backend,
 		};
 
 		start_collator(params).await?;


### PR DESCRIPTION
This change plumbs the polkadot backend into the cumulus collator. This enables us to collate storage proofs from the relay-parent to the parachain. (Expected to come in following PRs)

Besides, the type of the inherent data payload was altered so as to incorporate the storage proof.