### PR TITLE
Support xcm local execution in xcm-handler.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1304,6 +1304,7 @@ dependencies = [
  "parity-scale-codec",
  "sp-std",
  "xcm",
+ "xcm-executor",
 ]
 
 [[package]]

--- a/pallets/xcm-handler/Cargo.toml
+++ b/pallets/xcm-handler/Cargo.toml
@@ -16,6 +16,7 @@ frame-system = { git = "https://github.com/paritytech/substrate", default-featur
 
 # Polkadot Dependencies
 xcm = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "master" }
+xcm-executor = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "master" }
 
 # Cumulus Dependencies
 cumulus-primitives-core = { path = "../../primitives/core", default-features = false }
@@ -29,5 +30,6 @@ std = [
 	"frame-support/std",
 	"frame-system/std",
 	"cumulus-primitives-core/std",
-	"xcm/std"
+	"xcm/std",
+	"xcm-executor/std",
 ]

--- a/pallets/xcm-handler/src/lib.rs
+++ b/pallets/xcm-handler/src/lib.rs
@@ -27,12 +27,13 @@ use cumulus_primitives_core::{
 	DownwardMessageHandler, HrmpMessageHandler, HrmpMessageSender, InboundDownwardMessage,
 	InboundHrmpMessage, OutboundHrmpMessage, ParaId, UpwardMessageSender,
 };
-use frame_support::{decl_error, decl_event, decl_module, sp_runtime::traits::Hash, traits::EnsureOrigin};
+use frame_support::{decl_error, decl_event, decl_module, dispatch::DispatchResult, sp_runtime::traits::Hash, traits::EnsureOrigin};
 use sp_std::convert::{TryFrom, TryInto};
 use xcm::{
 	v0::{Error as XcmError, ExecuteXcm, Junction, MultiLocation, SendXcm, Xcm},
 	VersionedXcm,
 };
+use xcm_executor::traits::LocationConversion;
 
 pub trait Config: frame_system::Config {
 	type Event: From<Event<Self>> + Into<<Self as frame_system::Config>::Event>;
@@ -45,6 +46,9 @@ pub trait Config: frame_system::Config {
 	/// Required origin for sending XCM messages. Typically Root or parachain
 	/// council majority.
 	type SendXcmOrigin: EnsureOrigin<Self::Origin>;
+	/// Utility for converting from the signed origin (of type `Self::AccountId`) into a sensible
+	/// `MultiLocation` ready for passing to the XCM interpreter.
+	type AccountIdConverter: LocationConversion<Self::AccountId>;
 }
 
 decl_event! {
@@ -68,6 +72,8 @@ decl_error! {
 	pub enum Error for Module<T: Config> {
 		/// Failed to send XCM message.
 		FailedToSend,
+		/// Bad XCM origin.
+		BadXcmOrigin,
 	}
 }
 
@@ -98,6 +104,20 @@ decl_module! {
 			};
 			T::HrmpMessageSender::send_hrmp_message(outbound_message).map_err(|_| Error::<T>::FailedToSend)?;
 		}
+	}
+}
+
+impl<T: Config> Module<T> {
+	pub fn execute_xcm(origin: T::AccountId, xcm: Xcm) -> DispatchResult {
+		let xcm_origin = T::AccountIdConverter::try_into_location(origin)
+			.map_err(|_| Error::<T>::BadXcmOrigin)?;
+		let hash = T::Hashing::hash(&xcm.encode());
+		let event = match T::XcmExecutor::execute_xcm(xcm_origin, xcm) {
+			Ok(_) => Event::<T>::Success(hash),
+			Err(e) => Event::<T>::Fail(hash, e),
+		};
+		Self::deposit_event(event);
+		Ok(())
 	}
 }
 

--- a/pallets/xcm-handler/src/lib.rs
+++ b/pallets/xcm-handler/src/lib.rs
@@ -108,6 +108,7 @@ decl_module! {
 }
 
 impl<T: Config> Module<T> {
+	/// Execute an XCM message locally. Returns `DispatchError` if failed.
 	pub fn execute_xcm(origin: T::AccountId, xcm: Xcm) -> DispatchResult {
 		let xcm_origin = T::AccountIdConverter::try_into_location(origin)
 			.map_err(|_| Error::<T>::BadXcmOrigin)?;

--- a/rococo-parachains/runtime/src/lib.rs
+++ b/rococo-parachains/runtime/src/lib.rs
@@ -290,6 +290,7 @@ impl cumulus_pallet_xcm_handler::Config for Runtime {
 	type UpwardMessageSender = ParachainSystem;
 	type HrmpMessageSender = ParachainSystem;
 	type SendXcmOrigin = EnsureRoot<AccountId>;
+	type AccountIdConverter = LocationConverter;
 }
 
 construct_runtime! {


### PR DESCRIPTION
With xcm local execution support, modules like `xtokens` don't have to do workarounds and use xcm-executor to do the execution anymore.

As discussed with @shawntabrizi and @xlc, updating xcm-handler's `SendXcm` implementation can't achieve the same goal, unless adding a `origin` parameter to the `send_xcm` signature, which is not necessary IMO as in other cases this param is not needed:

```rust
fn send_xcm(origin: MultiLocation, dest: MultiLocation, msg: Xcm) -> Result<(), XcmError> {}
```