### PR TITLE
move to rust 2021

### DIFF
--- a/client/cli/Cargo.toml
+++ b/client/cli/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cumulus-client-cli"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 structopt = "0.3.3"

--- a/client/collator/Cargo.toml
+++ b/client/collator/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cumulus-client-collator"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 # Substrate dependencies

--- a/client/consensus/aura/Cargo.toml
+++ b/client/consensus/aura/Cargo.toml
@@ -3,7 +3,7 @@ name = "cumulus-client-consensus-aura"
 description = "AURA consensus algorithm for parachains"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 # Substrate dependencies

--- a/client/consensus/common/Cargo.toml
+++ b/client/consensus/common/Cargo.toml
@@ -3,7 +3,7 @@ name = "cumulus-client-consensus-common"
 description = "Cumulus specific common consensus implementations"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 # Substrate deps

--- a/client/consensus/relay-chain/Cargo.toml
+++ b/client/consensus/relay-chain/Cargo.toml
@@ -3,7 +3,7 @@ name = "cumulus-client-consensus-relay-chain"
 description = "The relay-chain provided consensus algorithm"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 # Substrate deps

--- a/client/network/Cargo.toml
+++ b/client/network/Cargo.toml
@@ -3,7 +3,7 @@ name = "cumulus-client-network"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Cumulus-specific networking protocol"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 # Substrate deps

--- a/client/pov-recovery/Cargo.toml
+++ b/client/pov-recovery/Cargo.toml
@@ -3,7 +3,7 @@ name = "cumulus-client-pov-recovery"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Cumulus-specific networking protocol"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 # Substrate deps

--- a/client/service/Cargo.toml
+++ b/client/service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cumulus-client-service"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 # Cumulus dependencies

--- a/pallets/asset-tx-payment/Cargo.toml
+++ b/pallets/asset-tx-payment/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pallet-asset-tx-payment"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 homepage = "https://substrate.io"
 repository = "https://github.com/paritytech/cumulus/"

--- a/pallets/aura-ext/Cargo.toml
+++ b/pallets/aura-ext/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cumulus-pallet-aura-ext"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
-edition = "2018"
+edition = "2021"
 description = "AURA consensus extension pallet for parachains"
 
 [dependencies]

--- a/pallets/collator-selection/Cargo.toml
+++ b/pallets/collator-selection/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ['Anonymous']
 description = 'Simple staking pallet with a fixed stake.'
-edition = '2018'
+edition = '2021'
 homepage = 'https://substrate.io'
 license = 'Apache-2.0'
 name = 'pallet-collator-selection'

--- a/pallets/collator-selection/Cargo.toml
+++ b/pallets/collator-selection/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ['Anonymous']
 description = 'Simple staking pallet with a fixed stake.'
-edition = '2021'
+edition = "2021"
 homepage = 'https://substrate.io'
 license = 'Apache-2.0'
 name = 'pallet-collator-selection'

--- a/pallets/dmp-queue/Cargo.toml
+++ b/pallets/dmp-queue/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cumulus-pallet-dmp-queue"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 # Other dependencies

--- a/pallets/parachain-system/Cargo.toml
+++ b/pallets/parachain-system/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cumulus-pallet-parachain-system"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
-edition = "2018"
+edition = "2021"
 description = "Base pallet for cumulus-based parachains"
 
 [dependencies]

--- a/pallets/parachain-system/proc-macro/Cargo.toml
+++ b/pallets/parachain-system/proc-macro/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
-edition = "2018"
+edition = "2021"
 description = "Proc macros provided by the parachain-system pallet"
 
 [lib]

--- a/pallets/session-benchmarking/Cargo.toml
+++ b/pallets/session-benchmarking/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cumulus-pallet-session-benchmarking"
 version = "3.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 homepage = "https://substrate.io"
 repository = "https://github.com/paritytech/cumulus/"

--- a/pallets/xcm/Cargo.toml
+++ b/pallets/xcm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 authors = ["Parity Technologies <admin@parity.io>"]
-edition = "2018"
+edition = "2021"
 name = "cumulus-pallet-xcm"
 version = "0.1.0"
 

--- a/pallets/xcmp-queue/Cargo.toml
+++ b/pallets/xcmp-queue/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cumulus-pallet-xcmp-queue"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 # Other dependencies

--- a/parachain-template/node/Cargo.toml
+++ b/parachain-template/node/Cargo.toml
@@ -6,7 +6,7 @@ description = "A new Cumulus FRAME-based Substrate Node, ready for hacking toget
 license = "Unlicense"
 homepage = "https://substrate.io"
 repository = "https://github.com/paritytech/cumulus/"
