### PR TITLE
Add srtool + subwasm workflow

### DIFF
--- a/.github/workflows/srtool.yml
+++ b/.github/workflows/srtool.yml
@@ -23,6 +23,6 @@ jobs:
       - name: Archive Runtime
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ matrix.chain }}-runtime-${{ github.ref }}
+          name: ${{ matrix.chain }}-runtime-${{ github.sha }}
           path: |
             ${{ steps.srtool_build.outputs.wasm }}

--- a/.github/workflows/srtool.yml
+++ b/.github/workflows/srtool.yml
@@ -23,6 +23,6 @@ jobs:
       - name: Archive Runtime
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ matrix.chain }}-runtime
+          name: ${{ matrix.chain }}-runtime-${{ github.ref }}
           path: |
-            "${{ steps.srtool_build.outputs.wasm }}"
+            ${{ steps.srtool_build.outputs.wasm }}

--- a/.github/workflows/srtool.yml
+++ b/.github/workflows/srtool.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Archive Subwasm results
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ matrix.chain }}-runtime-${GITHUB_SHA::8}
+          name: ${{ matrix.chain }}-runtime-${{ github.sha }}
           path: |
             ${{ matrix.chain }}-info.json
             ${{ matrix.chain }}-metadata.json

--- a/.github/workflows/srtool.yml
+++ b/.github/workflows/srtool.yml
@@ -1,0 +1,20 @@
+name: Srtool build
+
+on: push
+
+jobs:
+  srtool:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        chain: ["statemine"]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Srtool build
+        id: srtool_build
+        uses: chevdor/srtool-actions@draft
+        with:
+          chain: ${{ matrix.chain }}
+      - name: Summary
+        run: |
+          echo '${{ steps.srtool_build.outputs.json }}' | jq

--- a/.github/workflows/srtool.yml
+++ b/.github/workflows/srtool.yml
@@ -15,6 +15,7 @@ jobs:
         uses: chevdor/srtool-actions@draft
         with:
           chain: ${{ matrix.chain }}
+          runtime_dir: polkadot-parachains/${{ matrix.chain }}-runtime
       - name: Summary
         run: |
           echo '${{ steps.srtool_build.outputs.json }}' | jq

--- a/.github/workflows/srtool.yml
+++ b/.github/workflows/srtool.yml
@@ -28,3 +28,31 @@ jobs:
           path: |
             ${{ steps.srtool_build.outputs.wasm }}
             ${{ matrix.chain }}-srtool-digest.json
+      - name: Install subwasm
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: "--git https://gitlab.com/chevdor/subwasm"
+      - name: Show Runtime information
+        shell: bash
+        run: |
+          subwasm info ${{ steps.srtool_build.outputs.wasm }}
+          subwasm --json info ${{ steps.srtool_build.outputs.wasm }} > ${{ matrix.chain }}-info.json
+      - name: Extract the metadata
+        shell: bash
+        run: |
+          subwasm meta ${{ steps.srtool_build.outputs.wasm }}
+          subwasm --json meta ${{ steps.srtool_build.outputs.wasm }} > ${{ matrix.chain }}-metadata.json
+      - name: Check the metadata diff
+        shell: bash
+        run: |
+          subwasm diff ${{ steps.srtool_build.outputs.wasm }} --chain-b ${{ matrix.chain }} > ${{ matrix.chain }}-diff.txt
+          cat ${{ matrix.chain }}-diff.txt
+      - name: Archive Subwasm results
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.chain }}-runtime-${GITHUB_SHA::8}
+          path: |
+            ${{ matrix.chain }}-info.json
+            ${{ matrix.chain }}-metadata.json
+            ${{ matrix.chain }}-diff.txt

--- a/.github/workflows/srtool.yml
+++ b/.github/workflows/srtool.yml
@@ -19,3 +19,10 @@ jobs:
       - name: Summary
         run: |
           echo '${{ steps.srtool_build.outputs.json }}' | jq
+          echo "Runtime location: ${{ steps.srtool_build.outputs.wasm }}"
+      - name: Archive Runtime
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.chain }}-runtime
+          path: |
+            "${{ steps.srtool_build.outputs.wasm }}"

--- a/.github/workflows/srtool.yml
+++ b/.github/workflows/srtool.yml
@@ -18,7 +18,8 @@ jobs:
           runtime_dir: polkadot-parachains/${{ matrix.chain }}-runtime
       - name: Summary
         run: |
-          echo '${{ steps.srtool_build.outputs.json }}' | jq
+          echo '${{ steps.srtool_build.outputs.json }}' | jq > ${{ matrix.chain }}-srtool-digest.json
+          cat ${{ matrix.chain }}-srtool-digest.json
           echo "Runtime location: ${{ steps.srtool_build.outputs.wasm }}"
       - name: Archive Runtime
         uses: actions/upload-artifact@v2
@@ -26,3 +27,4 @@ jobs:
           name: ${{ matrix.chain }}-runtime-${GITHUB_SHA::8}
           path: |
             ${{ steps.srtool_build.outputs.wasm }}
+            ${{ matrix.chain }}-srtool-digest.json

--- a/.github/workflows/srtool.yml
+++ b/.github/workflows/srtool.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Archive Runtime
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ matrix.chain }}-runtime-${GITHUB_SHA::8}
+          name: ${{ matrix.chain }}-runtime-${{ github.sha }}
           path: |
             ${{ steps.srtool_build.outputs.wasm }}
             ${{ matrix.chain }}-srtool-digest.json

--- a/.github/workflows/srtool.yml
+++ b/.github/workflows/srtool.yml
@@ -23,6 +23,6 @@ jobs:
       - name: Archive Runtime
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ matrix.chain }}-runtime-${{ github.sha }}
+          name: ${{ matrix.chain }}-runtime-${GITHUB_SHA::8}
           path: |
             ${{ steps.srtool_build.outputs.wasm }}

--- a/.github/workflows/srtool.yml
+++ b/.github/workflows/srtool.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        chain: ["statemine"]
+        chain: ["statemine", "westmint"]
     steps:
       - uses: actions/checkout@v2
       - name: Srtool build


### PR DESCRIPTION
This PR adds a new github workflow to the CI.
It does the following:
- run `srtool`
- save the wasm
- install/run `subwasm`
- fetch the info, including the blake2_256 hash from the wasm
- store relevant artifacts