### PR TITLE
Add extrincic ordering check to CI

### DIFF
--- a/.github/workflows/extrinsic-ordering-check-from-bin.yml
+++ b/.github/workflows/extrinsic-ordering-check-from-bin.yml
@@ -70,7 +70,9 @@ jobs:
           cat output.txt
 
       - name: Stop our local node
-        run: pkill polkadot-collator || return 0
+        run: |
+          pkill polkadot-collator
+        continue-on-error: true
 
       - name: Save output as artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/extrinsic-ordering-check-from-bin.yml
+++ b/.github/workflows/extrinsic-ordering-check-from-bin.yml
@@ -1,0 +1,80 @@
+# This workflow performs the Extrinsic Ordering Check on demand using a binary
+
+name: Extrinsic Ordering Check from Binary
+on:
+  workflow_dispatch:
+    inputs:
+      reference_url:
+        description: The WebSocket url of the reference node
+        default: wss://kusama-statemine-rpc.paritytech.net
+        required: true
+      binary_url:
+        description: A url to a Linux binary for the node containing the runtime to test
+        default: https://github.com/paritytech/cumulus/releases/download/statemine_v3/polkadot-collator
+        required: true
+      chain:
+        description: The name of the chain under test. Usually, you would pass a local chain
+        default: local
+        required: true
+
+jobs:
+  check:
+    name: Run check
+    runs-on: ubuntu-latest
+    env:
+      CHAIN: ${{github.event.inputs.chain}}
+      BIN_URL: ${{github.event.inputs.binary_url}}
+      REF_URL: ${{github.event.inputs.reference_url}}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Fetch binary
+        run: |
+          echo Fetching $BIN_URL
+          wget $BIN_URL
+          chmod a+x polkadot-collator
+          ./polkadot-collator --version
+
+      - name: Start local node
+        run: |
+          echo Running on $CHAIN
+          ./polkadot-collator --chain=$CHAIN &
+
+      - name: Prepare output
+        run: |
+          VERSION=$(./polkadot-collator --version)
+          echo "Metadata comparison:" >> output.txt
+          echo "Date: $(date)" >> output.txt
+          echo "Reference: $REF_URL" >> output.txt
+          echo "Target version: $VERSION" >> output.txt
+          echo "Chain: $CHAIN" >> output.txt
+          echo "----------------------------------------------------------------------" >> output.txt
+
+      - name: Pull polkadot-js-tools image
+        run: docker pull jacogr/polkadot-js-tools
+
+      - name: Compare the metadata
+        run: |
+          CMD="docker run --pull always --network host jacogr/polkadot-js-tools metadata $REF_URL ws://localhost:9944"
+          echo -e "Running:\n$CMD"
+          $CMD >> output.txt
+          sed -z -i 's/\n\n/\n/g' output.txt
+          cat output.txt | egrep -n -i ''
+          SUMMARY=$(./scripts/github/extrinsic-ordering-filter.sh output.txt)
+          echo -e $SUMMARY
+          echo -e $SUMMARY >> output.txt
+
+      - name: Show result
+        run: |
+          cat output.txt
+
+      - name: Stop our local node
+        run: pkill polkadot-collator
+
+      - name: Save output as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.CHAIN }}
+          path: |
+            output.txt

--- a/.github/workflows/extrinsic-ordering-check-from-bin.yml
+++ b/.github/workflows/extrinsic-ordering-check-from-bin.yml
@@ -61,7 +61,7 @@ jobs:
           $CMD >> output.txt
           sed -z -i 's/\n\n/\n/g' output.txt
           cat output.txt | egrep -n -i ''
-          SUMMARY=$(./scripts/github/extrinsic-ordering-filter.sh output.txt)
+          SUMMARY=$(./scripts/extrinsic-ordering-filter.sh output.txt)
           echo -e $SUMMARY
           echo -e $SUMMARY >> output.txt
 

--- a/.github/workflows/extrinsic-ordering-check-from-bin.yml
+++ b/.github/workflows/extrinsic-ordering-check-from-bin.yml
@@ -14,7 +14,7 @@ on:
         required: true
       chain:
         description: The name of the chain under test. Usually, you would pass a local chain
-        default: local
+        default: statemine
         required: true
 
 jobs:

--- a/.github/workflows/extrinsic-ordering-check-from-bin.yml
+++ b/.github/workflows/extrinsic-ordering-check-from-bin.yml
@@ -70,7 +70,7 @@ jobs:
           cat output.txt
 
       - name: Stop our local node
-        run: pkill polkadot-collator
+        run: pkill polkadot-collator || return 0
 
       - name: Save output as artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/extrinsic-ordering-check-from-bin.yml
+++ b/.github/workflows/extrinsic-ordering-check-from-bin.yml
@@ -14,7 +14,7 @@ on:
         required: true
       chain:
         description: The name of the chain under test. Usually, you would pass a local chain
-        default: statemine
+        default: statemine-local
         required: true
 
 jobs:
@@ -39,7 +39,7 @@ jobs:
       - name: Start local node
         run: |
           echo Running on $CHAIN
