### PR TITLE
chore: bump subwasm version to support V14 runtimes

### DIFF
--- a/.github/workflows/srtool.yml
+++ b/.github/workflows/srtool.yml
@@ -1,7 +1,7 @@
 name: Srtool build
 
 env:
-  SUBWASM_VERSION: 0.13.2
+  SUBWASM_VERSION: 0.14.1
 
 on:
   push:


### PR DESCRIPTION
This bumps subwasm to the latest version in order to be able to decode V14 runtimes.

That will resolve the CI issues we can see [here](https://github.com/paritytech/cumulus/actions/workflows/srtool.yml).