### PR TITLE
Bump XCM weight to something more conservative

### DIFF
--- a/polkadot-parachains/statemine-runtime/src/lib.rs
+++ b/polkadot-parachains/statemine-runtime/src/lib.rs
@@ -481,8 +481,8 @@ pub type XcmOriginToTransactDispatchOrigin = (
 );
 
 parameter_types! {
-	// One XCM operation is 1_000_000 weight - almost certainly a conservative estimate.
-	pub UnitWeightCost: Weight = 1_000_000;
+	// One XCM operation is 1_000_000_000 weight - almost certainly a conservative estimate.
+	pub UnitWeightCost: Weight = 1_000_000_000;
 }
 
 match_type! {


### PR DESCRIPTION
Given a balance deposit (with account creation) was possible by paying only 3_000_000 weight, the old value is probably not conservative enough. Now that's gone up by a factor of 1000, it should be ok.