### PR TITLE
Make `set_validation_data` public

### DIFF
--- a/pallets/parachain-system/src/lib.rs
+++ b/pallets/parachain-system/src/lib.rs
@@ -171,7 +171,7 @@ decl_module! {
 		/// As a side effect, this function upgrades the current validation function
 		/// if the appropriate time has come.
 		#[weight = (0, DispatchClass::Mandatory)]
-		fn set_validation_data(origin, data: ParachainInherentData) -> DispatchResult {
+		pub fn set_validation_data(origin, data: ParachainInherentData) -> DispatchResult {
 			ensure_none(origin)?;
 			assert!(
 				!ValidationData::exists(),


### PR DESCRIPTION
This PR makes the dispatchable `set_validation_data` function public in the parachain system pallet. This allows calling the function during tests as we're trying to do in https://github.com/PureStake/moonbeam/pull/339

This is precedented in the timestamp pallet as well https://github.com/paritytech/substrate/blob/565078a965698c425cd909db55abb3b381e27701/frame/timestamp/src/lib.rs#L192

cc @4meta5