### PR TITLE
CI: build a test artifact

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,8 +31,6 @@ variables:                         &default-vars
     - if: $CI_PIPELINE_SOURCE == "web"
     - if: $CI_PIPELINE_SOURCE == "schedule"
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
-    # FIXME: remove me
-    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
 
 .docker-env:                       &docker-env
   image:                           "${CI_IMAGE}"
@@ -75,16 +73,17 @@ test-linux-stable:
   stage:                           test
   <<:                              *docker-env
   rules:
-    - if: $CI_PIPELINE_SOURCE == "web"
-    - if: $CI_PIPELINE_SOURCE == "schedule"
     - if: $CI_COMMIT_REF_NAME == "master"
     - if: $CI_COMMIT_REF_NAME == "tags"
-    - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
-    # FIXME: return tag here
-    # It doesn't make sense to build on every commit, so we build on tags
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
+    # It doesn't make sense to build on every commit, so we build on tags
+    - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
       variables:
         ARE_WE_RELEASING_YET:      maybe!
+    # web and schedule triggers can be provided with the non-empty variable ARE_WE_RELEASING_YET
+    # to run building and publishing the binary.
+    - if: $CI_PIPELINE_SOURCE == "web"
+    - if: $CI_PIPELINE_SOURCE == "schedule"
   <<:                              *collect-artifacts
   variables:
     <<:                            *default-vars
@@ -92,18 +91,17 @@ test-linux-stable:
     # but still want to have debug assertions.
     RUSTFLAGS: "-Cdebug-assertions=y -Dwarnings"
   script:
-    # FIXME: undebug
-    - echo "time cargo test --all --release --locked"
-    # it's almost free to produce a binary here, please refrain from using
-    # it in production since it goes with the debug assertions.
+    - time cargo test --all --release --locked
+    # It's almost free to produce a binary here, please refrain from using it in production since
+    # it goes with the debug assertions.
     - if [ "${ARE_WE_RELEASING_YET}" ]; then
-        echo "___Building a binary___"
-        mkdir -p ${CARGO_TARGET_DIR}/release/polkadot-collator
-        echo "time cargo build --release --locked --bin polkadot-collator" | tee ${CARGO_TARGET_DIR}/release/polkadot-collator;
+        echo "___Building a binary___";
+        time cargo build --release --locked --bin polkadot-collator;
         echo "___Packing the artifacts___";
         mkdir -p ./artifacts;
         mv ${CARGO_TARGET_DIR}/release/polkadot-collator ./artifacts/.;
-        echo ${CI_COMMIT_REF_NAME} | tee ./artifacts/VERSION
+        echo "___The VERSION is either a tag name or the curent branch if triggered not by a tag___";
+        echo ${CI_COMMIT_REF_NAME} | tee ./artifacts/VERSION;
       else
         exit 0;
       fi
@@ -120,8 +118,15 @@ publish-s3:
     GIT_STRATEGY:                  none
     BUCKET:                        "releases.parity.io"
     PREFIX:                        "cumulus/${ARCH}-${DOCKER_OS}"
+  before_script:
+    # Job will fail if no artifacts were provided by test-linux-stable job. It's only possible for
+    # this test to fail if the pipeline was triggered by web or schedule trigger without supplying
+    # a nono-empty ARE_WE_RELEASING_YET variable.
+    - test -e ./artifacts/polkadot-collator ||
+        ( echo "___No artifacts were provided by the previous job, please check the build there___"; exit 1 )
   script:
     - echo "___Publishing a binary with debug assertions!___"
+    - echo "___VERSION = $(cat ./artifacts/VERSION) ___"
     - aws s3 sync ./artifacts/ s3://${BUCKET}/${PREFIX}/$(cat ./artifacts/VERSION)/
     - echo "___Updating objects in latest path___"
     - aws s3 sync s3://${BUCKET}/${PREFIX}/$(cat ./artifacts/VERSION)/ s3://${BUCKET}/${PREFIX}/latest/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,16 +41,15 @@ variables:                         &default-vars
   tags:
     - linux-docker
 
