### PR TITLE
Question: How can I add a seal digest

### DIFF
--- a/client/consensus/relay-chain/src/lib.rs
+++ b/client/consensus/relay-chain/src/lib.rs
@@ -240,8 +240,8 @@ where
 		// But if I leave this in place, then the relay chain cannot validate the candidate.
 		// It fails with:
 		// 2021-03-03 15:58:54  panicked at 'assertion failed: `(left == right)`
-		// left: `2`,
-		// right: `1`: Number of digest items must match that calculated.', /home/joshy/.cargo/git/checkouts/substrate-7e08433d4c370a21/74d5612/frame/executive/src/lib.rs:421:9
+		// left: `1`,
+		// right: `0`: Number of digest items must match that calculated.', /home/joshy/.cargo/git/checkouts/substrate-7e08433d4c370a21/74d5612/frame/executive/src/lib.rs:421:9
 
 		let mut post_header = header.clone();
 		post_header.digest_mut().logs.push(test_digest.clone());


### PR DESCRIPTION
I'm working toward having the consensus engine sign blocks. I'm stuck on how to add the seal digest. I've reduced my confusion down to this minimal example, in which I add a simple silly digest item which contains no real data.

I'm able to successfully add the digest item and get my node to import the blocks. I haven't written the verifier yet, although I believe I understand the principles. Before I get to that, I'm stuck because the relay chain validators can't import my blocks.

I guess my final question is: what should I return from the `produce_candidate` function?
* The complete block including the seal
* The original block as it came out of the runtime (with no seal)
* We should change the interface and return both. Both are needed later by the cumulus collator.