### PR TITLE
Ignore offchain indexing in validation function.

### DIFF
--- a/runtime/src/validate_block/implementation.rs
+++ b/runtime/src/validate_block/implementation.rs
@@ -112,6 +112,8 @@ pub fn validate_block<B: BlockT, E: ExecuteBlock<B>>(params: ValidationParams) -
 			.replace_implementation(host_storage_rollback_transaction),
 		sp_io::storage::host_commit_transaction
 			.replace_implementation(host_storage_commit_transaction),
+		sp_io::storage::host_set_offchain_storage
+			.replace_implementation(host_default_set_offchain_storage),
 		sp_io::default_child_storage::host_get
 			.replace_implementation(host_default_child_storage_get),
 		sp_io::default_child_storage::host_read
@@ -130,8 +132,6 @@ pub fn validate_block<B: BlockT, E: ExecuteBlock<B>>(params: ValidationParams) -
 			.replace_implementation(host_default_child_storage_root),
 		sp_io::default_child_storage::host_next_key
 			.replace_implementation(host_default_child_storage_next_key),
-		sp_io::default_child_storage::host_set_offchain_storage
-			.replace_implementation(host_default_set_offchain_storage),
 	);
 
 	set_and_run_with_externalities(&mut ext, || {

--- a/runtime/src/validate_block/implementation.rs
+++ b/runtime/src/validate_block/implementation.rs
@@ -112,8 +112,6 @@ pub fn validate_block<B: BlockT, E: ExecuteBlock<B>>(params: ValidationParams) -
 			.replace_implementation(host_storage_rollback_transaction),
 		sp_io::storage::host_commit_transaction
 			.replace_implementation(host_storage_commit_transaction),
-		sp_io::storage::host_set_offchain_storage
-			.replace_implementation(host_default_set_offchain_storage),
 		sp_io::default_child_storage::host_get
 			.replace_implementation(host_default_child_storage_get),
 		sp_io::default_child_storage::host_read
@@ -132,6 +130,10 @@ pub fn validate_block<B: BlockT, E: ExecuteBlock<B>>(params: ValidationParams) -
 			.replace_implementation(host_default_child_storage_root),
 		sp_io::default_child_storage::host_next_key
 			.replace_implementation(host_default_child_storage_next_key),
+		sp_io::offchain_index::host_set
+			.replace_implementation(host_offchain_index_set),
+		sp_io::offchain_index::host_clear
+			.replace_implementation(host_offchain_index_clear),
 	);
 
 	set_and_run_with_externalities(&mut ext, || {
@@ -491,3 +493,7 @@ fn host_default_child_storage_next_key(storage_key: &[u8], key: &[u8]) -> Option
 	let child_info = ChildInfo::new_default(storage_key);
 	with_externalities(|ext| ext.next_child_storage_key(&child_info, key))
 }
+
+fn host_offchain_index_set(_key: &[u8], _value: &[u8]) { }
+
+fn host_offchain_index_clear(_key: &[u8]) { }

--- a/runtime/src/validate_block/implementation.rs
+++ b/runtime/src/validate_block/implementation.rs
@@ -130,6 +130,8 @@ pub fn validate_block<B: BlockT, E: ExecuteBlock<B>>(params: ValidationParams) -
 			.replace_implementation(host_default_child_storage_root),
 		sp_io::default_child_storage::host_next_key
 			.replace_implementation(host_default_child_storage_next_key),
+		sp_io::default_child_storage::host_set_offchain_storage
+			.replace_implementation(host_default_set_offchain_storage),
 	);
 
 	set_and_run_with_externalities(&mut ext, || {


### PR DESCRIPTION
Offchain indexing should be ignored when validation state.
This PR adds the function overload.
I could have call the externality, but seems more correct to noops.