-#### stage:                        test
+.collect-artifacts:                &collect-artifacts
+  artifacts:
+    name:                          "${CI_JOB_NAME}_${CI_COMMIT_REF_NAME}"
+    when:                          on_success
+    expire_in:                     28 days
+    paths:
+      - ./artifacts/
 
-cargo-audit:
-  stage:                           test
-  <<:                              *docker-env
-  except:
-    - /^[0-9]+$/
-  script:
-    - cargo audit
-  allow_failure:                   true
+#### stage:                        test
 
 test-linux-stable:
   stage:                           test
@@ -62,4 +61,10 @@ test-linux-stable:
     RUSTFLAGS: "-Cdebug-assertions=y -Dwarnings"
   script:
     - time cargo test --all --release --locked
+    # and it's almost free to produce a binary here, please refrain from using
+    # it in production since it goes with the debug assertions
+    - time cargo build --release
     - sccache -s
+    # pack artifacts
+    - mkdir -p ./artifacts
+    - mv ./target/release/cumulus ./artifacts/.

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -92,17 +92,19 @@ test-linux-stable:
     # but still want to have debug assertions.
     RUSTFLAGS: "-Cdebug-assertions=y -Dwarnings"
   script:
-    - time cargo test --all --release --locked
+    # FIXME: undebug
+    - echo "time cargo test --all --release --locked"
     # it's almost free to produce a binary here, please refrain from using
     # it in production since it goes with the debug assertions.
     - if [ "${ARE_WE_RELEASING_YET}" ]; then
         echo "___Building a binary___"
-        time cargo build --release --locked --bin polkadot-collator;
-        echo "___Packing the artifacts___"
+        mkdir -p ${CARGO_TARGET_DIR}/release/polkadot-collator
+        echo "time cargo build --release --locked --bin polkadot-collator" | tee ${CARGO_TARGET_DIR}/release/polkadot-collator;
+        echo "___Packing the artifacts___";
         mkdir -p ./artifacts;
         mv ${CARGO_TARGET_DIR}/release/polkadot-collator ./artifacts/.;
       else
-        exit 0
+        exit 0;
       fi
     - sccache -s
 
@@ -119,7 +121,7 @@ publish-s3:
     PREFIX:                        "cumulus/${ARCH}-${DOCKER_OS}"
   script:
     - echo "___Publishing a binary with debug assertions!___"
-    - git describe --tags | tee ./artifacts/VERSION
+    - echo ${CI_COMMIT_REF_NAME} | tee ./artifacts/VERSION
     - aws s3 sync ./artifacts/ s3://${BUCKET}/${PREFIX}/$(cat ./artifacts/VERSION)/
     - echo "___Updating objects in latest path___"
     - aws s3 sync s3://${BUCKET}/${PREFIX}/$(cat ./artifacts/VERSION)/ s3://${BUCKET}/${PREFIX}/latest/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -68,4 +68,4 @@ test-linux-stable:
     - sccache -s
     # pack artifacts
     - mkdir -p ./artifacts
-    - mv ./target/release/polkadot-collator ./artifacts/.
+    - mv ${CARGO_TARGET_DIR}/release/polkadot-collator ./artifacts/.

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,15 +7,16 @@
 
 stages:
   - test
-  - build
+  - publish
 
 variables:                         &default-vars
   GIT_STRATEGY:                    fetch
   GIT_DEPTH:                       100
   CARGO_INCREMENTAL:               0
   CARGO_TARGET_DIR:                "/ci-cache/${CI_PROJECT_NAME}/targets/${CI_COMMIT_REF_NAME}/${CI_JOB_NAME}"
-  CI_IMAGE:                        "paritytech/ink-ci-linux:production"
-  CI_SERVER_NAME:                  "GitLab CI"
+  CI_IMAGE:                        "paritytech/ci-linux:production"
+  DOCKER_OS:                       "debian:stretch"
+  ARCH:                            "x86_64"
 
 .rust-info-script:                 &rust-info-script
   - rustup show
