### PR TITLE
Build all runtimes and improve workflow setup

### DIFF
--- a/.github/workflows/srtool.yml
+++ b/.github/workflows/srtool.yml
@@ -14,12 +14,14 @@ on:
   schedule:
     - cron: "00 02 * * 1" # 2AM weekly on monday
 
+  workflow_dispatch:
+
 jobs:
   srtool:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        chain: ["statemine", "westmint"]
+        chain: ["statemine", "westmint", "statemint", "rococo", "shell"]
     steps:
       - name: Get Timestamp
         run: echo "TMSP=$(date '+%Y%m%d_%H%M%S')" >> $GITHUB_ENV
@@ -43,10 +45,10 @@ jobs:
             ${{ steps.srtool_build.outputs.wasm }}
             ${{ matrix.chain }}-srtool-digest.json
       - name: Install subwasm
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: "--git https://gitlab.com/chevdor/subwasm"
+        run: |
+          wget https://github.com/chevdor/subwasm/releases/download/v0.11.0/subwasm_linux_amd64.deb
+          dpkg -i subwasm_linux_amd64.deb
+          subwasm --version
       - name: Show Runtime information
         shell: bash
         run: |

--- a/.github/workflows/srtool.yml
+++ b/.github/workflows/srtool.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Srtool build
         id: srtool_build
-        uses: chevdor/srtool-actions@v0.1.0
+        uses: chevdor/srtool-actions@v0.2.0
         with:
           chain: ${{ matrix.chain }}
           runtime_dir: polkadot-parachains/${{ matrix.chain }}
@@ -38,7 +38,8 @@ jobs:
         run: |
           echo '${{ steps.srtool_build.outputs.json }}' | jq > ${{ matrix.chain }}-srtool-digest.json
           cat ${{ matrix.chain }}-srtool-digest.json
-          echo "Runtime location: ${{ steps.srtool_build.outputs.wasm }}"
+          echo "Compact Runtime: ${{ steps.srtool_build.outputs.wasm }}"
+          echo "Compressed Runtime: ${{ steps.srtool_build.outputs.wasm_compressed }}"
 
       # it takes a while to build the runtime, so let's save the artifact as soon as we have it
       - name: Archive Artifacts for ${{ matrix.chain }}
@@ -47,6 +48,7 @@ jobs:
           name: ${{ matrix.chain }}-runtime
           path: |
             ${{ steps.srtool_build.outputs.wasm }}
+            ${{ steps.srtool_build.outputs.wasm_compressed }}
             ${{ matrix.chain }}-srtool-digest.json
 
       # We now get extra information thanks to subwasm
@@ -60,7 +62,9 @@ jobs:
         shell: bash
         run: |
           subwasm info ${{ steps.srtool_build.outputs.wasm }}
+          subwasm info ${{ steps.srtool_build.outputs.wasm_compressed }}
           subwasm --json info ${{ steps.srtool_build.outputs.wasm }} > ${{ matrix.chain }}-info.json
+          subwasm --json info ${{ steps.srtool_build.outputs.wasm_compressed }} > ${{ matrix.chain }}-compressed-info.json
 
       - name: Extract the metadata
         shell: bash
@@ -72,8 +76,9 @@ jobs:
         shell: bash
         # the following subwasm call will error for chains that are not known and/or live, that includes shell for instance
         run: |
-          subwasm diff ${{ steps.srtool_build.outputs.wasm }} --chain-b ${{ matrix.chain }} \
-            || echo "Subwasm call failed, check the logs. This is likely because ${{ matrix.chain }} is not known by subwasm" | tee ${{ matrix.chain }}-diff.txt
+          subwasm diff ${{ steps.srtool_build.outputs.wasm }} --chain-b ${{ matrix.chain }} || \
+            echo "Subwasm call failed, check the logs. This is likely because ${{ matrix.chain }} is not known by subwasm" | \
+            tee ${{ matrix.chain }}-diff.txt
 
       - name: Archive Subwasm results
         uses: actions/upload-artifact@v2
