### PR TITLE
Remove borrowed box

### DIFF
--- a/rococo-parachains/src/chain_spec.rs
+++ b/rococo-parachains/src/chain_spec.rs
@@ -45,7 +45,7 @@ pub struct Extensions {
 
 impl Extensions {
 	/// Try to get the extension from the given `ChainSpec`.
-	pub fn try_get(chain_spec: &Box<dyn sc_service::ChainSpec>) -> Option<&Self> {
+	pub fn try_get(chain_spec: &dyn sc_service::ChainSpec) -> Option<&Self> {
 		sc_chain_spec::get_extension(chain_spec.extensions())
 	}
 }

--- a/rococo-parachains/src/command.rs
+++ b/rococo-parachains/src/command.rs
@@ -264,7 +264,7 @@ pub fn run() -> Result<()> {
 				// TODO
 				let key = sp_core::Pair::generate().0;
 
-				let extension = chain_spec::Extensions::try_get(&config.chain_spec);
+				let extension = chain_spec::Extensions::try_get(&*config.chain_spec);
 				let relay_chain_id = extension.map(|e| e.relay_chain.clone());
 				let para_id = extension.map(|e| e.para_id);
 

--- a/test/service/src/chain_spec.rs
+++ b/test/service/src/chain_spec.rs
@@ -46,7 +46,7 @@ pub struct Extensions {
 
 impl Extensions {
 	/// Try to get the extension from the given `ChainSpec`.
-	pub fn try_get(chain_spec: &Box<dyn sc_service::ChainSpec>) -> Option<&Self> {
+	pub fn try_get(chain_spec: &dyn sc_service::ChainSpec) -> Option<&Self> {
 		sc_chain_spec::get_extension(chain_spec.extensions())
 	}
 }


### PR DESCRIPTION
This PR changes the signature of the `try_get` function to not use a borrowed box. Clippy recommends this. Although cumulus does not use clippy, it still seems like a good change.

https://rust-lang.github.io/rust-clippy/master/index.html

![image](https://user-images.githubusercontent.com/2915325/103233155-5638dd80-490a-11eb-9e71-304023b20237.png)
