### PR TITLE
Slap runtime_version macro everywhere

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2369,7 +2369,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -2387,7 +2387,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "3.1.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2406,7 +2406,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "Inflector",
  "chrono",
@@ -2429,7 +2429,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2442,7 +2442,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2457,7 +2457,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -2468,7 +2468,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "bitflags",
  "frame-metadata",
@@ -2494,7 +2494,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "Inflector",
  "frame-support-procedural-tools",
@@ -2506,7 +2506,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 1.0.0",
@@ -2518,7 +2518,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "proc-macro2 1.0.26",
  "quote 1.0.9",
@@ -2528,7 +2528,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -2545,7 +2545,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -2554,7 +2554,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4896,7 +4896,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4909,7 +4909,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4925,7 +4925,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4940,7 +4940,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4954,7 +4954,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4977,7 +4977,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5006,7 +5006,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5019,7 +5019,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5034,7 +5034,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5049,7 +5049,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "frame-election-provider-support",
  "frame-support",
@@ -5067,7 +5067,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5083,7 +5083,7 @@ dependencies = [
 [[package]]
 name = "pallet-gilt"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5097,7 +5097,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5118,7 +5118,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -5133,7 +5133,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5151,7 +5151,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5166,7 +5166,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5181,7 +5181,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "ckb-merkle-mountain-range",
  "frame-benchmarking",
@@ -5198,7 +5198,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr-primitives"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5214,7 +5214,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr-rpc"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -5232,7 +5232,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5246,7 +5246,7 @@ dependencies = [
 [[package]]
 name = "pallet-nicks"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5259,7 +5259,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5275,7 +5275,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5289,7 +5289,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5302,7 +5302,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "enumflags2",
  "frame-support",
@@ -5316,7 +5316,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5331,7 +5331,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5350,7 +5350,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5363,7 +5363,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "frame-election-provider-support",
  "frame-support",
@@ -5385,7 +5385,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "proc-macro-crate 1.0.0",
  "proc-macro2 1.0.26",
@@ -5396,7 +5396,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -5405,7 +5405,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5418,7 +5418,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5435,7 +5435,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5449,7 +5449,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5465,7 +5465,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -5482,7 +5482,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -5493,7 +5493,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5508,7 +5508,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5522,7 +5522,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "enumflags2",
  "frame-support",
@@ -7803,7 +7803,7 @@ dependencies = [
 [[package]]
 name = "remote-externalities"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "env_logger 0.8.3",
  "hex-literal 0.3.1",
@@ -8083,7 +8083,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "async-trait",
  "derive_more 0.99.11",
@@ -8112,7 +8112,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "futures 0.3.14",
  "futures-timer 3.0.2",
@@ -8135,7 +8135,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -8151,7 +8151,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -8172,7 +8172,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "proc-macro-crate 1.0.0",
  "proc-macro2 1.0.26",
@@ -8183,7 +8183,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "chrono",
  "fdlimit",
@@ -8221,7 +8221,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "derive_more 0.99.11",
  "fnv",
@@ -8255,7 +8255,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "blake2-rfc",
  "hash-db",
@@ -8285,7 +8285,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "parking_lot 0.11.1",
  "sc-client-api",
@@ -8297,7 +8297,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "async-trait",
  "derive_more 0.99.11",
@@ -8328,7 +8328,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "async-trait",
  "derive_more 0.99.11",
@@ -8374,7 +8374,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "derive_more 0.99.11",
  "futures 0.3.14",
@@ -8398,7 +8398,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -8411,7 +8411,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "async-trait",
  "futures 0.3.14",
@@ -8439,7 +8439,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-uncles"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "sc-client-api",
  "sp-authorship",
@@ -8450,7 +8450,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "derive_more 0.99.11",
  "lazy_static",
@@ -8479,7 +8479,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "derive_more 0.99.11",
  "parity-scale-codec",
@@ -8497,7 +8497,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -8512,7 +8512,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -8530,7 +8530,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "async-trait",
  "derive_more 0.99.11",
@@ -8570,7 +8570,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa-rpc"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "derive_more 0.99.11",
  "finality-grandpa",
@@ -8594,7 +8594,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa-warp-sync"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "derive_more 0.99.11",
  "futures 0.3.14",
@@ -8615,7 +8615,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "ansi_term 0.12.1",
  "futures 0.3.14",
@@ -8633,7 +8633,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "async-trait",
  "derive_more 0.99.11",
@@ -8653,7 +8653,7 @@ dependencies = [
 [[package]]
 name = "sc-light"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "hash-db",
  "lazy_static",
@@ -8672,7 +8672,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "async-std",
  "async-trait",
@@ -8725,7 +8725,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "futures 0.3.14",
  "futures-timer 3.0.2",
@@ -8742,7 +8742,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "bytes 0.5.6",
  "fnv",
@@ -8770,7 +8770,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "futures 0.3.14",
  "libp2p",
@@ -8783,7 +8783,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -8792,7 +8792,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "futures 0.3.14",
  "hash-db",
@@ -8827,7 +8827,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "derive_more 0.99.11",
  "futures 0.3.14",
@@ -8852,7 +8852,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "futures 0.1.30",
  "jsonrpc-core",
@@ -8870,7 +8870,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "async-trait",
  "directories",
@@ -8934,7 +8934,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -8949,7 +8949,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -8969,7 +8969,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "chrono",
  "futures 0.3.14",
@@ -8989,7 +8989,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
@@ -9026,7 +9026,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "proc-macro-crate 1.0.0",
  "proc-macro2 1.0.26",
@@ -9037,7 +9037,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-graph"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "derive_more 0.99.11",
  "futures 0.3.14",
@@ -9059,7 +9059,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "futures 0.3.14",
  "futures-diagnose",
@@ -9489,7 +9489,7 @@ dependencies = [
 [[package]]
 name = "sp-allocator"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "log",
  "sp-core",
@@ -9501,7 +9501,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "hash-db",
  "log",
@@ -9518,7 +9518,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate 1.0.0",
@@ -9530,7 +9530,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -9542,7 +9542,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -9556,7 +9556,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -9568,7 +9568,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -9580,7 +9580,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -9592,7 +9592,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "futures 0.3.14",
  "log",
@@ -9610,7 +9610,7 @@ dependencies = [
 [[package]]
 name = "sp-chain-spec"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "serde",
  "serde_json",
@@ -9619,7 +9619,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "async-trait",
  "futures 0.3.14",
@@ -9646,7 +9646,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -9663,7 +9663,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "async-trait",
  "merlin",
@@ -9685,7 +9685,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "parity-scale-codec",
  "sp-arithmetic",
@@ -9695,7 +9695,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",
@@ -9707,7 +9707,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -9751,7 +9751,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "kvdb",
  "parking_lot 0.11.1",
@@ -9760,7 +9760,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "proc-macro2 1.0.26",
  "quote 1.0.9",
@@ -9770,7 +9770,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -9781,7 +9781,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -9798,7 +9798,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -9812,7 +9812,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "futures 0.3.14",
  "hash-db",
@@ -9837,7 +9837,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -9848,7 +9848,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "async-trait",
  "derive_more 0.99.11",
@@ -9865,7 +9865,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "ruzstd",
  "zstd",
@@ -9874,7 +9874,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -9887,7 +9887,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections-compact"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "proc-macro-crate 1.0.0",
  "proc-macro2 1.0.26",
@@ -9898,7 +9898,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -9908,7 +9908,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "backtrace",
 ]
@@ -9916,7 +9916,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -9927,7 +9927,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -9948,7 +9948,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -9965,7 +9965,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "Inflector",
  "proc-macro-crate 1.0.0",
@@ -9977,7 +9977,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "serde",
  "serde_json",
@@ -9986,7 +9986,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -9999,7 +9999,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -10009,7 +10009,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "hash-db",
  "log",
@@ -10032,12 +10032,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 
 [[package]]
 name = "sp-storage"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -10050,7 +10050,7 @@ dependencies = [
 [[package]]
 name = "sp-tasks"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "log",
  "sp-core",
@@ -10063,7 +10063,7 @@ dependencies = [
 [[package]]
 name = "sp-test-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "parity-scale-codec",
  "parity-util-mem",
@@ -10076,7 +10076,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "async-trait",
  "futures-timer 3.0.2",
@@ -10093,7 +10093,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "erased-serde",
  "log",
@@ -10111,7 +10111,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "derive_more 0.99.11",
  "futures 0.3.14",
@@ -10127,7 +10127,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -10141,7 +10141,7 @@ dependencies = [
 [[package]]
 name = "sp-utils"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "futures 0.3.14",
  "futures-core",
@@ -10153,7 +10153,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -10166,7 +10166,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-crate 1.0.0",
@@ -10178,7 +10178,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -10336,7 +10336,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "platforms",
 ]
@@ -10344,7 +10344,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.14",
@@ -10367,7 +10367,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "async-std",
  "derive_more 0.99.11",
@@ -10381,7 +10381,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "async-trait",
  "futures 0.1.30",
@@ -10410,7 +10410,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "cfg-if 1.0.0",
  "frame-support",
@@ -10451,7 +10451,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime-client"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "futures 0.3.14",
  "parity-scale-codec",
@@ -10472,7 +10472,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-utils"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "futures 0.3.14",
  "substrate-test-utils-derive",
@@ -10482,7 +10482,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-utils-derive"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "proc-macro-crate 1.0.0",
  "quote 1.0.9",
@@ -10508,7 +10508,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#60eb0c69fa264dd758c91e3d81ac68ef75036b8e"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
@@ -11186,7 +11186,7 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 [[package]]
 name = "try-runtime-cli"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#af14d493bec4d6ecdfd7b309df6c82d5d978469c"
+source = "git+https://github.com/paritytech/substrate?branch=master#d908ef803a0368236c8f5891cbe4df11d6e85ec6"
 dependencies = [
  "frame-try-runtime",
  "log",
@@ -11212,7 +11212,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04f8ab788026715fa63b31960869617cba39117e520eb415b0139543e325ab59"
 dependencies = [
  "cfg-if 0.1.10",
- "rand 0.7.3",
+ "rand 0.6.5",
  "static_assertions",
 ]
 

--- a/polkadot-parachains/rococo-runtime/src/lib.rs
+++ b/polkadot-parachains/rococo-runtime/src/lib.rs
@@ -76,6 +76,7 @@ impl_opaque_keys! {
 }
 
 /// This runtime version.
+#[sp_version::runtime_version]
 pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("test-parachain"),
 	impl_name: create_runtime_str!("test-parachain"),

--- a/polkadot-parachains/shell-runtime/src/lib.rs
+++ b/polkadot-parachains/shell-runtime/src/lib.rs
@@ -59,6 +59,7 @@ use xcm_builder::{
 use xcm_executor::{Config, XcmExecutor};
 
 /// This runtime version.
+#[sp_version::runtime_version]
 pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("shell"),
 	impl_name: create_runtime_str!("shell"),

--- a/test/runtime/src/lib.rs
+++ b/test/runtime/src/lib.rs
@@ -59,17 +59,38 @@ impl_opaque_keys! {
 	pub struct SessionKeys {}
 }
 
-const SPEC_VERSION: u32 = 3;
+// The only difference between the two declarations below is the `spec_version`. With the
+// `upgrade` feature enabled `spec_version` should be greater than the one of without the
+// `upgrade` feature.
+//
+// The duplication here is unfortunate necessity.
+//
+// runtime_version macro is dumb. It accepts a const item declaration, passes it through and
+// also emits runtime version custom section. It parses the expressions to extract the version
+// details. Since macro kicks in early, it operates on AST. Thus you cannot use constants.
+// Macros are expanded top to bottom, meaning we also cannot use `cfg` here.
 
-/// This runtime version.
+#[cfg(feature = "upgrade")]
+#[sp_version::runtime_version]
 pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("cumulus-test-parachain"),
 	impl_name: create_runtime_str!("cumulus-test-parachain"),
 	authoring_version: 1,
-	#[cfg(feature = "upgrade")]
-	spec_version: SPEC_VERSION + 1,
-	#[cfg(not(feature = "upgrade"))]
-	spec_version: SPEC_VERSION,
+	// Read the note above.
+	spec_version: 4,
+	impl_version: 1,
+	apis: RUNTIME_API_VERSIONS,
+	transaction_version: 1,
+};
+
+#[cfg(not(feature = "upgrade"))]
+#[sp_version::runtime_version]
+pub const VERSION: RuntimeVersion = RuntimeVersion {
+	spec_name: create_runtime_str!("cumulus-test-parachain"),
+	impl_name: create_runtime_str!("cumulus-test-parachain"),
+	authoring_version: 1,
+	// Read the note above.
+	spec_version: 3,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
This PR integrates the modern mechanism for reporting runtime version, introduced in https://github.com/paritytech/substrate/pull/8688.

This will do no difference until https://github.com/paritytech/polkadot/pull/3045 is merged.