-edition = "2018"
+edition = "2021"
 build = "build.rs"
 
 [package.metadata.docs.rs]

--- a/parachain-template/pallets/template/Cargo.toml
+++ b/parachain-template/pallets/template/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 license = "Unlicense"
 homepage = "https://substrate.io"
 repository = "https://github.com/paritytech/substrate/"
-edition = "2018"
+edition = "2021"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/parachain-template/runtime/Cargo.toml
+++ b/parachain-template/runtime/Cargo.toml
@@ -6,7 +6,7 @@ description = "A new Cumulus FRAME-based Substrate Runtime, ready for hacking to
 license = "Unlicense"
 homepage = "https://substrate.io"
 repository = "https://github.com/paritytech/cumulus/"
-edition = "2018"
+edition = "2021"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/polkadot-parachains/Cargo.toml
+++ b/polkadot-parachains/Cargo.toml
@@ -3,7 +3,7 @@ name = "polkadot-collator"
 version = "5.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 build = "build.rs"
-edition = "2018"
+edition = "2021"
 
 [[bin]]
 name = "polkadot-collator"

--- a/polkadot-parachains/pallets/parachain-info/Cargo.toml
+++ b/polkadot-parachains/pallets/parachain-info/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 authors = ["Parity Technologies <admin@parity.io>"]
-edition = "2018"
+edition = "2021"
 name = "parachain-info"
 version = "0.1.0"
 

--- a/polkadot-parachains/pallets/ping/Cargo.toml
+++ b/polkadot-parachains/pallets/ping/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 authors = ["Parity Technologies <admin@parity.io>"]
-edition = "2018"
+edition = "2021"
 name = "cumulus-ping"
 version = "0.1.0"
 

--- a/polkadot-parachains/parachains-common/Cargo.toml
+++ b/polkadot-parachains/parachains-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "parachains-common"
 version = "1.0.0"
 authors = ["Parity Technologies <admin@parity.io>"]
-edition = "2018"
+edition = "2021"
 description = "Logic which is common to all parachain runtimes"
 
 [package.metadata.docs.rs]

--- a/polkadot-parachains/rococo/Cargo.toml
+++ b/polkadot-parachains/rococo/Cargo.toml
@@ -2,7 +2,7 @@
 name = 'rococo-runtime'
 version = '0.1.0'
 authors = ["Parity Technologies <admin@parity.io>"]
-edition = '2018'
+edition = '2021'
 description = "Simple runtime used by the rococo parachain(s)"
 
 [dependencies]

--- a/polkadot-parachains/rococo/Cargo.toml
+++ b/polkadot-parachains/rococo/Cargo.toml
@@ -2,7 +2,7 @@
 name = 'rococo-runtime'
 version = '0.1.0'
 authors = ["Parity Technologies <admin@parity.io>"]
-edition = '2021'
+edition = "2021"
 description = "Simple runtime used by the rococo parachain(s)"
 
 [dependencies]

--- a/polkadot-parachains/shell/Cargo.toml
+++ b/polkadot-parachains/shell/Cargo.toml
@@ -2,7 +2,7 @@
 name = 'shell-runtime'
 version = '0.1.0'
 authors = ["Parity Technologies <admin@parity.io>"]
-edition = '2021'
+edition = "2021"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.3.0", default-features = false, features = ["derive"] }

--- a/polkadot-parachains/shell/Cargo.toml
+++ b/polkadot-parachains/shell/Cargo.toml
@@ -2,7 +2,7 @@
 name = 'shell-runtime'
 version = '0.1.0'
 authors = ["Parity Technologies <admin@parity.io>"]
-edition = '2018'
+edition = '2021'
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.3.0", default-features = false, features = ["derive"] }

--- a/polkadot-parachains/statemine/Cargo.toml
+++ b/polkadot-parachains/statemine/Cargo.toml
@@ -2,7 +2,7 @@
 name = 'statemine-runtime'
 version = '2.0.0'
 authors = ["Parity Technologies <admin@parity.io>"]
-edition = '2021'
+edition = "2021"
 description = "Kusama variant of Statemint parachain runtime"
 
 [dependencies]

--- a/polkadot-parachains/statemine/Cargo.toml
+++ b/polkadot-parachains/statemine/Cargo.toml
@@ -2,7 +2,7 @@
 name = 'statemine-runtime'
 version = '2.0.0'
 authors = ["Parity Technologies <admin@parity.io>"]
-edition = '2018'
+edition = '2021'
 description = "Kusama variant of Statemint parachain runtime"
 
 [dependencies]

