### PR TITLE
ci: reduce the list of events triggering matrix messages

### DIFF
--- a/.github/workflows/release-bot.yml
+++ b/.github/workflows/release-bot.yml
@@ -1,10 +1,9 @@
-name: Pushes release updates to a pre-defined Matrix room
+name: Pushes release notes to a Matrix room
 on:
   release:
     types:
-      - edited
-      - prereleased
       - published
+
 jobs:
   ping_matrix:
     runs-on: ubuntu-latest
@@ -14,5 +13,11 @@ jobs:
         with:
           room_id: ${{ secrets.MATRIX_ROOM_ID }}
           access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
-          message: "**${{github.event.repository.full_name}}:** A release has been ${{github.event.action}}<br/>Release version [${{github.event.release.tag_name}}](${{github.event.release.html_url}})<br/><br/>***Description:***<br/>${{github.event.release.body}}<br/>"
+          message: |
+            A (pre)release has been ${{github.event.action}} in **${{github.event.repository.full_name}}:**<br/>
+            Release version: [${{github.event.release.tag_name}}](${{github.event.release.html_url}})
+
+            -----
+
+            ${{github.event.release.body}}
           server: "matrix.parity.io"


### PR DESCRIPTION
Previous we used to send matrix notification for any edit, that ends up spamming the notification channel.
This PR only sends a notification on actuall release.

The message is also split on multiple line to make it more readable and easier to edit.