-          ./polkadot-collator --chain=$CHAIN &
+          ./polkadot-collator --chain=$CHAIN -- --chain polkadot-local &
 
       - name: Prepare output
         run: |

--- a/scripts/extrinsic-ordering-filter.sh
+++ b/scripts/extrinsic-ordering-filter.sh
@@ -8,7 +8,7 @@ FILE=$1
 
 # Higlight indexes that were deleted
 function find_deletions() {
-    printf "\n## Deletions\n"
+    echo "\n## Deletions\n"
     RES=$(cat "$FILE" | grep -n '\[\-\]' | tr -s " ")
     if [ "$RES" ]; then
         echo "$RES" | awk '{ printf "%s\\n", $0 }'
@@ -19,7 +19,7 @@ function find_deletions() {
 
 # Highlight indexes that have been deleted
 function find_index_changes() {
-    printf "\n## Index changes\n"
+    echo "\n## Index changes\n"
     RES=$(cat "$FILE" | grep -E -n -i 'idx:\s*([0-9]+)\s*(->)\s*([0-9]+)' | tr -s " ")
     if [ "$RES" ]; then
         echo "$RES" | awk '{ printf "%s\\n", $0 }'
@@ -30,7 +30,7 @@ function find_index_changes() {
 
 # Highlight values that decreased
 function find_decreases() {
-    printf "\n## Decreases\n"
+    echo "\n## Decreases\n"
     OUT=$(cat "$FILE" | grep -E -i -o '([0-9]+)\s*(->)\s*([0-9]+)' | awk '$1 > $3 { printf "%s;", $0 }')
     IFS=$';' LIST=("$OUT")
     unset RES
@@ -45,11 +45,11 @@ function find_decreases() {
     fi
 }
 
-printf "\n------------------------------ SUMMARY -------------------------------"
-printf "\n⚠️ This filter is here to help spotting changes that should be reviewed carefully."
-printf "\n⚠️ It catches only index changes, deletions and value decreases".
+echo "\n------------------------------ SUMMARY -------------------------------"
+echo "\n⚠️ This filter is here to help spotting changes that should be reviewed carefully."
+echo "\n⚠️ It catches only index changes, deletions and value decreases".
 
 find_deletions "$FILE"
 find_index_changes "$FILE"
 find_decreases "$FILE"
-printf "\n----------------------------------------------------------------------\n"
+echo "\n----------------------------------------------------------------------\n"

--- a/scripts/extrinsic-ordering-filter.sh
+++ b/scripts/extrinsic-ordering-filter.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# This script is used in a Github Workflow. It helps filtering out what is interesting
+# when comparing metadata and spot what would require a tx version bump.
+
+# shellcheck disable=SC2002,SC2086
+
+FILE=$1
+
+# Higlight indexes that were deleted
+function find_deletions() {
+    printf "\n## Deletions\n"
+    RES=$(cat "$FILE" | grep -n '\[\-\]' | tr -s " ")
+    if [ "$RES" ]; then
+        echo "$RES" | awk '{ printf "%s\\n", $0 }'
+    else
+        echo "n/a"
+    fi
+}
+
+# Highlight indexes that have been deleted
+function find_index_changes() {
+    printf "\n## Index changes\n"
+    RES=$(cat "$FILE" | grep -E -n -i 'idx:\s*([0-9]+)\s*(->)\s*([0-9]+)' | tr -s " ")
+    if [ "$RES" ]; then
+        echo "$RES" | awk '{ printf "%s\\n", $0 }'
+    else
+        echo "n/a"
+    fi
+}
+
+# Highlight values that decreased
+function find_decreases() {
+    printf "\n## Decreases\n"
+    OUT=$(cat "$FILE" | grep -E -i -o '([0-9]+)\s*(->)\s*([0-9]+)' | awk '$1 > $3 { printf "%s;", $0 }')
+    IFS=$';' LIST=("$OUT")
+    unset RES
+    for line in "${LIST[@]}"; do
+        RES="$RES\n$(cat "$FILE" | grep -E -i -n \"$line\" | tr -s " ")"
+    done
+
+    if [ "$RES" ]; then
+        echo "$RES" | awk '{ printf "%s\\n", $0 }' | sort -u -g | uniq
+    else
+        echo "n/a"
+    fi
+}
+
+printf "\n------------------------------ SUMMARY -------------------------------"
+printf "\n⚠️ This filter is here to help spotting changes that should be reviewed carefully."
+printf "\n⚠️ It catches only index changes, deletions and value decreases".
+
+find_deletions "$FILE"
+find_index_changes "$FILE"
+find_decreases "$FILE"
+printf "\n----------------------------------------------------------------------\n"


### PR DESCRIPTION
This PR adds running a manual check for the extrinsic ordering.
A test run can be seen here: https://github.com/chevdor/cumulus/actions/runs/1287438927

What currently fails for some reason atm is not critical, the CI seems to fail killing the `polkadot-collator` (it works fine with `polkadot`).