### PR TITLE
Improve Storage and Add `set_upgrade_block` to Validation Function Upgrade

### DIFF
--- a/pallets/parachain-system/src/lib.rs
+++ b/pallets/parachain-system/src/lib.rs
@@ -80,7 +80,7 @@ decl_storage! {
 		/// We need to store the new validation function for the span between
 		/// setting it and applying it. If it has a
 		/// value, then [`PendingValidationFunction`] must have a real value, and
-		/// together will coordinate what block number where the upgrade will happen.
+		/// together will coordinate the block number where the upgrade will happen.
 		PendingRelayChainBlockNumber: Option<RelayChainBlockNumber>;
 
 		/// The new validation function we will upgrade to when the relay chain

--- a/pallets/parachain-system/src/lib.rs
+++ b/pallets/parachain-system/src/lib.rs
@@ -78,14 +78,14 @@ pub trait Config: frame_system::Config {
 decl_storage! {
 	trait Store for Module<T: Config> as ParachainSystem {
 		/// We need to store the new validation function for the span between
-		/// setting it and applying it. If `PendingRelayChainBlockNumber` has a
-		/// value, then `PendingValidationFunction` must have a real value, and
+		/// setting it and applying it. If it has a
+		/// value, then [`PendingValidationFunction`] must have a real value, and
 		/// together will coordinate what block number where the upgrade will happen.
 		PendingRelayChainBlockNumber: Option<RelayChainBlockNumber>;
 
 		/// The new validation function we will upgrade to when the relay chain
-		/// reaches `PendingRelayChainBlockNumber`. A real validation function must
-		/// exist here as long as `PendingRelayChainBlockNumber` is set.
+		/// reaches [`PendingRelayChainBlockNumber`]. A real validation function must
+		/// exist here as long as [`PendingRelayChainBlockNumber`] is set.
 		PendingValidationFunction get(fn new_validation_function): Vec<u8>;
 
 		/// The [`PersistedValidationData`] set for this block.

--- a/pallets/parachain-system/src/lib.rs
+++ b/pallets/parachain-system/src/lib.rs
@@ -161,10 +161,10 @@ decl_module! {
 		/// chain and this parachain. Synchronizing the block for the upgrade is sensitive, and this
 		/// bypasses all checks and and normal protocols. Very easy to brick your chain if done wrong.
 		#[weight = (0, DispatchClass::Operational)]
-		pub fn set_upgrade_block(origin, relay_chain_block: T::BlockNumber) {
+		pub fn set_upgrade_block(origin, relay_chain_block: RelayChainBlockNumber) {
 			ensure_root(origin)?;
 			if let Some((_, validation_function)) = PendingValidationFunction::get() {
-				PendingValidationFunction::set((relay_chain_block, validation_function));
+				PendingValidationFunction::put((relay_chain_block, validation_function));
 			}
 		}
 

--- a/pallets/parachain-system/src/lib.rs
+++ b/pallets/parachain-system/src/lib.rs
@@ -145,6 +145,7 @@ decl_module! {
 		fn deposit_event() = default;
 
 		// TODO: figure out a better weight than this
+		// TODO: Bring back the correct validation checks: #374
 		#[weight = (0, DispatchClass::Operational)]
 		pub fn schedule_upgrade(origin, validation_function: Vec<u8>) {
 			ensure_root(origin)?;

--- a/pallets/parachain-system/src/lib.rs
+++ b/pallets/parachain-system/src/lib.rs
@@ -79,12 +79,12 @@ decl_storage! {
 	trait Store for Module<T: Config> as ParachainSystem {
 		/// We need to store the new validation function for the span between
 		/// setting it and applying it. If `PendingRelayChainBlockNumber` has a
-		/// value, then `PendingValidationFunction` must have a value too, and
-		/// together will coordinate what block number the upgrade will happen.
+		/// value, then `PendingValidationFunction` must have a real value, and
+		/// together will coordinate what block number where the upgrade will happen.
 		PendingRelayChainBlockNumber: Option<RelayChainBlockNumber>;
 
 		/// The new validation function we will upgrade to when the relay chain
-		/// reaches `RelayChainBlockNumber`. A real validation function will
+		/// reaches `PendingRelayChainBlockNumber`. A real validation function must
 		/// exist here as long as `PendingRelayChainBlockNumber` is set.
 		PendingValidationFunction get(fn new_validation_function): Vec<u8>;
 

--- a/pallets/parachain-system/src/lib.rs
+++ b/pallets/parachain-system/src/lib.rs
@@ -155,6 +155,19 @@ decl_module! {
 			Self::schedule_upgrade_impl(validation_function)?;
 		}
 
+		/// Force an already scheduled validation function upgrade to happen on a particular block.
+		///
+		/// Note that coordinating this block for the upgrade has to happen independently on the relay
+		/// chain and this parachain. Synchronizing the block for the upgrade is sensitive, and this
+		/// bypasses all checks and and normal protocols. Very easy to brick your chain if done wrong.
+		#[weight = (0, DispatchClass::Operational)]
+		pub fn set_upgrade_block(origin, relay_chain_block: T::BlockNumber) {
+			ensure_root(origin)?;
+			if let Some((_, validation_function)) = PendingValidationFunction::get() {
+				PendingValidationFunction::set((relay_chain_block, validation_function));
+			}
+		}
+
 		/// Set the current validation data.
 		///
 		/// This should be invoked exactly once per block. It will panic at the finalization


### PR DESCRIPTION
The first change in this PR is to the underlying storage structure of how Validation Function Upgrades are handled.

Before, we had a single storage item which has both the block when the upgrade would happen, and the whole wasm we would upgrade with. We would then check every block if it was the right block to upgrade on, reading the whole wasm each time!

Here we split storage into two storage items, one where we can more quickly check the block number being correct, and the other where only after we confirm we need the new validation function, we get it.

----

The second change allows Root to set the specific block where they expect the relay chain to upgrade their wasm.

This is useful if you want to coordinate with the relay chain for some different upgrade schedule than would be set up by default.

Lots of warnings here on using this function if you don't know what you are doing...