@@ -25,14 +26,13 @@ variables:                         &default-vars
   - bash --version
   - sccache -s
 
-.test-refs:                        &test-refs
+.publish-refs:                     &publish-refs
   rules:
     - if: $CI_PIPELINE_SOURCE == "web"
     - if: $CI_PIPELINE_SOURCE == "schedule"
-    - if: $CI_COMMIT_REF_NAME == "master"
-    - if: $CI_COMMIT_REF_NAME == "tags"
-    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
+    # FIXME: remove me
+    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
 
 .docker-env:                       &docker-env
   image:                           "${CI_IMAGE}"
@@ -40,15 +40,26 @@ variables:                         &default-vars
     - *rust-info-script
     - ./scripts/ci/pre_cache.sh
     - sccache -s
-  interruptible:                   true
   retry:
     max: 2
     when:
       - runner_system_failure
       - unknown_failure
       - api_failure
+  interruptible:                   true
   tags:
     - linux-docker
+
+.kubernetes-env:                   &kubernetes-env
+  retry:
+    max: 2
+    when:
+      - runner_system_failure
+      - unknown_failure
+      - api_failure
+  interruptible:                   true
+  tags:
+    - kubernetes-parity-build
 
 .collect-artifacts:                &collect-artifacts
   artifacts:
@@ -63,7 +74,17 @@ variables:                         &default-vars
 test-linux-stable:
   stage:                           test
   <<:                              *docker-env
-  <<:                              *test-refs
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "web"
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+    - if: $CI_COMMIT_REF_NAME == "master"
+    - if: $CI_COMMIT_REF_NAME == "tags"
+    - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
+    # FIXME: return tag here
+    # It doesn't make sense to build on every commit, so we build on tags
+    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
+      variables:
+        ARE_WE_RELEASING_YET:      maybe!
   <<:                              *collect-artifacts
   variables:
     <<:                            *default-vars
@@ -73,9 +94,35 @@ test-linux-stable:
   script:
     - time cargo test --all --release --locked
     # it's almost free to produce a binary here, please refrain from using
-    # it in production since it goes with the debug assertions
-    - time cargo build --release --locked --bin polkadot-collator
+    # it in production since it goes with the debug assertions.
+    - if [ "${ARE_WE_RELEASING_YET}" ]; then
+        echo "___Building a binary___"
+        time cargo build --release --locked --bin polkadot-collator;
+        echo "___Packing the artifacts___"
+        mkdir -p ./artifacts;
+        mv ${CARGO_TARGET_DIR}/release/polkadot-collator ./artifacts/.;
+      else
+        exit 0
+      fi
     - sccache -s
-    # pack artifacts
-    - mkdir -p ./artifacts
-    - mv ${CARGO_TARGET_DIR}/release/polkadot-collator ./artifacts/.
+
+#### stage:                        publish
+
+publish-s3:
+  stage:                           publish
+  <<:                              *kubernetes-env
+  image:                           paritytech/awscli:latest
+  <<:                              *publish-refs
+  variables:
+    GIT_STRATEGY:                  none
+    BUCKET:                        "releases.parity.io"
+    PREFIX:                        "cumulus/${ARCH}-${DOCKER_OS}"
+  script:
+    - echo "___Publishing a binary with debug assertions!___"
+    - git describe --tags | tee ./artifacts/VERSION
+    - aws s3 sync ./artifacts/ s3://${BUCKET}/${PREFIX}/$(cat ./artifacts/VERSION)/
+    - echo "___Updating objects in latest path___"
+    - aws s3 sync s3://${BUCKET}/${PREFIX}/$(cat ./artifacts/VERSION)/ s3://${BUCKET}/${PREFIX}/latest/
+  after_script:
+    - aws s3 ls s3://${BUCKET}/${PREFIX}/latest/
+        --recursive --human-readable --summarize

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -60,10 +60,10 @@ test-linux-stable:
     # but still want to have debug assertions.
     RUSTFLAGS: "-Cdebug-assertions=y -Dwarnings"
   script:
