### PR TITLE
Specify edition 2021 in .rustfmt.yml

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,4 +1,5 @@
 # Basic
+edition = "2021"
 hard_tabs = true
 max_width = 100
 use_small_heuristics = "Max"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6055,7 +6055,6 @@ dependencies = [
  "polkadot-parachain",
  "polkadot-primitives",
  "polkadot-service",
- "polkadot-test-service",
  "sc-basic-authorship",
  "sc-chain-spec",
  "sc-cli",

--- a/parachain-template/node/Cargo.toml
+++ b/parachain-template/node/Cargo.toml
@@ -92,4 +92,3 @@ polkadot-cli = { git = "https://github.com/paritytech/polkadot", branch = "maste
 polkadot-parachain = { git = "https://github.com/paritytech/polkadot", branch = "master" }
 polkadot-primitives = { git = "https://github.com/paritytech/polkadot", branch = "master" }
 polkadot-service = { git = "https://github.com/paritytech/polkadot", branch = "master" }
-polkadot-test-service = { git = "https://github.com/paritytech/polkadot", branch = "master" }


### PR DESCRIPTION
This PR is mainly to fix the error `[E0670]: async fn is not permitted in the 2015 edition` when
using Vim along with rust-analyzer, also removes an unused dependency from parachain-template.

Ref: https://github.com/rust-analyzer/rust-analyzer/issues/1959

Can be also merged into #759 if you prefer.