### PR TITLE
Remove `parachain-id` cli command

### DIFF
--- a/client/cli/src/lib.rs
+++ b/client/cli/src/lib.rs
@@ -125,10 +125,6 @@ pub struct RunCmd {
 	#[structopt(flatten)]
 	pub base: sc_cli::RunCmd,
 
-	/// Id of the parachain this collator collates for.
-	#[structopt(long)]
-	pub parachain_id: Option<u32>,
-
 	/// Run node as collator.
 	///
 	/// Note that this is the same as running with `--validator`.
@@ -142,8 +138,6 @@ pub struct RunCmd {
 pub struct NormalizedRunCmd {
 	/// The cumulus RunCmd inherents from sc_cli's
 	pub base: sc_cli::RunCmd,
-	/// Id of the parachain this collator collates for.
-	pub parachain_id: Option<u32>,
 }
 
 impl RunCmd {
@@ -153,7 +147,7 @@ impl RunCmd {
 
 		new_base.validator = self.base.validator || self.collator;
 
-		NormalizedRunCmd { base: new_base, parachain_id: self.parachain_id }
+		NormalizedRunCmd { base: new_base }
 	}
 }
 

--- a/parachain-template/node/src/chain_spec.rs
+++ b/parachain-template/node/src/chain_spec.rs
@@ -58,7 +58,7 @@ pub fn template_session_keys(keys: AuraId) -> parachain_template_runtime::Sessio
 	parachain_template_runtime::SessionKeys { aura: keys }
 }
 
-pub fn development_config(id: ParaId) -> ChainSpec {
+pub fn development_config() -> ChainSpec {
 	// Give your base currency a unit name and decimal places
 	let mut properties = sc_chain_spec::Properties::new();
 	properties.insert("tokenSymbol".into(), "ROC".into());
@@ -98,7 +98,7 @@ pub fn development_config(id: ParaId) -> ChainSpec {
 					get_account_id_from_seed::<sr25519::Public>("Eve//stash"),
 					get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"),
 				],
-				id,
+				1000.into(),
 			)
 		},
 		vec![],
@@ -107,12 +107,12 @@ pub fn development_config(id: ParaId) -> ChainSpec {
 		None,
 		Extensions {
 			relay_chain: "rococo-local".into(), // You MUST set this to the correct network!
-			para_id: id.into(),
+			para_id: 1000,
 		},
 	)
 }
 
-pub fn local_testnet_config(id: ParaId) -> ChainSpec {
+pub fn local_testnet_config() -> ChainSpec {
 	// Give your base currency a unit name and decimal places
 	let mut properties = sc_chain_spec::Properties::new();
 	properties.insert("tokenSymbol".into(), "ROC".into());
@@ -152,7 +152,7 @@ pub fn local_testnet_config(id: ParaId) -> ChainSpec {
 					get_account_id_from_seed::<sr25519::Public>("Eve//stash"),
 					get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"),
 				],
-				id,
+				1000.into(),
 			)
 		},
 		// Bootnodes
@@ -166,7 +166,7 @@ pub fn local_testnet_config(id: ParaId) -> ChainSpec {
 		// Extensions
 		Extensions {
 			relay_chain: "rococo-local".into(), // You MUST set this to the correct network!
-			para_id: id.into(),
+			para_id: 1000,
 		},
 	)
 }