-    - time cargo test --all --release --locked
-    # and it's almost free to produce a binary here, please refrain from using
+    # it's almost free to produce a binary here, please refrain from using
     # it in production since it goes with the debug assertions
     - time cargo build --release
+    - time cargo test --all --release --locked
     - sccache -s
     # pack artifacts
     - mkdir -p ./artifacts

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,6 +38,7 @@ variables:                         &default-vars
   image:                           "${CI_IMAGE}"
   before_script:
     - *rust-info-script
+    - ./scripts/ci/pre_cache.sh
     - sccache -s
   interruptible:                   true
   retry:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -62,9 +62,9 @@ test-linux-stable:
   script:
     # it's almost free to produce a binary here, please refrain from using
     # it in production since it goes with the debug assertions
-    - time cargo build --release
+    - time cargo build --release --locked --bin polkadot-collator
     - time cargo test --all --release --locked
     - sccache -s
     # pack artifacts
     - mkdir -p ./artifacts
-    - mv ./target/release/cumulus ./artifacts/.
+    - mv ./target/release/polkadot-collator ./artifacts/.

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,26 +11,34 @@ stages:
 
 variables:                         &default-vars
   GIT_STRATEGY:                    fetch
-  GIT_DEPTH:                       3
+  GIT_DEPTH:                       100
   CARGO_INCREMENTAL:               0
   CARGO_TARGET_DIR:                "/ci-cache/${CI_PROJECT_NAME}/targets/${CI_COMMIT_REF_NAME}/${CI_JOB_NAME}"
+  CI_IMAGE:                        "paritytech/ink-ci-linux:production"
   CI_SERVER_NAME:                  "GitLab CI"
 
+.rust-info-script:                 &rust-info-script
+  - rustup show
+  - cargo --version
+  - rustup +nightly show
+  - cargo +nightly --version
+  - bash --version
+  - sccache -s
+
+.test-refs:                        &test-refs
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "web"
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+    - if: $CI_COMMIT_REF_NAME == "master"
+    - if: $CI_COMMIT_REF_NAME == "tags"
+    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
+    - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
+
 .docker-env:                       &docker-env
-  image:                           paritytech/ci-linux:production
+  image:                           "${CI_IMAGE}"
   before_script:
-    - cargo -vV
-    - rustc -vV
-    - rustup show
-    - cargo --version
+    - *rust-info-script
     - sccache -s
-  only:
-    - master
-    - /^v[0-9]+\.[0-9]+.*$/        # i.e. v1.0, v2.1rc1
-    - schedules
-    - web
-    - /^[0-9]+$/                   # PRs
-  dependencies:                    []
   interruptible:                   true
   retry:
     max: 2
@@ -54,17 +62,18 @@ variables:                         &default-vars
 test-linux-stable:
   stage:                           test
   <<:                              *docker-env
+  <<:                              *test-refs
+  <<:                              *collect-artifacts
   variables:
     <<:                            *default-vars
     # Enable debug assertions since we are running optimized builds for testing
     # but still want to have debug assertions.
     RUSTFLAGS: "-Cdebug-assertions=y -Dwarnings"
   script:
-    - cargo clean
+    - time cargo test --all --release --locked
     # it's almost free to produce a binary here, please refrain from using
     # it in production since it goes with the debug assertions
     - time cargo build --release --locked --bin polkadot-collator
-    - time cargo test --all --release --locked
     - sccache -s
     # pack artifacts
     - mkdir -p ./artifacts

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -103,6 +103,7 @@ test-linux-stable:
         echo "___Packing the artifacts___";
         mkdir -p ./artifacts;
         mv ${CARGO_TARGET_DIR}/release/polkadot-collator ./artifacts/.;
+        echo ${CI_COMMIT_REF_NAME} | tee ./artifacts/VERSION
       else
         exit 0;
       fi