--- a/polkadot-parachains/statemint/Cargo.toml
+++ b/polkadot-parachains/statemint/Cargo.toml
@@ -2,7 +2,7 @@
 name = 'statemint-runtime'
 version = '1.0.0'
 authors = ["Parity Technologies <admin@parity.io>"]
-edition = '2021'
+edition = "2021"
 description = "Statemint parachain runtime"
 
 [dependencies]

--- a/polkadot-parachains/statemint/Cargo.toml
+++ b/polkadot-parachains/statemint/Cargo.toml
@@ -2,7 +2,7 @@
 name = 'statemint-runtime'
 version = '1.0.0'
 authors = ["Parity Technologies <admin@parity.io>"]
-edition = '2018'
+edition = '2021'
 description = "Statemint parachain runtime"
 
 [dependencies]

--- a/polkadot-parachains/westmint/Cargo.toml
+++ b/polkadot-parachains/westmint/Cargo.toml
@@ -2,7 +2,7 @@
 name = 'westmint-runtime'
 version = '1.0.0'
 authors = ["Parity Technologies <admin@parity.io>"]
-edition = '2018'
+edition = '2021'
 description = "Westend variant of Statemint parachain runtime"
 
 [dependencies]

--- a/polkadot-parachains/westmint/Cargo.toml
+++ b/polkadot-parachains/westmint/Cargo.toml
@@ -2,7 +2,7 @@
 name = 'westmint-runtime'
 version = '1.0.0'
 authors = ["Parity Technologies <admin@parity.io>"]
-edition = '2021'
+edition = "2021"
 description = "Westend variant of Statemint parachain runtime"
 
 [dependencies]

--- a/primitives/core/Cargo.toml
+++ b/primitives/core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cumulus-primitives-core"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 # Substrate dependencies

--- a/primitives/parachain-inherent/Cargo.toml
+++ b/primitives/parachain-inherent/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cumulus-primitives-parachain-inherent"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 # Substrate dependencies

--- a/primitives/timestamp/Cargo.toml
+++ b/primitives/timestamp/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cumulus-primitives-timestamp"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
-edition = "2018"
+edition = "2021"
 description = "Provides timestamp related functionality for parachains."
 
 [dependencies]

--- a/primitives/utility/Cargo.toml
+++ b/primitives/utility/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cumulus-primitives-utility"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 # Substrate dependencies

--- a/test/client/Cargo.toml
+++ b/test/client/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cumulus-test-client"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 sc-service = { git = "https://github.com/paritytech/substrate", branch = "master" }

--- a/test/relay-sproof-builder/Cargo.toml
+++ b/test/relay-sproof-builder/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cumulus-test-relay-sproof-builder"
 version = '0.1.0'
 authors = ["Parity Technologies <admin@parity.io>"]
-edition = '2021'
+edition = "2021"
 
 [dependencies]
 # Other dependencies

--- a/test/relay-sproof-builder/Cargo.toml
+++ b/test/relay-sproof-builder/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cumulus-test-relay-sproof-builder"
 version = '0.1.0'
 authors = ["Parity Technologies <admin@parity.io>"]
-edition = '2018'
+edition = '2021'
 
 [dependencies]
 # Other dependencies

--- a/test/relay-validation-worker-provider/Cargo.toml
+++ b/test/relay-validation-worker-provider/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cumulus-test-relay-validation-worker-provider"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
-edition = "2018"
+edition = "2021"
 build = "build.rs"
 
 [dependencies]

--- a/test/relay-validation-worker-provider/build.rs
+++ b/test/relay-validation-worker-provider/build.rs
@@ -65,7 +65,7 @@ fn create_project(out_dir: &Path) -> PathBuf {
 			name = "{project_name}"
 			version = "0.1.0"
 			authors = ["Parity Technologies <admin@parity.io>"]
-			edition = "2018"
+			edition = "2021"
 
 			[dependencies]
 			cumulus-test-relay-validation-worker-provider = {{ path = "{provider_path}" }}

--- a/test/runtime/Cargo.toml
+++ b/test/runtime/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cumulus-test-runtime"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.3.0", default-features = false, features = ["derive"] }

--- a/test/service/Cargo.toml
+++ b/test/service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cumulus-test-service"
 version = "0.1.0"
 authors = ["Parity Technologies <admin@parity.io>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "2.3.0" }


### PR DESCRIPTION
closes #758 
Confirmed to build locally on Ubuntu 20.04.3 LTS:
```
rustc 1.56.1 (59eed8a2a 2021-11-01)
rustc 1.58.0-nightly (e90c5fbbc 2021-11-12)
```