--- a/parachain-template/node/src/cli.rs
+++ b/parachain-template/node/src/cli.rs
@@ -46,12 +46,6 @@ pub struct ExportGenesisStateCommand {
 	#[structopt(parse(from_os_str))]
 	pub output: Option<PathBuf>,
 
-	/// Id of the parachain this state is for.
-	///
-	/// Default: 100
-	#[structopt(long, conflicts_with = "chain")]
-	pub parachain_id: Option<u32>,
-
 	/// Write output in binary. Default is to write in hex.
 	#[structopt(short, long)]
 	pub raw: bool,

--- a/parachain-template/node/src/command.rs
+++ b/parachain-template/node/src/command.rs
@@ -18,14 +18,11 @@ use sp_core::hexdisplay::HexDisplay;
 use sp_runtime::traits::Block as BlockT;
 use std::{io::Write, net::SocketAddr};
 
-fn load_spec(
-	id: &str,
-	para_id: ParaId,
-) -> std::result::Result<Box<dyn sc_service::ChainSpec>, String> {
+fn load_spec(id: &str) -> std::result::Result<Box<dyn sc_service::ChainSpec>, String> {
 	Ok(match id {
-		"dev" => Box::new(chain_spec::development_config(para_id)),
-		"template-rococo" => Box::new(chain_spec::local_testnet_config(para_id)),
-		"" | "local" => Box::new(chain_spec::local_testnet_config(para_id)),
+		"dev" => Box::new(chain_spec::development_config()),
+		"template-rococo" => Box::new(chain_spec::local_testnet_config()),
+		"" | "local" => Box::new(chain_spec::local_testnet_config()),
 		path => Box::new(chain_spec::ChainSpec::from_json_file(std::path::PathBuf::from(path))?),
 	})
 }
@@ -62,7 +59,7 @@ impl SubstrateCli for Cli {
 	}
 
 	fn load_spec(&self, id: &str) -> std::result::Result<Box<dyn sc_service::ChainSpec>, String> {
-		load_spec(id, self.run.parachain_id.unwrap_or(2000).into())
+		load_spec(id)
 	}
 
 	fn native_runtime_version(_: &Box<dyn ChainSpec>) -> &'static RuntimeVersion {
@@ -194,10 +191,8 @@ pub fn run() -> Result<()> {
 			builder.with_profiling(sc_tracing::TracingReceiver::Log, "");
 			let _ = builder.init();
 
-			let block: Block = generate_genesis_block(&load_spec(
-				&params.chain.clone().unwrap_or_default(),
-				params.parachain_id.unwrap_or(2000).into(),
-			)?)?;
+			let block: Block =
+				generate_genesis_block(&load_spec(&params.chain.clone().unwrap_or_default())?)?;
 			let raw_header = block.header().encode();
 			let output_buf = if params.raw {
 				raw_header
@@ -248,15 +243,16 @@ pub fn run() -> Result<()> {
 			let runner = cli.create_runner(&cli.run.normalize())?;
 
 			runner.run_node_until_exit(|config| async move {
-				let para_id =
-					chain_spec::Extensions::try_get(&*config.chain_spec).map(|e| e.para_id);
+				let para_id = chain_spec::Extensions::try_get(&*config.chain_spec)
+					.map(|e| e.para_id)
+					.ok_or_else(|| "Could not find parachain extension for chain-spec.")?;
 
 				let polkadot_cli = RelayChainCli::new(
 					&config,
 					[RelayChainCli::executable_name()].iter().chain(cli.relaychain_args.iter()),
 				);
 
-				let id = ParaId::from(cli.run.parachain_id.or(para_id).unwrap_or(2000));
+				let id = ParaId::from(para_id);
 
 				let parachain_account =
 					AccountIdConversion::<polkadot_primitives::v0::AccountId>::into_account(&id);

--- a/polkadot-parachains/src/chain_spec.rs
+++ b/polkadot-parachains/src/chain_spec.rs
@@ -64,7 +64,7 @@ where
 	AccountPublic::from(get_from_seed::<TPublic>(seed)).into_account()
 }
 
-pub fn get_chain_spec(id: ParaId) -> ChainSpec {
+pub fn get_chain_spec() -> ChainSpec {
 	ChainSpec::from_genesis(
 		"Local Testnet",
 		"local_testnet",
@@ -87,32 +87,32 @@ pub fn get_chain_spec(id: ParaId) -> ChainSpec {
 					get_account_id_from_seed::<sr25519::Public>("Eve//stash"),
 					get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"),
 				],
-				id,
+				1000.into(),
 			)
 		},
 		vec![],
 		None,
 		None,
 		None,
-		Extensions { relay_chain: "westend".into(), para_id: id.into() },
+		Extensions { relay_chain: "westend".into(), para_id: 1000 },
 	)
 }
 
-pub fn get_shell_chain_spec(id: ParaId) -> ShellChainSpec {
+pub fn get_shell_chain_spec() -> ShellChainSpec {
 	ShellChainSpec::from_genesis(
 		"Shell Local Testnet",
 		"shell_local_testnet",
 		ChainType::Local,
-		move || shell_testnet_genesis(id),
+		move || shell_testnet_genesis(1000.into()),
 		vec![],
 		None,
 		None,
 		None,
-		Extensions { relay_chain: "westend".into(), para_id: id.into() },
+		Extensions { relay_chain: "westend".into(), para_id: 1000 },
 	)
 }
 
-pub fn staging_test_net(id: ParaId) -> ChainSpec {
+pub fn staging_test_net() -> ChainSpec {
 	ChainSpec::from_genesis(
 		"Staging Testnet",
 		"staging_testnet",
@@ -131,14 +131,14 @@ pub fn staging_test_net(id: ParaId) -> ChainSpec {
 				vec![
 					hex!["9ed7705e3c7da027ba0583a22a3212042f7e715d3c168ba14f1424e2bc111d00"].into()
 				],
-				id,
+				1000.into(),
 			)
 		},
 		Vec::new(),
 		None,
 		None,
 		None,
-		Extensions { relay_chain: "westend".into(), para_id: id.into() },
+		Extensions { relay_chain: "westend".into(), para_id: 1000 },
 	)
 }
 
@@ -228,7 +228,7 @@ pub fn westmint_session_keys(keys: AuraId) -> westmint_runtime::SessionKeys {
 	westmint_runtime::SessionKeys { aura: keys }
 }
 
-pub fn statemint_development_config(id: ParaId) -> StatemintChainSpec {
+pub fn statemint_development_config() -> StatemintChainSpec {
 	let mut properties = sc_chain_spec::Properties::new();
 	properties.insert("tokenSymbol".into(), "DOT".into());
 	properties.insert("tokenDecimals".into(), 10.into());
@@ -252,18 +252,18 @@ pub fn statemint_development_config(id: ParaId) -> StatemintChainSpec {
 					get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
 					get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
 				],
-				id,
+				1000.into(),
 			)
 		},
 		vec![],
 		None,
 		None,
 		Some(properties),
-		Extensions { relay_chain: "polkadot-dev".into(), para_id: id.into() },
+		Extensions { relay_chain: "polkadot-dev".into(), para_id: 1000 },
 	)
 }
 
-pub fn statemint_local_config(id: ParaId) -> StatemintChainSpec {
+pub fn statemint_local_config() -> StatemintChainSpec {
 	let mut properties = sc_chain_spec::Properties::new();
 	properties.insert("tokenSymbol".into(), "DOT".into());
 	properties.insert("tokenDecimals".into(), 10.into());
@@ -301,14 +301,14 @@ pub fn statemint_local_config(id: ParaId) -> StatemintChainSpec {
 					get_account_id_from_seed::<sr25519::Public>("Eve//stash"),
 					get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"),
 				],
-				id,
+				1000.into(),
 			)
 		},
 		vec![],
 		None,
 		None,
 		Some(properties),
-		Extensions { relay_chain: "polkadot-local".into(), para_id: id.into() },
+		Extensions { relay_chain: "polkadot-local".into(), para_id: 1000 },
 	)
 }
 
@@ -354,7 +354,7 @@ fn statemint_genesis(
 	}
 }
 
-pub fn statemine_development_config(id: ParaId) -> StatemineChainSpec {
+pub fn statemine_development_config() -> StatemineChainSpec {
 	let mut properties = sc_chain_spec::Properties::new();
 	properties.insert("tokenSymbol".into(), "KSM".into());
 	properties.insert("tokenDecimals".into(), 12.into());
@@ -378,18 +378,18 @@ pub fn statemine_development_config(id: ParaId) -> StatemineChainSpec {
 					get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
 					get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
 				],
-				id,
+				1000.into(),
 			)
 		},
 		vec![],
 		None,
 		None,
 		Some(properties),
-		Extensions { relay_chain: "kusama-dev".into(), para_id: id.into() },
+		Extensions { relay_chain: "kusama-dev".into(), para_id: 1000 },
 	)
 }
 
