### PR TITLE
Fix block propagation between non-collator nodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1208,6 +1208,7 @@ dependencies = [
 name = "cumulus-client-network"
 version = "0.1.0"
 dependencies = [
+ "cumulus-primitives-core",
  "cumulus-test-service",
  "derive_more 0.99.11",
  "futures 0.3.12",
@@ -1220,7 +1221,10 @@ dependencies = [
  "polkadot-service",
  "polkadot-statement-table",
  "polkadot-test-client",
+ "polkadot-test-service",
+ "sc-cli",
  "sc-client-api",
+ "sc-service",
  "sp-api",
  "sp-blockchain",
  "sp-consensus",
@@ -1228,6 +1232,8 @@ dependencies = [
  "sp-keyring",
  "sp-keystore",
  "sp-runtime",
+ "substrate-test-utils",
+ "tokio 0.2.24",
  "tracing",
 ]
 
@@ -1459,12 +1465,10 @@ dependencies = [
  "cumulus-test-runtime",
  "futures 0.3.12",
  "jsonrpc-core",
- "pallet-sudo",
  "parity-scale-codec",
  "polkadot-overseer",
  "polkadot-primitives",
  "polkadot-service",
- "polkadot-test-runtime",
  "polkadot-test-service",
  "rand 0.7.3",
  "sc-basic-authorship",
@@ -1494,7 +1498,6 @@ dependencies = [
  "sp-transaction-pool",
  "sp-trie",
  "substrate-test-client",
- "substrate-test-runtime-client",
  "substrate-test-utils",
  "tokio 0.2.24",
 ]
@@ -1976,7 +1979,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -1994,7 +1997,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "3.1.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2013,7 +2016,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "Inflector",
  "chrono",
@@ -2036,7 +2039,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2052,7 +2055,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -2063,7 +2066,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "bitflags",
  "frame-metadata",
@@ -2089,7 +2092,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "Inflector",
  "frame-support-procedural-tools",
@@ -2101,7 +2104,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 1.0.0",
@@ -2113,7 +2116,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
@@ -2123,7 +2126,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -2140,7 +2143,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -2149,7 +2152,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4394,7 +4397,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4410,7 +4413,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4425,7 +4428,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4450,7 +4453,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4465,7 +4468,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4479,7 +4482,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4495,7 +4498,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4510,7 +4513,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4529,7 +4532,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4544,7 +4547,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4566,7 +4569,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -4582,7 +4585,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4601,7 +4604,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4617,7 +4620,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4631,7 +4634,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4646,7 +4649,7 @@ dependencies = [
 [[package]]
 name = "pallet-nicks"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4660,7 +4663,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4676,7 +4679,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4691,7 +4694,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4704,7 +4707,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "enumflags2",
  "frame-support",
@@ -4719,7 +4722,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4735,7 +4738,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4755,7 +4758,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4769,7 +4772,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4791,7 +4794,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "proc-macro-crate 1.0.0",
  "proc-macro2 1.0.24",
@@ -4802,7 +4805,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4816,7 +4819,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4834,7 +4837,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4848,7 +4851,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4864,7 +4867,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -4881,7 +4884,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -4892,7 +4895,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4907,7 +4910,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4922,7 +4925,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "enumflags2",
  "frame-support",
@@ -7105,7 +7108,7 @@ dependencies = [
 [[package]]
 name = "remote-externalities"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "env_logger 0.8.3",
  "hex-literal 0.3.1",
@@ -7431,7 +7434,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "async-trait",
  "derive_more 0.99.11",
@@ -7459,7 +7462,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "futures 0.3.12",
  "futures-timer 3.0.2",
@@ -7482,7 +7485,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -7498,7 +7501,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -7519,7 +7522,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "proc-macro-crate 1.0.0",
  "proc-macro2 1.0.24",
@@ -7530,7 +7533,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "chrono",
  "fdlimit",
@@ -7568,7 +7571,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "derive_more 0.99.11",
  "fnv",
@@ -7602,7 +7605,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "blake2-rfc",
  "hash-db",
@@ -7632,7 +7635,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "sc-client-api",
  "sp-blockchain",
@@ -7643,7 +7646,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "derive_more 0.99.11",
  "fork-tree",
@@ -7689,7 +7692,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "derive_more 0.99.11",
  "futures 0.3.12",
@@ -7713,7 +7716,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -7726,7 +7729,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "futures 0.3.12",
  "futures-timer 3.0.2",
@@ -7752,7 +7755,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-uncles"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "log",
  "sc-client-api",
@@ -7766,7 +7769,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "derive_more 0.99.11",
  "lazy_static",
@@ -7795,7 +7798,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "derive_more 0.99.11",
  "parity-scale-codec",
@@ -7811,7 +7814,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -7826,7 +7829,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -7844,7 +7847,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "derive_more 0.99.11",
  "dyn-clone",
@@ -7883,7 +7886,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa-rpc"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "derive_more 0.99.11",
  "finality-grandpa",
@@ -7907,7 +7910,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa-warp-sync"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "derive_more 0.99.11",
  "futures 0.3.12",
@@ -7928,7 +7931,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "ansi_term 0.12.1",
  "futures 0.3.12",
@@ -7946,7 +7949,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "async-trait",
  "derive_more 0.99.11",
@@ -7966,7 +7969,7 @@ dependencies = [
 [[package]]
 name = "sc-light"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "hash-db",
  "lazy_static",
@@ -7985,7 +7988,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "async-std",
  "async-trait",
@@ -8038,7 +8041,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "futures 0.3.12",
  "futures-timer 3.0.2",
@@ -8054,7 +8057,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "bytes 0.5.6",
  "fnv",
@@ -8082,7 +8085,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "futures 0.3.12",
  "libp2p",
@@ -8095,7 +8098,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -8104,7 +8107,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "futures 0.3.12",
  "hash-db",
@@ -8138,7 +8141,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "derive_more 0.99.11",
  "futures 0.3.12",
@@ -8162,7 +8165,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "futures 0.1.30",
  "jsonrpc-core",
@@ -8180,7 +8183,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "directories",
  "exit-future 0.2.0",
@@ -8243,7 +8246,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -8258,7 +8261,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -8278,7 +8281,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "chrono",
  "futures 0.3.12",
@@ -8298,7 +8301,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
@@ -8325,7 +8328,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "proc-macro-crate 1.0.0",
  "proc-macro2 1.0.24",
@@ -8336,7 +8339,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-graph"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "derive_more 0.99.11",
  "futures 0.3.12",
@@ -8358,7 +8361,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "futures 0.3.12",
  "futures-diagnose",
@@ -8763,7 +8766,7 @@ dependencies = [
 [[package]]
 name = "sp-allocator"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "log",
  "sp-core",
@@ -8775,7 +8778,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "hash-db",
  "log",
@@ -8792,7 +8795,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate 1.0.0",
@@ -8804,7 +8807,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -8816,7 +8819,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -8829,7 +8832,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -8841,7 +8844,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -8852,7 +8855,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -8864,7 +8867,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "futures 0.3.12",
  "log",
@@ -8882,7 +8885,7 @@ dependencies = [
 [[package]]
 name = "sp-chain-spec"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "serde",
  "serde_json",
@@ -8891,7 +8894,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "futures 0.3.12",
  "futures-timer 3.0.2",
@@ -8917,7 +8920,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -8932,7 +8935,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "merlin",
  "parity-scale-codec",
@@ -8953,7 +8956,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "parity-scale-codec",
  "sp-arithmetic",
@@ -8963,7 +8966,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",
@@ -8975,7 +8978,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -9019,7 +9022,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "kvdb",
  "parking_lot 0.11.1",
@@ -9028,7 +9031,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
@@ -9038,7 +9041,7 @@ dependencies = [
 [[package]]
 name = "sp-election-providers"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "parity-scale-codec",
  "sp-arithmetic",
@@ -9049,7 +9052,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -9060,7 +9063,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -9077,7 +9080,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.11.1",
@@ -9089,7 +9092,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "futures 0.3.12",
  "hash-db",
@@ -9113,7 +9116,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -9124,7 +9127,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "async-trait",
  "derive_more 0.99.11",
@@ -9141,7 +9144,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -9154,7 +9157,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections-compact"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "proc-macro-crate 1.0.0",
  "proc-macro2 1.0.24",
@@ -9165,7 +9168,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -9175,7 +9178,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "backtrace",
 ]
@@ -9183,7 +9186,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "serde",
  "sp-core",
@@ -9192,7 +9195,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -9213,7 +9216,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -9230,7 +9233,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "Inflector",
  "proc-macro-crate 1.0.0",
@@ -9242,7 +9245,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "serde",
  "serde_json",
@@ -9251,7 +9254,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -9264,7 +9267,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -9274,7 +9277,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "hash-db",
  "log",
@@ -9296,12 +9299,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 
 [[package]]
 name = "sp-storage"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -9314,7 +9317,7 @@ dependencies = [
 [[package]]
 name = "sp-tasks"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "log",
  "sp-core",
@@ -9327,7 +9330,7 @@ dependencies = [
 [[package]]
 name = "sp-test-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "parity-scale-codec",
  "parity-util-mem",
@@ -9340,7 +9343,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -9354,7 +9357,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -9367,7 +9370,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "derive_more 0.99.11",
  "futures 0.3.12",
@@ -9383,7 +9386,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -9397,7 +9400,7 @@ dependencies = [
 [[package]]
 name = "sp-utils"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "futures 0.3.12",
  "futures-core",
@@ -9409,7 +9412,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -9421,7 +9424,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -9554,7 +9557,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "platforms",
 ]
@@ -9562,7 +9565,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.12",
@@ -9585,7 +9588,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "async-std",
  "derive_more 0.99.11",
@@ -9599,7 +9602,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "futures 0.1.30",
  "futures 0.3.12",
@@ -9627,7 +9630,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "cfg-if 1.0.0",
  "frame-support",
@@ -9668,7 +9671,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime-client"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "futures 0.3.12",
  "parity-scale-codec",
@@ -9689,7 +9692,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-utils"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "futures 0.3.12",
  "substrate-test-utils-derive",
@@ -9699,7 +9702,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-utils-derive"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "proc-macro-crate 1.0.0",
  "quote 1.0.9",
@@ -9725,7 +9728,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
@@ -10229,9 +10232,9 @@ checksum = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
 
 [[package]]
 name = "tracing"
-version = "0.1.22"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f47026cdc4080c07e49b37087de021820269d996f581aac150ef9e5583eefe3"
+checksum = "01ebdc2bb4498ab1ab5f5b73c5803825e60199229ccba0698170e3be0e7f959f"
 dependencies = [
  "cfg-if 1.0.0",
  "log",
@@ -10242,9 +10245,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.11"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e0ccfc3378da0cce270c946b676a376943f5cd16aeba64568e7939806f4ada"
+checksum = "41768be5b9f3489491825f56f01f25290aa1d3e7cc97e182d4d34360493ba6fa"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.9",
@@ -10359,7 +10362,7 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 [[package]]
 name = "try-runtime-cli"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6ac86d545f6da8e4afc373dc0876c3e7ba79e51b"
+source = "git+https://github.com/paritytech/substrate?branch=master#8b3e5bc7cd056112d390920fca5a554b2d0b0475"
 dependencies = [
  "frame-try-runtime",
  "log",

--- a/client/collator/src/lib.rs
+++ b/client/collator/src/lib.rs
@@ -79,7 +79,7 @@ where
 	fn new(
 		block_status: Arc<BS>,
 		spawner: Arc<dyn SpawnNamed + Send + Sync>,
-		announce_block: Arc<dyn Fn(Block::Hash, Vec<u8>) + Send + Sync>,
+		announce_block: Arc<dyn Fn(Block::Hash, Option<Vec<u8>>) + Send + Sync>,
 		backend: Arc<Backend>,
 		parachain_consensus: Box<dyn ParachainConsensus<Block>>,
 	) -> Self {
@@ -337,7 +337,7 @@ pub struct StartCollatorParams<Block: BlockT, Backend, BS, Spawner> {
 	pub para_id: ParaId,
 	pub backend: Arc<Backend>,
 	pub block_status: Arc<BS>,
-	pub announce_block: Arc<dyn Fn(Block::Hash, Vec<u8>) + Send + Sync>,
+	pub announce_block: Arc<dyn Fn(Block::Hash, Option<Vec<u8>>) + Send + Sync>,
 	pub overseer_handler: OverseerHandler,
 	pub spawner: Spawner,
 	pub key: CollatorPair,

--- a/client/consensus/common/Cargo.toml
+++ b/client/consensus/common/Cargo.toml
@@ -26,7 +26,7 @@ polkadot-runtime = { git = "https://github.com/paritytech/polkadot", branch = "m
 futures = { version = "0.3.8", features = ["compat"] }
 tokio = "0.1.22"
 codec = { package = "parity-scale-codec", version = "2.0.0", features = [ "derive" ] }
-tracing = "0.1.22"
+tracing = "0.1.25"
 async-trait = "0.1.42"
 dyn-clone = "1.0.4"
 

--- a/client/network/Cargo.toml
+++ b/client/network/Cargo.toml
@@ -30,11 +30,15 @@ parking_lot = "0.10.2"
 derive_more = "0.99.2"
 
 [dev-dependencies]
+tokio = { version = "0.2.21", features = ["macros"] }
+
 # Cumulus deps
 cumulus-test-service = { path = "../../test/service" }
+cumulus-primitives-core = { path = "../../primitives/core" }
 
 # Polkadot deps
 polkadot-test-client = { git = "https://github.com/paritytech/polkadot", branch = "master" }
+polkadot-test-service = { git = "https://github.com/paritytech/polkadot", branch = "master" }
 
 # substrate deps
 sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
@@ -42,3 +46,6 @@ sp-core = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sp-keystore = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sp-consensus = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-cli = { git = "https://github.com/paritytech/substrate", branch = "master" }
+substrate-test-utils = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-service = { git = "https://github.com/paritytech/substrate", branch = "master" }

--- a/client/network/tests/sync.rs
+++ b/client/network/tests/sync.rs
@@ -1,0 +1,86 @@
+// Copyright 2021 Parity Technologies (UK) Ltd.
+// This file is part of Substrate.
+
+// Substrate is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Substrate is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
+
+use cumulus_primitives_core::ParaId;
+use cumulus_test_service::{initial_head_data, Keyring::*};
+use futures::join;
+use sc_service::TaskExecutor;
+
+#[substrate_test_utils::test]
+async fn sync_blocks_from_tip_without_being_connected_to_a_collator(task_executor: TaskExecutor) {
+	let mut builder = sc_cli::LoggerBuilder::new("");
+	builder.with_colors(false);
+	let _ = builder.init();
+
+	let para_id = ParaId::from(100);
+
+	// start alice
+	let alice =
+		polkadot_test_service::run_validator_node(task_executor.clone(), Alice, || {}, vec![]);
+
+	// start bob
+	let bob = polkadot_test_service::run_validator_node(
+		task_executor.clone(),
+		Bob,
+		|| {},
+		vec![alice.addr.clone()],
+	);
+
+	// register parachain
+	alice
+		.register_parachain(
+			para_id,
+			cumulus_test_service::runtime::WASM_BINARY
+				.expect("You need to build the WASM binary to run this test!")
+				.to_vec(),
+			initial_head_data(para_id),
+		)
+		.await
+		.unwrap();
+
+	// run charlie as parachain collator
+	let charlie =
+		cumulus_test_service::TestNodeBuilder::new(para_id, task_executor.clone(), Charlie)
+			.enable_collator()
+			.connect_to_relay_chain_nodes(vec![&alice, &bob])
+			.build()
+			.await;
+
+	// run dave as parachain full node
+	let dave = cumulus_test_service::TestNodeBuilder::new(para_id, task_executor.clone(), Dave)
+		.connect_to_parachain_node(&charlie)
+		.connect_to_relay_chain_nodes(vec![&alice, &bob])
+		.build()
+		.await;
+
+	// run eve as parachain full node that is only connected to dave
+	let eve = cumulus_test_service::TestNodeBuilder::new(para_id, task_executor.clone(), Eve)
+		.connect_to_parachain_node(&dave)
+		.exclusively_connect_to_registered_parachain_nodes()
+		.connect_to_relay_chain_nodes(vec![&alice, &bob])
+		.build()
+		.await;
+
+	eve.wait_for_blocks(7).await;
+
+	join!(
+		alice.task_manager.clean_shutdown(),
+		bob.task_manager.clean_shutdown(),
+		charlie.task_manager.clean_shutdown(),
+		dave.task_manager.clean_shutdown(),
+		eve.task_manager.clean_shutdown(),
+	);
+}

--- a/client/service/src/lib.rs
+++ b/client/service/src/lib.rs
@@ -44,7 +44,7 @@ pub struct StartCollatorParams<'a, Block: BlockT, BS, Client, Backend, Spawner, 
 	pub backend: Arc<Backend>,
 	pub block_status: Arc<BS>,
 	pub client: Arc<Client>,
-	pub announce_block: Arc<dyn Fn(Block::Hash, Vec<u8>) + Send + Sync>,
+	pub announce_block: Arc<dyn Fn(Block::Hash, Option<Vec<u8>>) + Send + Sync>,
 	pub spawner: Spawner,
 	pub para_id: ParaId,
 	pub collator_key: CollatorPair,
@@ -121,7 +121,7 @@ pub struct StartFullNodeParams<'a, Block: BlockT, Client, PClient> {
 	pub client: Arc<Client>,
 	pub polkadot_full_node: RFullNode<PClient>,
 	pub task_manager: &'a mut TaskManager,
-	pub announce_block: Arc<dyn Fn(Block::Hash, Vec<u8>) + Send + Sync>,
+	pub announce_block: Arc<dyn Fn(Block::Hash, Option<Vec<u8>>) + Send + Sync>,
 }
 
 /// Start a full node for a parachain.
@@ -165,7 +165,7 @@ where
 
 struct StartConsensus<'a, Block: BlockT, Client, Backend> {
 	para_id: ParaId,
-	announce_block: Arc<dyn Fn(Block::Hash, Vec<u8>) + Send + Sync>,
+	announce_block: Arc<dyn Fn(Block::Hash, Option<Vec<u8>>) + Send + Sync>,
 	client: Arc<Client>,
 	task_manager: &'a mut TaskManager,
 	_phantom: PhantomData<Backend>,

--- a/rococo-parachains/src/service.rs
+++ b/rococo-parachains/src/service.rs
@@ -207,7 +207,7 @@ where
 
 	let announce_block = {
 		let network = network.clone();
-		Arc::new(move |hash, data| network.announce_block(hash, Some(data)))
+		Arc::new(move |hash, data| network.announce_block(hash, data))
 	};
 
 	if validator {

--- a/test/service/Cargo.toml
+++ b/test/service/Cargo.toml
@@ -56,12 +56,6 @@ jsonrpc-core = "15.1.0"
 futures = { version = "0.3.5" }
 tokio = { version = "0.2.21", features = ["macros"] }
 
-# Polkadot dependencies
-polkadot-test-runtime = { git = "https://github.com/paritytech/polkadot", branch = "master" }
-polkadot-test-service = { git = "https://github.com/paritytech/polkadot", branch = "master" }
-
 # Substrate dependencies
-pallet-sudo = { git = "https://github.com/paritytech/substrate", branch = "master" }
-substrate-test-runtime-client = { git = "https://github.com/paritytech/substrate", branch = "master" }
 substrate-test-utils = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sc-cli = { git = "https://github.com/paritytech/substrate", branch = "master" }

--- a/test/service/src/lib.rs
+++ b/test/service/src/lib.rs
@@ -122,10 +122,9 @@ pub fn new_partial(
 #[sc_tracing::logging::prefix_logs_with(parachain_config.network.node_name.as_str())]
 async fn start_node_impl<RB>(
 	parachain_config: Configuration,
-	collator_key: CollatorPair,
+	collator_key: Option<CollatorPair>,
 	relay_chain_config: Configuration,
 	para_id: ParaId,
-	is_collator: bool,
 	rpc_ext_builder: RB,
 ) -> sc_service::error::Result<(
 	TaskManager,
@@ -157,7 +156,11 @@ where
 
 	let relay_chain_full_node = polkadot_test_service::new_full(
 		relay_chain_config,
-		polkadot_service::IsCollator::Yes(collator_key.public()),
+		if let Some(ref key) = collator_key {
+			polkadot_service::IsCollator::Yes(key.public())
+		} else {
+			polkadot_service::IsCollator::No
+		},
 	)
 	.map_err(|e| match e {
 		polkadot_service::Error::Sub(x) => x,
@@ -215,7 +218,7 @@ where
 		Arc::new(move |hash, data| network.announce_block(hash, Some(data)))
 	};
 
-	if is_collator {
+	if let Some(collator_key) = collator_key {
 		let proposer_factory = sc_basic_authorship::ProposerFactory::with_proof_recording(
 			task_manager.spawn_handle(),
 			client.clone(),
@@ -270,7 +273,7 @@ where
 }
 
 /// A Cumulus test node instance used for testing.
-pub struct CumulusTestNode {
+pub struct TestNode {
 	/// TaskManager's instance.
 	pub task_manager: TaskManager,
 	/// Client's instance.
@@ -284,73 +287,156 @@ pub struct CumulusTestNode {
 	pub rpc_handlers: RpcHandlers,
 }
 
-/// Run a Cumulus test node using the Cumulus test runtime. The node will be using an in-memory
-/// socket, therefore you need to provide boot nodes if you want it to be connected to other nodes.
-/// The `storage_update_func` can be used to make adjustements to the runtime before the node
-/// starts.
-pub async fn run_test_node(
+
+/// A builder to create a [`TestNode`].
+pub struct TestNodeBuilder {
+	para_id: ParaId,
 	task_executor: TaskExecutor,
 	key: Sr25519Keyring,
-	parachain_storage_update_func: impl Fn(),
-	relay_chain_storage_update_func: impl Fn(),
-	parachain_boot_nodes: Vec<MultiaddrWithPeerId>,
-	relay_chain_boot_nodes: Vec<MultiaddrWithPeerId>,
-	para_id: ParaId,
-	is_collator: bool,
-) -> CumulusTestNode {
-	let collator_key = CollatorPair::generate().0;
-	let parachain_config = node_config(
-		parachain_storage_update_func,
-		task_executor.clone(),
-		key,
-		parachain_boot_nodes,
-		para_id,
-		is_collator,
-	)
-	.expect("could not generate Configuration");
-	let mut relay_chain_config = polkadot_test_service::node_config(
-		relay_chain_storage_update_func,
-		task_executor.clone(),
-		key,
-		relay_chain_boot_nodes,
-		false,
-	);
+	collator_key: Option<CollatorPair>,
+	parachain_nodes: Vec<MultiaddrWithPeerId>,
+	parachain_nodes_exclusive: bool,
+	relay_chain_nodes: Vec<MultiaddrWithPeerId>,
+}
 
-	relay_chain_config.network.node_name =
-		format!("{} (relay chain)", relay_chain_config.network.node_name);
+impl TestNodeBuilder {
+	/// Create a new instance of `Self`.
+	///
+	/// `para_id` - The parachain id this node is running for.
+	/// `task_executor` - The task executor to use.
+	/// `key` - The key that will be used to generate the name and that will be passed as `dev_seed`.
+	pub fn new(para_id: ParaId, task_executor: TaskExecutor, key: Sr25519Keyring) -> Self {
+		TestNodeBuilder {
+			key,
+			para_id,
+			task_executor,
+			collator_key: None,
+			parachain_nodes: Vec::new(),
+			parachain_nodes_exclusive: false,
+			relay_chain_nodes: Vec::new(),
+		}
+	}
 
-	let multiaddr = parachain_config.network.listen_addresses[0].clone();
-	let (task_manager, client, network, rpc_handlers) = start_node_impl(
-		parachain_config,
-		collator_key,
-		relay_chain_config,
-		para_id,
-		is_collator,
-		|_| Default::default(),
-	)
-	.await
-	.expect("could not create Cumulus test service");
+	/// Enable collator for this node.
+	pub fn enable_collator(mut self) -> Self {
+		let collator_key = CollatorPair::generate().0;
+		self.collator_key = Some(collator_key);
+		self
+	}
 
-	let peer_id = network.local_peer_id().clone();
-	let addr = MultiaddrWithPeerId { multiaddr, peer_id };
+	/// Instruct the node to exclusively connect to registered parachain nodes.
+	///
+	/// Parachain nodes can be registered using [`Self::connect_to_parachain_node`] and
+	/// [`Self::connect_to_parachain_nodes`].
+	pub fn exclusively_connect_to_registered_parachain_nodes(mut self) -> Self {
+		self.parachain_nodes_exclusive = true;
+		self
+	}
 
-	CumulusTestNode {
-		task_manager,
-		client,
-		network,
-		addr,
-		rpc_handlers,
+	/// Make the node connect to the given parachain node.
+	///
+	/// By default the node will not be connected to any node or will be able to discover any other
+	/// node.
+	pub fn connect_to_parachain_node(mut self, node: &TestNode) -> Self {
+		self.parachain_nodes.push(node.addr.clone());
+		self
+	}
+
+	/// Make the node connect to the given parachain nodes.
+	///
+	/// By default the node will not be connected to any node or will be able to discover any other
+	/// node.
+	pub fn connect_to_parachain_nodes<'a>(
+		mut self,
+		nodes: impl Iterator<Item = &'a TestNode>,
+	) -> Self {
+		self.parachain_nodes.extend(nodes.map(|n| n.addr.clone()));
+		self
+	}
+
+	/// Make the node connect to the given relay chain node.
+	///
+	/// By default the node will not be connected to any node or will be able to discover any other
+	/// node.
+	pub fn connect_to_relay_chain_node(
+		mut self,
+		node: &polkadot_test_service::PolkadotTestNode,
+	) -> Self {
+		self.relay_chain_nodes.push(node.addr.clone());
+		self
+	}
+
+	/// Make the node connect to the given relay chain nodes.
+	///
+	/// By default the node will not be connected to any node or will be able to discover any other
+	/// node.
+	pub fn connect_to_relay_chain_nodes<'a>(
+		mut self,
+		nodes: impl IntoIterator<Item = &'a polkadot_test_service::PolkadotTestNode>,
+	) -> Self {
+		self.relay_chain_nodes.extend(nodes.into_iter().map(|n| n.addr.clone()));
+		self
+	}
+
+	/// Build the [`TestNode`].
+	pub async fn build(self) -> TestNode {
+		let parachain_config = node_config(
+			|| (),
+			self.task_executor.clone(),
+			self.key.clone(),
+			self.parachain_nodes,
+			self.parachain_nodes_exclusive,
+			self.para_id,
+			self.collator_key.is_some(),
+		)
+		.expect("could not generate Configuration");
+		let mut relay_chain_config = polkadot_test_service::node_config(
+			|| (),
+			self.task_executor,
+			self.key,
+			self.relay_chain_nodes,
+			false,
+		);
+
+		relay_chain_config.network.node_name =
+			format!("{} (relay chain)", relay_chain_config.network.node_name);
+
+		let multiaddr = parachain_config.network.listen_addresses[0].clone();
+		let (task_manager, client, network, rpc_handlers) = start_node_impl(
+			parachain_config,
+			self.collator_key,
+			relay_chain_config,
+			self.para_id,
+			|_| Default::default(),
+		)
+		.await
+		.expect("could not create Cumulus test service");
+
+		let peer_id = network.local_peer_id().clone();
+		let addr = MultiaddrWithPeerId { multiaddr, peer_id };
+
+		TestNode {
+			task_manager,
+			client,
+			network,
+			addr,
+			rpc_handlers,
+		}
 	}
 }
 
-/// Create a Cumulus `Configuration`. By default an in-memory socket will be used, therefore you
-/// need to provide boot nodes if you want the future node to be connected to other nodes. The
-/// `storage_update_func` can be used to make adjustments to the runtime before the node starts.
+/// Create a Cumulus `Configuration`.
+///
+/// By default an in-memory socket will be used, therefore you need to provide nodes if you want the
+/// node to be connected to other nodes. If `nodes_exclusive` is `true`, the node will only connect
+/// to the given `nodes` and not to any other node. The `storage_update_func` can be used to make
+/// adjustments to the runtime genesis.
 pub fn node_config(
 	storage_update_func: impl Fn(),
 	task_executor: TaskExecutor,
 	key: Sr25519Keyring,
-	boot_nodes: Vec<MultiaddrWithPeerId>,
+	nodes: Vec<MultiaddrWithPeerId>,
+	nodes_exlusive: bool,
 	para_id: ParaId,
 	is_collator: bool,
 ) -> Result<Configuration, ServiceError> {
@@ -379,7 +465,13 @@ pub fn node_config(
 		None,
 	);
 
-	network_config.boot_nodes = boot_nodes;
+	if nodes_exlusive {
+		network_config.default_peers_set.reserved_nodes = nodes;
+		network_config.default_peers_set.non_reserved_mode =
+			sc_network::config::NonReservedPeerMode::Deny;
+	} else {
+		network_config.boot_nodes = nodes;
+	}
 
 	network_config.allow_non_globals_in_dht = true;
 
@@ -445,7 +537,7 @@ pub fn node_config(
 	})
 }
 
-impl CumulusTestNode {
+impl TestNode {
 	/// Wait for `count` blocks to be imported in the node and then exit. This function will not
 	/// return if no blocks are ever created, thus you should restrict the maximum amount of time of
 	/// the test execution.

--- a/test/service/src/lib.rs
+++ b/test/service/src/lib.rs
@@ -21,10 +21,6 @@
 mod chain_spec;
 mod genesis;
 
-pub use chain_spec::*;
-pub use cumulus_test_runtime as runtime;
-pub use genesis::*;
-
 use core::future::Future;
 use cumulus_client_network::BlockAnnounceValidator;
 use cumulus_client_service::{
@@ -52,6 +48,11 @@ use sp_state_machine::BasicExternalities;
 use sp_trie::PrefixedMemoryDB;
 use std::sync::Arc;
 use substrate_test_client::BlockchainEventsExt;
+
+pub use chain_spec::*;
+pub use cumulus_test_runtime as runtime;
+pub use genesis::*;
+pub use sp_keyring::Sr25519Keyring as Keyring;
 
 // Native executor instance.
 native_executor_instance!(
@@ -215,7 +216,7 @@ where
 
 	let announce_block = {
 		let network = network.clone();
-		Arc::new(move |hash, data| network.announce_block(hash, Some(data)))
+		Arc::new(move |hash, data| network.announce_block(hash, data))
 	};
 
 	if let Some(collator_key) = collator_key {

--- a/test/service/tests/integration.rs
+++ b/test/service/tests/integration.rs
@@ -15,10 +15,9 @@
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
 use cumulus_primitives_core::ParaId;
-use cumulus_test_service::initial_head_data;
+use cumulus_test_service::{initial_head_data, Keyring::*};
 use futures::join;
 use sc_service::TaskExecutor;
-use substrate_test_runtime_client::AccountKeyring::*;
 
 #[substrate_test_utils::test]
 async fn test_collating_and_non_collator_mode_catching_up(task_executor: TaskExecutor) {


### PR DESCRIPTION
There was an issue that non collator, actually all nodes that didn't produced a particular block, did not propagate this block to its peers. This pr fixes this by propagating every imported block that was not build by the local block to its peers. Actually this is a hack, until it is fixed in Substrate ;)

Fixes: https://github.com/paritytech/cumulus/issues/335

To make the tests work, the following pr in Substrate is required: https://github.com/paritytech/substrate/pull/8325

(I have executed the tests locally with the mentioned pr and everything is green)