@@ -121,7 +122,6 @@ publish-s3:
     PREFIX:                        "cumulus/${ARCH}-${DOCKER_OS}"
   script:
     - echo "___Publishing a binary with debug assertions!___"
-    - echo ${CI_COMMIT_REF_NAME} | tee ./artifacts/VERSION
     - aws s3 sync ./artifacts/ s3://${BUCKET}/${PREFIX}/$(cat ./artifacts/VERSION)/
     - echo "___Updating objects in latest path___"
     - aws s3 sync s3://${BUCKET}/${PREFIX}/$(cat ./artifacts/VERSION)/ s3://${BUCKET}/${PREFIX}/latest/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -61,10 +61,10 @@ test-linux-stable:
     RUSTFLAGS: "-Cdebug-assertions=y -Dwarnings"
   script:
     - cargo clean
-    - time cargo test --all --release --locked
     # it's almost free to produce a binary here, please refrain from using
     # it in production since it goes with the debug assertions
     - time cargo build --release --locked --bin polkadot-collator
+    - time cargo test --all --release --locked
     - sccache -s
     # pack artifacts
     - mkdir -p ./artifacts

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -60,6 +60,7 @@ test-linux-stable:
     # but still want to have debug assertions.
     RUSTFLAGS: "-Cdebug-assertions=y -Dwarnings"
   script:
+    - cargo clean
     # it's almost free to produce a binary here, please refrain from using
     # it in production since it goes with the debug assertions
     - time cargo build --release --locked --bin polkadot-collator

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -61,10 +61,10 @@ test-linux-stable:
     RUSTFLAGS: "-Cdebug-assertions=y -Dwarnings"
   script:
     - cargo clean
+    - time cargo test --all --release --locked
     # it's almost free to produce a binary here, please refrain from using
     # it in production since it goes with the debug assertions
     - time cargo build --release --locked --bin polkadot-collator
-    - time cargo test --all --release --locked
     - sccache -s
     # pack artifacts
     - mkdir -p ./artifacts

--- a/scripts/ci/pre_cache.sh
+++ b/scripts/ci/pre_cache.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -u
+
+# if there is no directory for this $CI_COMMIT_REF_NAME/$CI_JOB_NAME
+# create such directory and
+# copy recursively all the files from the newest dir which has $CI_JOB_NAME, if it exists
+
+# cache lives in /ci-cache/${CI_PROJECT_NAME}/${2}/${CI_COMMIT_REF_NAME}/${CI_JOB_NAME}
+
+function prepopulate {
+  if [[ ! -d $1 ]]; then
+    mkdir -p "/ci-cache/$CI_PROJECT_NAME/$2/$CI_COMMIT_REF_NAME";
+    FRESH_CACHE=$(find "/ci-cache/$CI_PROJECT_NAME/$2" -mindepth 2 -maxdepth 2 \
+      -type d -name "$CI_JOB_NAME"  -exec stat --printf="%Y\t%n\n" {} \; |sort -n -r |head -1 |cut -f2);
+    if [[ -d $FRESH_CACHE ]]; then
+      echo "____Using" "$FRESH_CACHE" "to prepopulate the cache____";
+      time cp -r "$FRESH_CACHE" "$1";
+    else
+      echo "_____No such $2 dir, proceeding from scratch_____";
+    fi
+  else
+    echo "____No need to prepopulate $2 cache____";
+  fi
+}
+
+# CARGO_HOME cache is still broken so would be handled some other way.
+prepopulate "$CARGO_TARGET_DIR" targets


### PR DESCRIPTION
`build --release --bin polkadot-collator` takes 5 minutes after a test, `test --release --all` gets built in ~8 minutes without the cache.
So in the case of building after the test it saves a parallel/concurrent task, but certainly it doesn't make sense to run it every time on PRs, not even on every master pipeline.

I can run the build as it is, in the same job, but only when the pipeline's executed by schedule/trigger, @lovelaced WDYT?

Closes: https://github.com/paritytech/ci_cd/issues/141