-pub fn statemine_local_config(id: ParaId) -> StatemineChainSpec {
+pub fn statemine_local_config() -> StatemineChainSpec {
 	let mut properties = sc_chain_spec::Properties::new();
 	properties.insert("tokenSymbol".into(), "KSM".into());
 	properties.insert("tokenDecimals".into(), 12.into());
@@ -427,18 +427,18 @@ pub fn statemine_local_config(id: ParaId) -> StatemineChainSpec {
 					get_account_id_from_seed::<sr25519::Public>("Eve//stash"),
 					get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"),
 				],
-				id,
+				1000.into(),
 			)
 		},
 		vec![],
 		None,
 		None,
 		Some(properties),
-		Extensions { relay_chain: "kusama-local".into(), para_id: id.into() },
+		Extensions { relay_chain: "kusama-local".into(), para_id: 1000 },
 	)
 }
 
-pub fn statemine_config(id: ParaId) -> StatemineChainSpec {
+pub fn statemine_config() -> StatemineChainSpec {
 	let mut properties = sc_chain_spec::Properties::new();
 	properties.insert("tokenSymbol".into(), "KSM".into());
 	properties.insert("tokenDecimals".into(), 12.into());
@@ -479,14 +479,14 @@ pub fn statemine_config(id: ParaId) -> StatemineChainSpec {
 					),
 				],
 				vec![],
-				id,
+				1000.into(),
 			)
 		},
 		vec![],
 		None,
 		None,
 		Some(properties),
