### PR TITLE
Remove pov hash comparison when waiting on a block to announce

### DIFF
--- a/client/collator/src/lib.rs
+++ b/client/collator/src/lib.rs
@@ -309,17 +309,15 @@ where
 
 		let block_hash = b.header().hash();
 		let collation = self.build_collation(b, block_hash, validation_data.relay_parent_number)?;
-		let pov_hash = collation.proof_of_validity.hash();
 
 		let (result_sender, signed_stmt_recv) = oneshot::channel();
 
 		self.wait_to_announce
 			.lock()
-			.wait_to_announce(block_hash, pov_hash, signed_stmt_recv);
+			.wait_to_announce(block_hash, signed_stmt_recv);
 
 		tracing::info!(
 			target: LOG_TARGET,
-			pov_hash = ?pov_hash,
 			?block_hash,
 			"Produced proof-of-validity candidate.",
 		);

--- a/client/network/src/lib.rs
+++ b/client/network/src/lib.rs
@@ -35,7 +35,7 @@ use sp_runtime::{
 
 use polkadot_node_primitives::{SignedFullStatement, Statement};
 use polkadot_primitives::v1::{
-	Block as PBlock, CandidateReceipt, CompactStatement, Hash as PHash, Id as ParaId,
+	Block as PBlock, CandidateReceipt, CompactStatement, Id as ParaId,
 	OccupiedCoreAssumption, ParachainHost, SignedStatement, SigningContext,
 };
 use polkadot_service::ClientHandle;
@@ -179,10 +179,10 @@ impl BlockAnnounceData {
 	}
 }
 
-impl TryFrom<SignedFullStatement> for BlockAnnounceData {
+impl TryFrom<&'_ SignedFullStatement> for BlockAnnounceData {
 	type Error = ();
 
-	fn try_from(stmt: SignedFullStatement) -> Result<BlockAnnounceData, ()> {
+	fn try_from(stmt: &SignedFullStatement) -> Result<BlockAnnounceData, ()> {
 		let receipt = if let Statement::Seconded(receipt) = stmt.payload() {
 			receipt.to_plain()
 		} else {
@@ -493,7 +493,6 @@ impl<Block: BlockT> WaitToAnnounce<Block> {
 	pub fn wait_to_announce(
 		&mut self,
 		block_hash: <Block as BlockT>::Hash,
-		pov_hash: PHash,
 		signed_stmt_recv: oneshot::Receiver<SignedFullStatement>,
 	) {
 		let announce_block = self.announce_block.clone();
@@ -506,8 +505,7 @@ impl<Block: BlockT> WaitToAnnounce<Block> {
 					"waiting for announce block in a background task...",
 				);
 
-				wait_to_announce::<Block>(block_hash, pov_hash, announce_block, signed_stmt_recv)
-					.await;
+				wait_to_announce::<Block>(block_hash, announce_block, signed_stmt_recv).await;
 
 				tracing::trace!(
 					target: "cumulus-network",
@@ -521,7 +519,6 @@ impl<Block: BlockT> WaitToAnnounce<Block> {
 
 async fn wait_to_announce<Block: BlockT>(
 	block_hash: <Block as BlockT>::Hash,
-	pov_hash: PHash,
 	announce_block: Arc<dyn Fn(Block::Hash, Option<Vec<u8>>) + Send + Sync>,
 	signed_stmt_recv: oneshot::Receiver<SignedFullStatement>,
 ) {
@@ -530,7 +527,6 @@ async fn wait_to_announce<Block: BlockT>(
 		Err(_) => {
 			tracing::debug!(
 				target: "cumulus-network",
-				pov_hash = ?pov_hash,
 				block = ?block_hash,
 				"Wait to announce stopped, because sender was dropped.",
 			);
@@ -538,18 +534,14 @@ async fn wait_to_announce<Block: BlockT>(
 		}
 	};
 
-	match statement.payload() {
-		Statement::Seconded(c) if &c.descriptor.pov_hash == &pov_hash => {
-			if let Ok(data) = BlockAnnounceData::try_from(statement) {
-				announce_block(block_hash, Some(data.encode()));
-			}
-		}
-		_ => tracing::debug!(
+	if let Ok(data) = BlockAnnounceData::try_from(&statement) {
+		announce_block(block_hash, Some(data.encode()));
+	} else {
+		tracing::debug!(
 			target: "cumulus-network",
 			statement = ?statement,
 			block = ?block_hash,
-			expected_pov_hash = ?pov_hash,
 			"Received invalid statement while waiting to announce block.",
-		),
+		);
 	}
 }

--- a/client/network/src/lib.rs
+++ b/client/network/src/lib.rs
@@ -36,7 +36,7 @@ use sp_runtime::{
 use polkadot_node_primitives::{SignedFullStatement, Statement};
 use polkadot_parachain::primitives::HeadData;
 use polkadot_primitives::v1::{
-	Block as PBlock, CandidateReceipt, CompactStatement, Id as ParaId,
+	Block as PBlock, Hash as PHash, CandidateReceipt, CompactStatement, Id as ParaId,
 	OccupiedCoreAssumption, ParachainHost, SignedStatement, SigningContext,
 };
 use polkadot_service::ClientHandle;

--- a/client/network/src/tests.rs
+++ b/client/network/src/tests.rs
@@ -219,7 +219,7 @@ fn check_signer_is_legit_validator() {
 	let (mut validator, api) = make_validator_and_api();
 
 	let (signed_statement, header) = block_on(make_gossip_message_and_header_using_genesis(api, 1));
-	let data = BlockAnnounceData::try_from(signed_statement)
+	let data = BlockAnnounceData::try_from(&signed_statement)
 		.unwrap()
 		.encode();
 
@@ -233,7 +233,7 @@ fn check_statement_is_correctly_signed() {
 
 	let (signed_statement, header) = block_on(make_gossip_message_and_header_using_genesis(api, 0));
 
-	let mut data = BlockAnnounceData::try_from(signed_statement)
+	let mut data = BlockAnnounceData::try_from(&signed_statement)
 		.unwrap()
 		.encode();
 
@@ -296,7 +296,7 @@ fn check_header_match_candidate_receipt_header() {
 
 	let (signed_statement, mut header) =
 		block_on(make_gossip_message_and_header_using_genesis(api, 0));
-	let data = BlockAnnounceData::try_from(signed_statement)
+	let data = BlockAnnounceData::try_from(&signed_statement)
 		.unwrap()
 		.encode();
 	header.number = 300;
@@ -323,7 +323,7 @@ fn relay_parent_not_imported_when_block_announce_is_processed() {
 
 		let (signed_statement, header) = make_gossip_message_and_header(api, block.hash(), 0).await;
 
-		let data = BlockAnnounceData::try_from(signed_statement)
+		let data = BlockAnnounceData::try_from(&signed_statement)
 			.unwrap()
 			.encode();
 


### PR DESCRIPTION
Internally we get notified on the channel for our candidate anyway.
Besides that polkadot will compress the pov which leads to a different
pov hash and thus, would lead to a failing check on the `pov_hash`.