### PR TITLE
use PolkadotXcm for XcmRouter WrapVersion

### DIFF
--- a/polkadot-parachains/statemine/src/lib.rs
+++ b/polkadot-parachains/statemine/src/lib.rs
@@ -595,7 +595,7 @@ pub type LocalOriginToLocation = ();
 /// queues.
 pub type XcmRouter = (
 	// Two routers - use UMP to communicate with the relay chain:
-	cumulus_primitives_utility::ParentAsUmp<ParachainSystem, ()>,
+	cumulus_primitives_utility::ParentAsUmp<ParachainSystem, PolkadotXcm>,
 	// ..and XCMP to communicate with the sibling chains.
 	XcmpQueue,
 );


### PR DESCRIPTION
Any reason why this isn't used?