-		Extensions { relay_chain: "kusama".into(), para_id: id.into() },
+		Extensions { relay_chain: "kusama".into(), para_id: 1000 },
 	)
 }
 
@@ -530,7 +530,7 @@ fn statemine_genesis(
 	}
 }
 
-pub fn westmint_development_config(id: ParaId) -> WestmintChainSpec {
+pub fn westmint_development_config() -> WestmintChainSpec {
 	let mut properties = sc_chain_spec::Properties::new();
 	properties.insert("tokenSymbol".into(), "WND".into());
 	properties.insert("tokenDecimals".into(), 12.into());
@@ -555,18 +555,18 @@ pub fn westmint_development_config(id: ParaId) -> WestmintChainSpec {
 					get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
 				],
 				get_account_id_from_seed::<sr25519::Public>("Alice"),
-				id,
+				1000.into(),
 			)
 		},
 		vec![],
 		None,
 		None,
 		Some(properties),
-		Extensions { relay_chain: "westend".into(), para_id: id.into() },
+		Extensions { relay_chain: "westend".into(), para_id: 1000 },
 	)
 }
 
-pub fn westmint_local_config(id: ParaId) -> WestmintChainSpec {
+pub fn westmint_local_config() -> WestmintChainSpec {
 	let mut properties = sc_chain_spec::Properties::new();
 	properties.insert("tokenSymbol".into(), "WND".into());
 	properties.insert("tokenDecimals".into(), 12.into());
@@ -605,18 +605,18 @@ pub fn westmint_local_config(id: ParaId) -> WestmintChainSpec {
 					get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"),
 				],
 				get_account_id_from_seed::<sr25519::Public>("Alice"),
-				id,
+				1000.into(),
 			)
 		},
 		vec![],
 		None,
 		None,
 		Some(properties),
-		Extensions { relay_chain: "westend-local".into(), para_id: id.into() },
+		Extensions { relay_chain: "westend-local".into(), para_id: 1000 },
 	)
 }
 
-pub fn westmint_config(id: ParaId) -> WestmintChainSpec {
+pub fn westmint_config() -> WestmintChainSpec {
 	let mut properties = sc_chain_spec::Properties::new();
 	properties.insert("tokenSymbol".into(), "WND".into());
 	properties.insert("tokenDecimals".into(), 12.into());
@@ -659,14 +659,14 @@ pub fn westmint_config(id: ParaId) -> WestmintChainSpec {
 				vec![],
 				// re-use the Westend sudo key
 				hex!("6648d7f3382690650c681aba1b993cd11e54deb4df21a3a18c3e2177de9f7342").into(),
-				id,
+				1000.into(),
 			)
 		},
 		vec![],
 		None,
 		None,
 		Some(properties),
-		Extensions { relay_chain: "westend".into(), para_id: id.into() },
+		Extensions { relay_chain: "westend".into(), para_id: 1000 },
 	)
 }
 


### PR DESCRIPTION
This was never planned to be a permanent feature. This was mainly added for testing purposes, but
now was copied by everybody. The users should be more specific about the para id and set this
properly in the chain spec.