### PR TITLE
Use correct relative path for parachain

### DIFF
--- a/xcm-handler/src/lib.rs
+++ b/xcm-handler/src/lib.rs
@@ -159,18 +159,22 @@ impl<T: Config> SendXcm for Module<T> {
 				Ok(())
 			}
 			// An HRMP message for a sibling parachain.
-			Some(Junction::Parachain { id }) => {
-				let data = msg.encode();
-				let hash = T::Hashing::hash(&data);
-				let message = OutboundHrmpMessage {
-					recipient: (*id).into(),
-					data,
-				};
-				// TODO: Better error here
-				T::HrmpMessageSender::send_hrmp_message(message)
-					.map_err(|_| XcmError::Undefined)?;
-				Self::deposit_event(RawEvent::HrmpMessageSent(hash));
-				Ok(())
+			Some(Junction::Parent) if dest.len() == 2 => {
+				if let Some(Junction::Parachain { id }) = dest.at(1) {
+					let data = msg.encode();
+					let hash = T::Hashing::hash(&data);
+					let message = OutboundHrmpMessage {
+						recipient: (*id).into(),
+						data,
+					};
+					// TODO: Better error here
+					T::HrmpMessageSender::send_hrmp_message(message)
+						.map_err(|_| XcmError::Undefined)?;
+					Self::deposit_event(RawEvent::HrmpMessageSent(hash));
+					Ok(())
+				} else {
+					Err(XcmError::UnhandledXcmMessage)
+				}
 			}
 			_ => {
 				/* TODO: Handle other cases, like downward message */


### PR DESCRIPTION
According to my understanding of the XCM spec, location of parachains is of the form:
`MultiLocation::X2(Junction::Parent, Junction::Parachain { id })`

This fix was necessary to execute the following message and forward the effects to via HRMP:
```rust
Xcm::WithdrawAsset {
	assets: vec![MultiAsset::ConcreteFungible {
		id: location,
		amount: amount.into(),
	}],
	effects: vec![Order::DepositReserveAsset {
		assets: vec![MultiAsset::All],
		dest: MultiLocation::X2(Junction::Parent, Junction::Parachain { id: para_id.into() }),
		effects: vec![Order::DepositAsset {
			assets: vec![MultiAsset::All],
			dest: MultiLocation::X1(Junction::AccountId32 {
				network: network.clone(),
				id: T::AccountId32Converter::convert(recipient.clone()),
			}),
		}],
	}],
}
```