### PR TITLE
Bring back runtime upgrade test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -715,7 +715,7 @@ dependencies = [
 [[package]]
 name = "bp-header-chain"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#0347e253a55e98814d3923074a870678c21677ac"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
 dependencies = [
  "finality-grandpa",
  "frame-support",
@@ -728,9 +728,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "bp-message-dispatch"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
+dependencies = [
+ "bp-runtime",
+ "frame-support",
+ "parity-scale-codec",
+ "sp-std",
+]
+
+[[package]]
 name = "bp-messages"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#0347e253a55e98814d3923074a870678c21677ac"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
 dependencies = [
  "bitvec",
  "bp-runtime",
@@ -745,7 +756,7 @@ dependencies = [
 [[package]]
 name = "bp-polkadot-core"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#0347e253a55e98814d3923074a870678c21677ac"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -760,9 +771,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "bp-rialto"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
+dependencies = [
+ "bp-messages",
+ "bp-runtime",
+ "frame-support",
+ "frame-system",
+ "sp-api",
+ "sp-core",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "bp-rococo"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#0347e253a55e98814d3923074a870678c21677ac"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
 dependencies = [
  "bp-messages",
  "bp-polkadot-core",
@@ -779,7 +805,7 @@ dependencies = [
 [[package]]
 name = "bp-runtime"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#0347e253a55e98814d3923074a870678c21677ac"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
 dependencies = [
  "frame-support",
  "hash-db",
@@ -796,7 +822,7 @@ dependencies = [
 [[package]]
 name = "bp-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#0347e253a55e98814d3923074a870678c21677ac"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
 dependencies = [
  "bp-header-chain",
  "ed25519-dalek",
@@ -811,7 +837,7 @@ dependencies = [
 [[package]]
 name = "bp-wococo"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#0347e253a55e98814d3923074a870678c21677ac"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
 dependencies = [
  "bp-messages",
  "bp-polkadot-core",
@@ -821,6 +847,28 @@ dependencies = [
  "sp-api",
  "sp-runtime",
  "sp-std",
+]
+
+[[package]]
+name = "bridge-runtime-common"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
+dependencies = [
+ "bp-message-dispatch",
+ "bp-messages",
+ "bp-runtime",
+ "frame-support",
+ "hash-db",
+ "pallet-bridge-dispatch",
+ "pallet-bridge-grandpa",
+ "pallet-bridge-messages",
+ "pallet-transaction-payment",
+ "parity-scale-codec",
+ "sp-core",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-std",
+ "sp-trie",
 ]
 
 [[package]]
@@ -1995,6 +2043,7 @@ dependencies = [
  "sp-consensus",
  "sp-core",
  "sp-keyring",
+ "sp-maybe-compressed-blob",
  "sp-offchain",
  "sp-runtime",
  "sp-session",
@@ -2002,6 +2051,7 @@ dependencies = [
  "sp-timestamp",
  "sp-transaction-pool",
  "sp-trie",
+ "sp-version",
  "substrate-test-client",
  "substrate-test-utils",
  "tokio 0.2.24",
@@ -2525,7 +2575,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -2543,7 +2593,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "3.1.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2562,7 +2612,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "Inflector",
  "chrono",
@@ -2585,7 +2635,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2598,7 +2648,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2613,7 +2663,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata"
 version = "13.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -2624,14 +2674,13 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "bitflags",
  "frame-metadata",
  "frame-support-procedural",
  "impl-trait-for-tuples",
  "log",
- "max-encoded-len",
  "once_cell",
  "parity-scale-codec",
  "paste",
@@ -2651,7 +2700,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "Inflector",
  "frame-support-procedural-tools",
@@ -2663,7 +2712,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 1.0.0",
@@ -2675,7 +2724,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
@@ -2685,7 +2734,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -2702,7 +2751,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2716,7 +2765,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -2725,7 +2774,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -3830,7 +3879,7 @@ dependencies = [
 [[package]]
 name = "kusama-runtime"
 version = "0.9.8"
-source = "git+https://github.com/paritytech/polkadot?branch=master#0347e253a55e98814d3923074a870678c21677ac"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
 dependencies = [
  "beefy-primitives",
  "bitvec",
@@ -3844,7 +3893,6 @@ dependencies = [
  "frame-try-runtime",
  "hex-literal 0.3.1",
  "log",
- "max-encoded-len",
  "pallet-authority-discovery",
  "pallet-authorship",
  "pallet-babe",
@@ -4623,28 +4671,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "max-encoded-len"
-version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
-dependencies = [
- "impl-trait-for-tuples",
- "max-encoded-len-derive",
- "parity-scale-codec",
- "primitive-types",
-]
-
-[[package]]
-name = "max-encoded-len-derive"
-version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
-dependencies = [
- "proc-macro-crate 1.0.0",
- "proc-macro2 1.0.27",
- "quote 1.0.9",
- "syn 1.0.73",
-]
-
-[[package]]
 name = "maybe-uninit"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4724,7 +4750,7 @@ dependencies = [
 [[package]]
 name = "metered-channel"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#0347e253a55e98814d3923074a870678c21677ac"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
 dependencies = [
  "derive_more 0.99.14",
  "futures 0.3.15",
@@ -4991,7 +5017,7 @@ dependencies = [
 [[package]]
 name = "node-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "frame-system",
  "parity-scale-codec",
@@ -5159,12 +5185,11 @@ dependencies = [
 [[package]]
 name = "pallet-assets"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "max-encoded-len",
  "parity-scale-codec",
  "sp-runtime",
  "sp-std",
@@ -5173,7 +5198,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5189,7 +5214,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5204,7 +5229,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5218,7 +5243,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5241,13 +5266,12 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
  "log",
- "max-encoded-len",
  "parity-scale-codec",
  "sp-runtime",
  "sp-std",
@@ -5271,7 +5295,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5283,9 +5307,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-bridge-dispatch"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
+dependencies = [
+ "bp-message-dispatch",
+ "bp-runtime",
+ "frame-support",
+ "frame-system",
+ "log",
+ "parity-scale-codec",
+ "sp-core",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "pallet-bridge-grandpa"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#0347e253a55e98814d3923074a870678c21677ac"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
 dependencies = [
  "bp-header-chain",
  "bp-runtime",
@@ -5301,6 +5341,27 @@ dependencies = [
  "sp-runtime",
  "sp-std",
  "sp-trie",
+]
+
+[[package]]
+name = "pallet-bridge-messages"
+version = "0.1.0"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
+dependencies = [
+ "bitvec",
+ "bp-message-dispatch",
+ "bp-messages",
+ "bp-rialto",
+ "bp-runtime",
+ "frame-support",
+ "frame-system",
+ "log",
+ "num-traits",
+ "parity-scale-codec",
+ "serde",
+ "sp-core",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -5330,7 +5391,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5346,7 +5407,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5361,7 +5422,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5382,7 +5443,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5399,7 +5460,7 @@ dependencies = [
 [[package]]
 name = "pallet-gilt"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5413,7 +5474,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "3.1.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5435,7 +5496,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -5450,7 +5511,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5469,7 +5530,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5485,7 +5546,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5500,7 +5561,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "ckb-merkle-mountain-range",
  "frame-benchmarking",
@@ -5517,7 +5578,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr-primitives"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5533,7 +5594,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr-rpc"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -5551,7 +5612,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5566,7 +5627,7 @@ dependencies = [
 [[package]]
 name = "pallet-nicks"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5579,7 +5640,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5595,7 +5656,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5617,12 +5678,11 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "max-encoded-len",
  "parity-scale-codec",
  "sp-core",
  "sp-io",
@@ -5633,7 +5693,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5646,7 +5706,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "enumflags2",
  "frame-support",
@@ -5660,7 +5720,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5675,7 +5735,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5695,7 +5755,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5711,7 +5771,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5724,7 +5784,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5748,7 +5808,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "proc-macro-crate 1.0.0",
  "proc-macro2 1.0.27",
@@ -5759,7 +5819,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -5768,7 +5828,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5781,7 +5841,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5799,7 +5859,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5814,7 +5874,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5830,7 +5890,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -5847,7 +5907,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -5858,7 +5918,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5874,7 +5934,7 @@ dependencies = [
 [[package]]
 name = "pallet-uniques"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5888,7 +5948,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5903,7 +5963,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -5917,10 +5977,11 @@ dependencies = [
 [[package]]
 name = "pallet-xcm"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#0347e253a55e98814d3923074a870678c21677ac"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
 dependencies = [
  "frame-support",
  "frame-system",
+ "log",
  "parity-scale-codec",
  "serde",
  "sp-runtime",
@@ -6367,7 +6428,7 @@ checksum = "989d43012e2ca1c4a02507c67282691a0a3207f9dc67cec596b43fe925b3d325"
 [[package]]
 name = "polkadot-approval-distribution"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#0347e253a55e98814d3923074a870678c21677ac"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
 dependencies = [
  "futures 0.3.15",
  "polkadot-node-network-protocol",
@@ -6381,7 +6442,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#0347e253a55e98814d3923074a870678c21677ac"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
 dependencies = [
  "futures 0.3.15",
  "polkadot-node-network-protocol",
@@ -6394,7 +6455,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-distribution"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#0347e253a55e98814d3923074a870678c21677ac"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
 dependencies = [
  "futures 0.3.15",
  "lru",
@@ -6417,7 +6478,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-recovery"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#0347e253a55e98814d3923074a870678c21677ac"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
 dependencies = [
  "futures 0.3.15",
  "lru",
@@ -6436,7 +6497,7 @@ dependencies = [
 [[package]]
 name = "polkadot-cli"
 version = "0.9.8"
-source = "git+https://github.com/paritytech/polkadot?branch=master#0347e253a55e98814d3923074a870678c21677ac"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
 dependencies = [
  "frame-benchmarking-cli",
  "futures 0.3.15",
@@ -6456,7 +6517,7 @@ dependencies = [
 [[package]]
 name = "polkadot-client"
 version = "0.9.8"
-source = "git+https://github.com/paritytech/polkadot?branch=master#0347e253a55e98814d3923074a870678c21677ac"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
 dependencies = [
  "beefy-primitives",
  "frame-benchmarking",
@@ -6558,7 +6619,7 @@ dependencies = [
 [[package]]
 name = "polkadot-collator-protocol"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#0347e253a55e98814d3923074a870678c21677ac"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
 dependencies = [
  "always-assert",
  "futures 0.3.15",
@@ -6578,7 +6639,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "0.9.8"
-source = "git+https://github.com/paritytech/polkadot?branch=master#0347e253a55e98814d3923074a870678c21677ac"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
 dependencies = [
  "parity-scale-codec",
  "parity-util-mem",
@@ -6590,7 +6651,7 @@ dependencies = [
 [[package]]
 name = "polkadot-erasure-coding"
 version = "0.9.8"
-source = "git+https://github.com/paritytech/polkadot?branch=master#0347e253a55e98814d3923074a870678c21677ac"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -6604,7 +6665,7 @@ dependencies = [
 [[package]]
 name = "polkadot-gossip-support"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#0347e253a55e98814d3923074a870678c21677ac"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
 dependencies = [
  "futures 0.3.15",
  "polkadot-node-network-protocol",
@@ -6622,7 +6683,7 @@ dependencies = [
 [[package]]
 name = "polkadot-network-bridge"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#0347e253a55e98814d3923074a870678c21677ac"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
 dependencies = [
  "async-trait",
  "futures 0.3.15",
@@ -6642,7 +6703,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-collation-generation"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#0347e253a55e98814d3923074a870678c21677ac"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
 dependencies = [
  "futures 0.3.15",
  "parity-scale-codec",
@@ -6660,7 +6721,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#0347e253a55e98814d3923074a870678c21677ac"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
 dependencies = [
  "bitvec",
  "derive_more 0.99.14",
@@ -6690,7 +6751,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-av-store"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#0347e253a55e98814d3923074a870678c21677ac"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
 dependencies = [
  "bitvec",
  "futures 0.3.15",
@@ -6710,7 +6771,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-backing"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#0347e253a55e98814d3923074a870678c21677ac"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
 dependencies = [
  "bitvec",
  "futures 0.3.15",
@@ -6728,7 +6789,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#0347e253a55e98814d3923074a870678c21677ac"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
 dependencies = [
  "futures 0.3.15",
  "polkadot-node-subsystem",
@@ -6743,7 +6804,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-candidate-validation"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#0347e253a55e98814d3923074a870678c21677ac"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
 dependencies = [
  "async-trait",
  "futures 0.3.15",
@@ -6761,7 +6822,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-api"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#0347e253a55e98814d3923074a870678c21677ac"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
 dependencies = [
  "futures 0.3.15",
  "polkadot-node-subsystem",
@@ -6776,7 +6837,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#0347e253a55e98814d3923074a870678c21677ac"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
 dependencies = [
  "async-trait",
  "futures 0.3.15",
@@ -6794,7 +6855,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-provisioner"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#0347e253a55e98814d3923074a870678c21677ac"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
 dependencies = [
  "bitvec",
  "futures 0.3.15",
@@ -6809,7 +6870,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#0347e253a55e98814d3923074a870678c21677ac"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
 dependencies = [
  "always-assert",
  "assert_matches",
@@ -6839,7 +6900,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-runtime-api"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#0347e253a55e98814d3923074a870678c21677ac"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
 dependencies = [
  "futures 0.3.15",
  "memory-lru",
@@ -6857,7 +6918,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-jaeger"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#0347e253a55e98814d3923074a870678c21677ac"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
 dependencies = [
  "async-std",
  "lazy_static",
@@ -6875,7 +6936,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#0347e253a55e98814d3923074a870678c21677ac"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
 dependencies = [
  "futures 0.3.15",
  "parity-scale-codec",
@@ -6890,7 +6951,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#0347e253a55e98814d3923074a870678c21677ac"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
 dependencies = [
  "futures 0.3.15",
  "parity-scale-codec",
@@ -6913,7 +6974,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#0347e253a55e98814d3923074a870678c21677ac"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
 dependencies = [
  "async-std",
  "async-trait",
@@ -6943,7 +7004,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-test-helpers"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#0347e253a55e98814d3923074a870678c21677ac"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
 dependencies = [
  "async-trait",
  "futures 0.3.15",
@@ -6965,7 +7026,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-util"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#0347e253a55e98814d3923074a870678c21677ac"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
 dependencies = [
  "async-trait",
  "futures 0.3.15",
@@ -6993,7 +7054,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#0347e253a55e98814d3923074a870678c21677ac"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
 dependencies = [
  "async-trait",
  "futures 0.3.15",
@@ -7012,7 +7073,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain"
 version = "0.9.8"
-source = "git+https://github.com/paritytech/polkadot?branch=master#0347e253a55e98814d3923074a870678c21677ac"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
 dependencies = [
  "derive_more 0.99.14",
  "parity-scale-codec",
@@ -7027,7 +7088,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "0.9.8"
-source = "git+https://github.com/paritytech/polkadot?branch=master#0347e253a55e98814d3923074a870678c21677ac"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
 dependencies = [
  "bitvec",
  "frame-system",
@@ -7057,7 +7118,7 @@ dependencies = [
 [[package]]
 name = "polkadot-procmacro-overseer-subsystems-gen"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#0347e253a55e98814d3923074a870678c21677ac"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
 dependencies = [
  "assert_matches",
  "proc-macro2 1.0.27",
@@ -7068,7 +7129,7 @@ dependencies = [
 [[package]]
 name = "polkadot-procmacro-subsystem-dispatch-gen"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#0347e253a55e98814d3923074a870678c21677ac"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
 dependencies = [
  "assert_matches",
  "proc-macro2 1.0.27",
@@ -7079,7 +7140,7 @@ dependencies = [
 [[package]]
 name = "polkadot-rpc"
 version = "0.9.8"
-source = "git+https://github.com/paritytech/polkadot?branch=master#0347e253a55e98814d3923074a870678c21677ac"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
 dependencies = [
  "beefy-gadget",
  "beefy-gadget-rpc",
@@ -7112,7 +7173,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime"
 version = "0.9.8"
-source = "git+https://github.com/paritytech/polkadot?branch=master#0347e253a55e98814d3923074a870678c21677ac"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
 dependencies = [
  "beefy-primitives",
  "bitvec",
@@ -7126,7 +7187,6 @@ dependencies = [
  "frame-try-runtime",
  "hex-literal 0.3.1",
  "log",
- "max-encoded-len",
  "pallet-authority-discovery",
  "pallet-authorship",
  "pallet-babe",
@@ -7188,7 +7248,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-common"
 version = "0.9.8"
-source = "git+https://github.com/paritytech/polkadot?branch=master#0347e253a55e98814d3923074a870678c21677ac"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
 dependencies = [
  "beefy-primitives",
  "bitvec",
@@ -7233,7 +7293,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "0.9.8"
-source = "git+https://github.com/paritytech/polkadot?branch=master#0347e253a55e98814d3923074a870678c21677ac"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
 dependencies = [
  "bitvec",
  "derive_more 0.99.14",
@@ -7272,7 +7332,7 @@ dependencies = [
 [[package]]
 name = "polkadot-service"
 version = "0.9.8"
-source = "git+https://github.com/paritytech/polkadot?branch=master#0347e253a55e98814d3923074a870678c21677ac"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
 dependencies = [
  "async-trait",
  "beefy-gadget",
@@ -7364,7 +7424,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-distribution"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=master#0347e253a55e98814d3923074a870678c21677ac"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
 dependencies = [
  "arrayvec 0.5.2",
  "futures 0.3.15",
@@ -7385,7 +7445,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "0.9.8"
-source = "git+https://github.com/paritytech/polkadot?branch=master#0347e253a55e98814d3923074a870678c21677ac"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -7395,7 +7455,7 @@ dependencies = [
 [[package]]
 name = "polkadot-test-client"
 version = "0.9.8"
-source = "git+https://github.com/paritytech/polkadot?branch=master#0347e253a55e98814d3923074a870678c21677ac"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-subsystem",
@@ -7420,7 +7480,7 @@ dependencies = [
 [[package]]
 name = "polkadot-test-runtime"
 version = "0.9.8"
-source = "git+https://github.com/paritytech/polkadot?branch=master#0347e253a55e98814d3923074a870678c21677ac"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
 dependencies = [
  "beefy-primitives",
  "bitvec",
@@ -7476,7 +7536,7 @@ dependencies = [
 [[package]]
 name = "polkadot-test-service"
 version = "0.9.8"
-source = "git+https://github.com/paritytech/polkadot?branch=master#0347e253a55e98814d3923074a870678c21677ac"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
 dependencies = [
  "frame-benchmarking",
  "frame-system",
@@ -8203,7 +8263,7 @@ dependencies = [
 [[package]]
 name = "remote-externalities"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "env_logger 0.8.3",
  "hex",
@@ -8330,24 +8390,28 @@ dependencies = [
 [[package]]
 name = "rococo-runtime"
 version = "0.9.8"
-source = "git+https://github.com/paritytech/polkadot?branch=master#0347e253a55e98814d3923074a870678c21677ac"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
 dependencies = [
  "beefy-primitives",
+ "bp-messages",
  "bp-rococo",
+ "bp-runtime",
  "bp-wococo",
+ "bridge-runtime-common",
  "frame-executive",
  "frame-support",
  "frame-system",
  "frame-system-rpc-runtime-api",
  "hex-literal 0.3.1",
  "log",
- "max-encoded-len",
  "pallet-authority-discovery",
  "pallet-authorship",
  "pallet-babe",
  "pallet-balances",
  "pallet-beefy",
+ "pallet-bridge-dispatch",
  "pallet-bridge-grandpa",
+ "pallet-bridge-messages",
  "pallet-collective",
  "pallet-grandpa",
  "pallet-im-online",
@@ -8550,7 +8614,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "log",
  "sp-core",
@@ -8562,7 +8626,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "async-trait",
  "derive_more 0.99.14",
@@ -8591,7 +8655,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "futures 0.3.15",
  "futures-timer 3.0.2",
@@ -8614,7 +8678,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -8630,7 +8694,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -8650,7 +8714,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "proc-macro-crate 1.0.0",
  "proc-macro2 1.0.27",
@@ -8661,7 +8725,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "chrono",
  "fdlimit",
@@ -8699,7 +8763,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "derive_more 0.99.14",
  "fnv",
@@ -8733,7 +8797,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "blake2-rfc",
  "hash-db",
@@ -8763,7 +8827,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "async-trait",
  "parking_lot 0.11.1",
@@ -8776,7 +8840,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "async-trait",
  "derive_more 0.99.14",
@@ -8807,7 +8871,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "async-trait",
  "derive_more 0.99.14",
@@ -8853,7 +8917,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "derive_more 0.99.14",
  "futures 0.3.15",
@@ -8877,7 +8941,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -8890,7 +8954,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "async-trait",
  "futures 0.3.15",
@@ -8918,7 +8982,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-uncles"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "sc-client-api",
  "sp-authorship",
@@ -8929,7 +8993,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "derive_more 0.99.14",
  "lazy_static",
@@ -8958,7 +9022,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "derive_more 0.99.14",
  "parity-scale-codec",
@@ -8975,7 +9039,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -8990,7 +9054,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -9009,7 +9073,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "async-trait",
  "derive_more 0.99.14",
@@ -9050,7 +9114,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa-rpc"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "derive_more 0.99.14",
  "finality-grandpa",
@@ -9074,7 +9138,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa-warp-sync"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "derive_more 0.99.14",
  "futures 0.3.15",
@@ -9095,7 +9159,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "ansi_term 0.12.1",
  "futures 0.3.15",
@@ -9113,7 +9177,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "async-trait",
  "derive_more 0.99.14",
@@ -9133,7 +9197,7 @@ dependencies = [
 [[package]]
 name = "sc-light"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "hash-db",
  "lazy_static",
@@ -9152,7 +9216,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "async-std",
  "async-trait",
@@ -9205,7 +9269,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "futures 0.3.15",
  "futures-timer 3.0.2",
@@ -9222,7 +9286,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "bytes 0.5.6",
  "fnv",
@@ -9250,7 +9314,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "futures 0.3.15",
  "libp2p",
@@ -9263,7 +9327,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -9272,7 +9336,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "futures 0.3.15",
  "hash-db",
@@ -9307,7 +9371,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "derive_more 0.99.14",
  "futures 0.3.15",
@@ -9332,7 +9396,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "futures 0.1.30",
  "jsonrpc-core",
@@ -9350,7 +9414,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "async-trait",
  "directories",
@@ -9416,7 +9480,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -9431,7 +9495,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-core-client",
@@ -9451,7 +9515,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "chrono",
  "futures 0.3.15",
@@ -9471,7 +9535,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
@@ -9508,7 +9572,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "proc-macro-crate 1.0.0",
  "proc-macro2 1.0.27",
@@ -9519,7 +9583,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-graph"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "derive_more 0.99.14",
  "futures 0.3.15",
@@ -9541,7 +9605,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "futures 0.3.15",
  "intervalier",
@@ -9937,7 +10001,7 @@ dependencies = [
 [[package]]
 name = "slot-range-helper"
 version = "0.9.8"
-source = "git+https://github.com/paritytech/polkadot?branch=master#0347e253a55e98814d3923074a870678c21677ac"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -10043,7 +10107,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "hash-db",
  "log",
@@ -10060,7 +10124,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate 1.0.0",
@@ -10072,9 +10136,8 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
- "max-encoded-len",
  "parity-scale-codec",
  "serde",
  "sp-core",
@@ -10085,7 +10148,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -10099,7 +10162,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -10111,7 +10174,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -10123,7 +10186,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -10135,7 +10198,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "futures 0.3.15",
  "log",
@@ -10153,7 +10216,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "async-trait",
  "futures 0.3.15",
@@ -10180,7 +10243,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -10197,7 +10260,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "async-trait",
  "merlin",
@@ -10219,7 +10282,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "parity-scale-codec",
  "sp-arithmetic",
@@ -10229,7 +10292,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",
@@ -10241,7 +10304,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -10256,7 +10319,6 @@ dependencies = [
  "lazy_static",
  "libsecp256k1",
  "log",
- "max-encoded-len",
  "merlin",
  "num-traits",
  "parity-scale-codec",
@@ -10286,7 +10348,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "kvdb",
  "parking_lot 0.11.1",
@@ -10295,7 +10357,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "proc-macro2 1.0.27",
  "quote 1.0.9",
@@ -10305,7 +10367,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -10316,7 +10378,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -10333,7 +10395,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -10347,7 +10409,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "futures 0.3.15",
  "hash-db",
@@ -10372,7 +10434,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -10383,7 +10445,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "async-trait",
  "derive_more 0.99.14",
@@ -10400,7 +10462,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "ruzstd",
  "zstd",
@@ -10409,7 +10471,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -10422,7 +10484,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections-compact"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "proc-macro-crate 1.0.0",
  "proc-macro2 1.0.27",
@@ -10433,7 +10495,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -10443,7 +10505,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "backtrace",
 ]
@@ -10451,7 +10513,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -10462,13 +10524,12 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "either",
  "hash256-std-hasher",
  "impl-trait-for-tuples",
  "log",
- "max-encoded-len",
  "parity-scale-codec",
  "parity-util-mem",
  "paste",
@@ -10484,7 +10545,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -10501,7 +10562,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "Inflector",
  "proc-macro-crate 1.0.0",
@@ -10513,7 +10574,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "serde",
  "serde_json",
@@ -10522,7 +10583,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -10535,7 +10596,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -10545,7 +10606,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "hash-db",
  "log",
@@ -10568,12 +10629,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 
 [[package]]
 name = "sp-storage"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -10586,7 +10647,7 @@ dependencies = [
 [[package]]
 name = "sp-tasks"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "log",
  "sp-core",
@@ -10599,7 +10660,7 @@ dependencies = [
 [[package]]
 name = "sp-test-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "parity-scale-codec",
  "parity-util-mem",
@@ -10612,7 +10673,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "async-trait",
  "futures-timer 3.0.2",
@@ -10629,7 +10690,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "erased-serde",
  "log",
@@ -10647,7 +10708,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "derive_more 0.99.14",
  "futures 0.3.15",
@@ -10663,7 +10724,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "async-trait",
  "log",
@@ -10678,7 +10739,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -10692,7 +10753,7 @@ dependencies = [
 [[package]]
 name = "sp-utils"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "futures 0.3.15",
  "futures-core",
@@ -10704,20 +10765,22 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
+ "parity-wasm 0.42.2",
  "serde",
  "sp-runtime",
  "sp-std",
  "sp-version-proc-macro",
+ "thiserror",
 ]
 
 [[package]]
 name = "sp-version-proc-macro"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-crate 1.0.0",
@@ -10729,7 +10792,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -10772,7 +10835,6 @@ dependencies = [
  "hex",
  "hex-literal 0.3.1",
  "log",
- "max-encoded-len",
  "node-primitives",
  "pallet-assets",
  "pallet-aura",
@@ -10861,7 +10923,6 @@ dependencies = [
  "hex",
  "hex-literal 0.3.1",
  "log",
- "max-encoded-len",
  "node-primitives",
  "pallet-assets",
  "pallet-aura",
@@ -11033,7 +11094,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "platforms",
 ]
@@ -11041,7 +11102,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.15",
@@ -11064,7 +11125,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "async-std",
  "derive_more 0.99.14",
@@ -11078,7 +11139,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "async-trait",
  "futures 0.1.30",
@@ -11107,7 +11168,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-utils"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "futures 0.3.15",
  "substrate-test-utils-derive",
@@ -11117,7 +11178,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-utils-derive"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "proc-macro-crate 1.0.0",
  "quote 1.0.9",
@@ -11127,7 +11188,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
@@ -11828,7 +11889,7 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 [[package]]
 name = "try-runtime-cli"
 version = "0.9.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#32a365d549dfb123d2d14443b3e35ed908da6de4"
+source = "git+https://github.com/paritytech/substrate?branch=master#66187cbe143dd8f70c610e0d51ead4d5888ee5c3"
 dependencies = [
  "frame-try-runtime",
  "log",
@@ -11858,7 +11919,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04f8ab788026715fa63b31960869617cba39117e520eb415b0139543e325ab59"
 dependencies = [
  "cfg-if 0.1.10",
- "rand 0.6.5",
+ "rand 0.7.3",
  "static_assertions",
 ]
 
@@ -12491,7 +12552,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime"
 version = "0.9.8"
-source = "git+https://github.com/paritytech/polkadot?branch=master#0347e253a55e98814d3923074a870678c21677ac"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
 dependencies = [
  "beefy-primitives",
  "bitvec",
@@ -12505,7 +12566,6 @@ dependencies = [
  "frame-try-runtime",
  "hex-literal 0.3.1",
  "log",
- "max-encoded-len",
  "pallet-authority-discovery",
  "pallet-authorship",
  "pallet-babe",
@@ -12594,7 +12654,6 @@ dependencies = [
  "hex",
  "hex-literal 0.3.1",
  "log",
- "max-encoded-len",
  "node-primitives",
  "pallet-assets",
  "pallet-aura",
@@ -12734,17 +12793,18 @@ dependencies = [
 [[package]]
 name = "xcm"
 version = "0.9.8"
-source = "git+https://github.com/paritytech/polkadot?branch=master#0347e253a55e98814d3923074a870678c21677ac"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
 dependencies = [
  "derivative",
  "impl-trait-for-tuples",
+ "log",
  "parity-scale-codec",
 ]
 
 [[package]]
 name = "xcm-builder"
 version = "0.9.8"
-source = "git+https://github.com/paritytech/polkadot?branch=master#0347e253a55e98814d3923074a870678c21677ac"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -12763,7 +12823,7 @@ dependencies = [
 [[package]]
 name = "xcm-executor"
 version = "0.9.8"
-source = "git+https://github.com/paritytech/polkadot?branch=master#0347e253a55e98814d3923074a870678c21677ac"
+source = "git+https://github.com/paritytech/polkadot?branch=master#ad6e755b842aee67543c9af66db1801b27cc7d87"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",

--- a/polkadot-parachains/statemine/Cargo.toml
+++ b/polkadot-parachains/statemine/Cargo.toml
@@ -7,7 +7,7 @@ description = "Kusama variant of Statemint parachain runtime"
 
 [dependencies]
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
-codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive", "max-encoded-len"] }
 log = { version = "0.4.14", default-features = false }
 parachain-info = { path = "../pallets/parachain-info", default-features = false }
 smallvec = "1.6.1"
@@ -49,7 +49,6 @@ pallet-uniques = { git = "https://github.com/paritytech/substrate", default-feat
 pallet-utility = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
 
 node-primitives = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
-max-encoded-len = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
 
 # Cumulus dependencies
 cumulus-pallet-aura-ext = { path = "../../pallets/aura-ext", default-features = false }

--- a/polkadot-parachains/statemine/src/lib.rs
+++ b/polkadot-parachains/statemine/src/lib.rs
@@ -39,11 +39,11 @@ use sp_std::prelude::*;
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
 
-use codec::{Decode, Encode};
+use codec::{Decode, Encode, MaxEncodedLen};
 use constants::{currency::*, fee::WeightToFee};
 use frame_support::{
 	construct_runtime, match_type, parameter_types,
-	traits::{All, Filter, InstanceFilter, MaxEncodedLen},
+	traits::{All, Filter, InstanceFilter},
 	weights::{
 		constants::{BlockExecutionWeight, ExtrinsicBaseWeight},
 		DispatchClass, IdentityFee, Weight,
@@ -365,12 +365,9 @@ impl InstanceFilter<Call> for ProxyType {
 	fn filter(&self, c: &Call) -> bool {
 		match self {
 			ProxyType::Any => true,
-			ProxyType::NonTransfer => !matches!(
-				c,
-				Call::Balances(..)
-					| Call::Assets(..)
-					| Call::Uniques(..)
-			),
+			ProxyType::NonTransfer => {
+				!matches!(c, Call::Balances(..) | Call::Assets(..) | Call::Uniques(..))
+			}
 			ProxyType::CancelProxy => matches!(
 				c,
 				Call::Proxy(pallet_proxy::Call::reject_announcement(..))

--- a/polkadot-parachains/statemint/Cargo.toml
+++ b/polkadot-parachains/statemint/Cargo.toml
@@ -7,7 +7,7 @@ description = "Statemint parachain runtime"
 
 [dependencies]
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
-codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive", "max-encoded-len"] }
 log = { version = "0.4.14", default-features = false }
 parachain-info = { path = "../pallets/parachain-info", default-features = false }
 smallvec = "1.6.1"
@@ -48,7 +48,6 @@ pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/parityt
 pallet-utility = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
 
 node-primitives = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
-max-encoded-len = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
 
 # Cumulus dependencies
 cumulus-pallet-aura-ext = { path = "../../pallets/aura-ext", default-features = false }

--- a/polkadot-parachains/statemint/src/lib.rs
+++ b/polkadot-parachains/statemint/src/lib.rs
@@ -39,11 +39,11 @@ use sp_std::prelude::*;
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
 
-use codec::{Decode, Encode};
+use codec::{Decode, Encode, MaxEncodedLen};
 use constants::{currency::*, fee::WeightToFee};
 use frame_support::{
 	construct_runtime, match_type, parameter_types,
-	traits::{All, InstanceFilter, MaxEncodedLen},
+	traits::{All, InstanceFilter},
 	weights::{
 		constants::{BlockExecutionWeight, ExtrinsicBaseWeight},
 		DispatchClass, IdentityFee, Weight,
@@ -327,11 +327,7 @@ impl InstanceFilter<Call> for ProxyType {
 	fn filter(&self, c: &Call) -> bool {
 		match self {
 			ProxyType::Any => true,
-			ProxyType::NonTransfer => !matches!(
-				c,
-				Call::Balances(..)
-					| Call::Assets(..)
-			),
+			ProxyType::NonTransfer => !matches!(c, Call::Balances(..) | Call::Assets(..)),
 			ProxyType::CancelProxy => matches!(
 				c,
 				Call::Proxy(pallet_proxy::Call::reject_announcement(..))

--- a/polkadot-parachains/westmint/Cargo.toml
+++ b/polkadot-parachains/westmint/Cargo.toml
@@ -7,7 +7,7 @@ description = "Westend variant of Statemint parachain runtime"
 
 [dependencies]
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
-codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive", "max-encoded-len"] }
 log = { version = "0.4.14", default-features = false }
 parachain-info = { path = "../pallets/parachain-info", default-features = false }
 smallvec = "1.6.1"
@@ -48,7 +48,6 @@ pallet-transaction-payment-rpc-runtime-api = { git = "https://github.com/parityt
 pallet-utility = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
 
 node-primitives = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
-max-encoded-len = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
 
 # Cumulus dependencies
 cumulus-pallet-aura-ext = { path = "../../pallets/aura-ext", default-features = false }

--- a/polkadot-parachains/westmint/src/lib.rs
+++ b/polkadot-parachains/westmint/src/lib.rs
@@ -39,11 +39,11 @@ use sp_std::prelude::*;
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
 
-use codec::{Decode, Encode};
+use codec::{Decode, Encode, MaxEncodedLen};
 use constants::{currency::*, fee::WeightToFee};
 use frame_support::{
 	construct_runtime, match_type, parameter_types,
-	traits::{All, InstanceFilter, MaxEncodedLen},
+	traits::{All, InstanceFilter},
 	weights::{
 		constants::{BlockExecutionWeight, ExtrinsicBaseWeight},
 		DispatchClass, IdentityFee, Weight,
@@ -313,7 +313,7 @@ pub enum ProxyType {
 	AssetOwner,
 	/// Asset manager. Can execute calls related to asset management.
 	AssetManager,
-	// Collator selection proxy. Can execute calls related to collator selection mechanism.
+	/// Collator selection proxy. Can execute calls related to collator selection mechanism.
 	Collator,
 }
 impl Default for ProxyType {
@@ -325,11 +325,7 @@ impl InstanceFilter<Call> for ProxyType {
 	fn filter(&self, c: &Call) -> bool {
 		match self {
 			ProxyType::Any => true,
-			ProxyType::NonTransfer => !matches!(
-				c,
-				Call::Balances(..)
-					| Call::Assets(..)
-			),
+			ProxyType::NonTransfer => !matches!(c, Call::Balances(..) | Call::Assets(..)),
 			ProxyType::CancelProxy => matches!(
 				c,
 				Call::Proxy(pallet_proxy::Call::reject_announcement(..))

--- a/test/runtime/src/lib.rs
+++ b/test/runtime/src/lib.rs
@@ -253,15 +253,6 @@ impl cumulus_pallet_parachain_system::Config for Runtime {
 
 parameter_types! {
 	pub storage ParachainId: cumulus_primitives_core::ParaId = 100.into();
-	pub storage UpgradeDetection: bool = false;
-}
-
-pub struct UpgradeDetectionOnRuntimeUpgrade;
-impl frame_support::traits::OnRuntimeUpgrade for UpgradeDetectionOnRuntimeUpgrade {
-	fn on_runtime_upgrade() -> u64 {
-		UpgradeDetection::set(&true);
-		0
-	}
 }
 
 construct_runtime! {
@@ -326,7 +317,6 @@ pub type Executive = frame_executive::Executive<
 	frame_system::ChainContext<Runtime>,
 	Runtime,
 	AllPallets,
-	UpgradeDetectionOnRuntimeUpgrade,
 >;
 /// The payload being signed in transactions.
 pub type SignedPayload = generic::SignedPayload<Call, SignedExtra>;
@@ -335,10 +325,6 @@ decl_runtime_apis! {
 	pub trait GetLastTimestamp {
 		/// Returns the last timestamp of a runtime.
 		fn get_last_timestamp() -> u64;
-	}
-	pub trait GetUpgradeDetection {
-		/// Returns `true` if the runtime has been upgraded at least once.
-		fn has_upgraded() -> bool;
 	}
 }
 
@@ -414,12 +400,6 @@ impl_runtime_apis! {
 	impl crate::GetLastTimestamp<Block> for Runtime {
 		fn get_last_timestamp() -> u64 {
 			Timestamp::now()
-		}
-	}
-
-	impl crate::GetUpgradeDetection<Block> for Runtime {
-		fn has_upgraded() -> bool {
-			UpgradeDetection::get()
 		}
 	}
 

--- a/test/service/Cargo.toml
+++ b/test/service/Cargo.toml
@@ -70,6 +70,8 @@ polkadot-test-service = { git = "https://github.com/paritytech/polkadot", branch
 # Substrate dependencies
 sc-cli = { git = "https://github.com/paritytech/substrate", branch = "master" }
 substrate-test-utils = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-maybe-compressed-blob = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-version = { git = "https://github.com/paritytech/substrate", branch = "master" }
 
 # Cumulus
 cumulus-test-runtime-upgrade = { path = "../runtime-upgrade" }

--- a/test/service/src/lib.rs
+++ b/test/service/src/lib.rs
@@ -669,7 +669,7 @@ impl TestNode {
 
 	/// Register a parachain at this relay chain.
 	pub async fn schedule_upgrade(&self, validation: Vec<u8>) -> Result<(), RpcTransactionError> {
-		let call = frame_system::Call::set_code_without_checks(validation);
+		let call = frame_system::Call::set_code(validation);
 
 		self.send_extrinsic(
 			runtime::SudoCall::sudo_unchecked_weight(Box::new(call.into()), 1_000),


### PR DESCRIPTION
This brings back the runtime upgrade test and also updates Substrate &
Polkadot.

Fixes: https://github.com/paritytech/cumulus/issues/524