### PR TITLE
Feature-gate client-side of cumulus-primitive-parachain-inherent

### DIFF
--- a/primitives/parachain-inherent/Cargo.toml
+++ b/primitives/parachain-inherent/Cargo.toml
@@ -27,19 +27,22 @@ tracing = { version = "0.1.22", optional = true }
 async-trait = { version = "0.1.42", optional = true }
 
 [features]
-default = [ "std" ]
-std = [
+default = [ "std", "client-side" ]
+client-side = [
+	"std",
 	"async-trait",
-	"codec/std",
-	"cumulus-primitives-core/std",
-	"sp-inherents/std",
-	"sp-core/std",
-	"sp-trie/std",
-	"sp-std/std",
 	"sp-state-machine",
 	"tracing",
 	"sp-runtime",
 	"sc-client-api",
 	"sp-api",
 	"polkadot-service",
+]
+std = [
+	"codec/std",
+	"cumulus-primitives-core/std",
+	"sp-inherents/std",
+	"sp-core/std",
+	"sp-trie/std",
+	"sp-std/std",
 ]

--- a/primitives/parachain-inherent/src/lib.rs
+++ b/primitives/parachain-inherent/src/lib.rs
@@ -34,9 +34,9 @@ use cumulus_primitives_core::{
 use sp_inherents::InherentIdentifier;
 use sp_std::{collections::btree_map::BTreeMap, vec::Vec};
 
-#[cfg(feature = "std")]
+#[cfg(feature = "client-side")]
 mod client_side;
-#[cfg(feature = "std")]
+#[cfg(feature = "client-side")]
 pub use client_side::*;
 
 /// The identifier for the parachain inherent.


### PR DESCRIPTION
This is my attempt at solving #466 

It doesn't seem to work though because when I `cargo check -p cumulus-pallet-parachain-system` it still builds all the polkadot runtimes.