### PR TITLE
Fix CI for runtimes and rococo

### DIFF
--- a/.github/workflows/draft_release.yml
+++ b/.github/workflows/draft_release.yml
@@ -38,6 +38,8 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.ref2 }}
 
       - name: Cache target dir
         uses: actions/cache@v2
@@ -86,6 +88,7 @@ jobs:
         with:
           fetch-depth: 0
           path: cumulus
+          ref: ${{ github.event.inputs.ref2 }}
 
       - uses: ruby/setup-ruby@v1
         with:
@@ -158,6 +161,8 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.ref2 }}
 
       - name: Download artifacts
         uses: actions/download-artifact@v2

--- a/.github/workflows/draft_release.yml
+++ b/.github/workflows/draft_release.yml
@@ -9,7 +9,7 @@ on:
         required: true
       ref2:
         description: The 'to' tag to use for the diff
-        default: HEAD
+        default: release-statemine-v6
         required: true
       pre_release:
         description: For pre-releases

--- a/.github/workflows/draft_release.yml
+++ b/.github/workflows/draft_release.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        runtime: ["shell", "statemine", "statemint", "westmint", "rococo"]
+        runtime: ["shell", "statemine", "statemint", "westmint", "rococo-parachain"]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -157,7 +157,7 @@ jobs:
       RUNTIME_DIR: polkadot-parachains
     strategy:
       matrix:
-        runtime: ["shell", "statemine", "statemint", "westmint", "rococo"]
+        runtime: ["shell", "statemine", "statemint", "westmint", "rococo-parachain"]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2


### PR DESCRIPTION
This PR fixes the release generation in CI.
It specifies the branch to checkout and provides a more appropriate default.

The full fix requires also to backport the following to the `release-statemine-v6`:
- #761
- this PR