### PR TITLE
Fix package naming conflict

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6527,7 +6527,7 @@ dependencies = [
  "polkadot-parachain",
  "polkadot-primitives",
  "polkadot-service",
- "rococo-runtime 0.1.0",
+ "rococo-parachain-runtime",
  "sc-basic-authorship",
  "sc-chain-spec",
  "sc-cli",
@@ -7424,7 +7424,7 @@ dependencies = [
  "polkadot-runtime",
  "polkadot-runtime-parachains",
  "polkadot-statement-distribution",
- "rococo-runtime 0.9.12",
+ "rococo-runtime",
  "sc-authority-discovery",
  "sc-basic-authorship",
  "sc-block-builder",
@@ -8258,7 +8258,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "rococo-runtime"
+name = "rococo-parachain-runtime"
 version = "0.1.0"
 dependencies = [
  "cumulus-pallet-aura-ext",

--- a/polkadot-parachains/Cargo.toml
+++ b/polkadot-parachains/Cargo.toml
@@ -19,7 +19,7 @@ hex-literal = "0.2.1"
 async-trait = "0.1.42"
 
 # Parachain runtimes
-rococo-parachain-runtime = { package = "rococo-runtime", path = "rococo" }
+rococo-parachain-runtime = { package = "rococo-parachain-runtime", path = "rococo" }
 shell-runtime = { path = "shell" }
 statemint-runtime = { path = "statemint" }
 statemine-runtime = { path = "statemine" }

--- a/polkadot-parachains/rococo/Cargo.toml
+++ b/polkadot-parachains/rococo/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = 'rococo-runtime'
+name = 'rococo-parachain-runtime'
 version = '0.1.0'
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = '2018'


### PR DESCRIPTION
Fixes: #750 

The problem was there are two different packages with the same name: `rococo-runtime` and it was generating some conflict when compiling since they have different versions too.

Not sure why it is only complaining when using `--features runtime-benchmarks`