### PR TITLE
Explicit drop of compact proof memory.

### DIFF
--- a/pallets/parachain-system/src/validate_block/implementation.rs
+++ b/pallets/parachain-system/src/validate_block/implementation.rs
@@ -79,6 +79,7 @@ where
 		Ok(root) => root,
 		Err(_) => panic!("Compact proof decoding failure."),
 	};
+	sp_std::mem::drop(storage_proof);
 
 	let backend = sp_state_machine::TrieBackend::new(db, root);
 


### PR DESCRIPTION
Calls drop to ensure memory of the compacted proof is dropped.