@@ -81,5 +86,6 @@ jobs:
           name: ${{ matrix.chain }}-runtime
           path: |
             ${{ matrix.chain }}-info.json
+            ${{ matrix.chain }}-compressed-info.json
             ${{ matrix.chain }}-metadata.json
             ${{ matrix.chain }}-diff.txt

--- a/.github/workflows/srtool.yml
+++ b/.github/workflows/srtool.yml
@@ -23,51 +23,62 @@ jobs:
       matrix:
         chain: ["statemine", "westmint", "statemint", "rococo", "shell"]
     steps:
-      - name: Get Timestamp
-        run: echo "TMSP=$(date '+%Y%m%d_%H%M%S')" >> $GITHUB_ENV
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
       - name: Srtool build
         id: srtool_build
         uses: chevdor/srtool-actions@v0.1.0
         with:
           chain: ${{ matrix.chain }}
           runtime_dir: polkadot-parachains/${{ matrix.chain }}
+
       - name: Summary
         run: |
           echo '${{ steps.srtool_build.outputs.json }}' | jq > ${{ matrix.chain }}-srtool-digest.json
           cat ${{ matrix.chain }}-srtool-digest.json
           echo "Runtime location: ${{ steps.srtool_build.outputs.wasm }}"
-      - name: Archive Runtime
+
+      # it takes a while to build the runtime, so let's save the artifact as soon as we have it
+      - name: Archive Artifacts for ${{ matrix.chain }}
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ matrix.chain }}-runtime-${{ env.TMSP }}-${{ github.sha }}
+          name: ${{ matrix.chain }}-runtime
           path: |
             ${{ steps.srtool_build.outputs.wasm }}
             ${{ matrix.chain }}-srtool-digest.json
+
+      # We now get extra information thanks to subwasm
       - name: Install subwasm
         run: |
-          wget https://github.com/chevdor/subwasm/releases/download/v0.11.0/subwasm_linux_amd64.deb
-          dpkg -i subwasm_linux_amd64.deb
+          wget https://github.com/chevdor/subwasm/releases/download/v0.11.0/subwasm_linux_amd64_v0.11.0.deb
+          sudo dpkg -i subwasm_linux_amd64_v0.11.0.deb
           subwasm --version
+
       - name: Show Runtime information
         shell: bash
         run: |
           subwasm info ${{ steps.srtool_build.outputs.wasm }}
           subwasm --json info ${{ steps.srtool_build.outputs.wasm }} > ${{ matrix.chain }}-info.json
+
       - name: Extract the metadata
         shell: bash
         run: |
           subwasm meta ${{ steps.srtool_build.outputs.wasm }}
           subwasm --json meta ${{ steps.srtool_build.outputs.wasm }} > ${{ matrix.chain }}-metadata.json
+
       - name: Check the metadata diff
         shell: bash
+        # the following subwasm call will error for chains that are not known and/or live, that includes shell for instance
         run: |
-          subwasm diff ${{ steps.srtool_build.outputs.wasm }} --chain-b ${{ matrix.chain }} > ${{ matrix.chain }}-diff.txt
-          cat ${{ matrix.chain }}-diff.txt
+          subwasm diff ${{ steps.srtool_build.outputs.wasm }} --chain-b ${{ matrix.chain }} \
+            || echo "Subwasm call failed, check the logs. This is likely because ${{ matrix.chain }} is not known by subwasm" | tee ${{ matrix.chain }}-diff.txt
+
       - name: Archive Subwasm results
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ matrix.chain }}-runtime-${{ env.TMSP }}-${{ github.sha }}
+          name: ${{ matrix.chain }}-runtime
           path: |
             ${{ matrix.chain }}-info.json
             ${{ matrix.chain }}-metadata.json


### PR DESCRIPTION
This PR depends on #507

It upgrade to srtool-actions@v0.2.0 to support compressed runtimes.

It additionally builds:
- statemint
- rococo
- shell

The setup is faster as we install a pre-built binary for subwasm instead of building it.
