### PR TITLE
Feature gate client side of parachain inherent

### DIFF
--- a/primitives/parachain-inherent/Cargo.toml
+++ b/primitives/parachain-inherent/Cargo.toml
@@ -30,6 +30,7 @@ tracing = { version = "0.1.22", optional = true }
 
 [features]
 default = [ "std" ]
+client-side = ["polkadot-client", "std"]
 std = [
 	"async-trait",
 	"codec/std",
@@ -44,6 +45,5 @@ std = [
 	"sp-runtime",
 	"sc-client-api",
 	"sp-api",
-	"polkadot-client",
 	"cumulus-test-relay-sproof-builder"
 ]

--- a/primitives/parachain-inherent/src/lib.rs
+++ b/primitives/parachain-inherent/src/lib.rs
@@ -35,9 +35,9 @@ use scale_info::TypeInfo;
 use sp_inherents::InherentIdentifier;
 use sp_std::{collections::btree_map::BTreeMap, vec::Vec};
 
-#[cfg(feature = "std")]
+#[cfg(feature = "client-side")]
 mod client_side;
-#[cfg(feature = "std")]
+#[cfg(feature = "client-side")]
 pub use client_side::*;
 #[cfg(feature = "std")]
 mod mock;


### PR DESCRIPTION
This PR adds a `client-side` feature to the `cumulus-primitives-parachain-inherent` crate. Previously the client-side features were gated only with the `std` feature. This solution was not ideal because runtimes are also built to `std`, and when they are the entire client-side of this crate is built including its dependency on polkadot runtime which adds a lot of compile time.

With this new feature, we can express whether we want the client side or not without abusing the std feature.