### PR TITLE
CI: fix gh doc publishing

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,9 +1,10 @@
 name: Publish Rust Docs
 
 on:
-  push:
-    branches:
-      - master
+  pull_request:
+  # push:
+  #   branches:
+  #     - master
 
 jobs:
   deploy-docs:
@@ -12,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/actions/checkout@v2.3.4
+        uses: actions/checkout@v2.3.4
 
       - name: Rust show versions
-        run: rustup show
+        run:  rustup show
 
       - name: Rust cache
         uses: Swatinem/rust-cache@v1
@@ -29,7 +30,7 @@ jobs:
       # Make an index.html file that redirects to the cumulus-client-collator page
       # Copied from https://github.com/substrate-developer-hub/rustdocs/blob/master/index.html
       - name: Make index.html
-        run: echo "<meta http-equiv=refresh content=0;url=cumulus_client_collator/index.html>" > ./target/doc/index.html
+        run:  echo "<meta http-equiv=refresh content=0;url=cumulus_client_collator/index.html>" > ./target/doc/index.html
 
       - name: Deploy documentation
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Rust toolchains and versions
         run:  |
-          rustup toolchain install nightly
+          rustup toolchain install nightly --target wasm32-unknown-unknown
           rustup show
           rustup +nightly show
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,8 +15,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2.3.4
 
-      - name: Rust show versions
-        run:  rustup show
+      - name: Rust toolchains and versions
+        run:  |
+          rustup toolchain install nightly
+          rustup show
+          rustup +nightly show
 
       - name: Rust cache
         uses: Swatinem/rust-cache@v1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,10 +1,9 @@
 name: Publish Rust Docs
 
 on:
-  pull_request:
-  # push:
-  #   branches:
-  #     - master
+  push:
+    branches:
+      - master
 
 jobs:
   deploy-docs:
@@ -30,8 +29,6 @@ jobs:
           command: doc
           args: --all --no-deps
 
-      # Make an index.html file that redirects to the cumulus-client-collator page
-      # Copied from https://github.com/substrate-developer-hub/rustdocs/blob/master/index.html
       - name: Make index.html
         run:  echo "<meta http-equiv=refresh content=0;url=cumulus_client_collator/index.html>" > ./target/doc/index.html
 


### PR DESCRIPTION
the `cargo doc` job takes 55 minutes! I'll rewrite it to gitlab CI. Just merge this fix for now.
Docs are published at https://paritytech.github.io/cumulus.