### PR TITLE
Add srtool check in master and release branches

### DIFF
--- a/.github/workflows/srtool.yml
+++ b/.github/workflows/srtool.yml
@@ -14,6 +14,10 @@ on:
       - "scripts"
       - "test"
 
+    branches:
+      - "release*"
+      - "master"
+
   schedule:
     - cron: "00 02 * * 1" # 2AM weekly on monday
 


### PR DESCRIPTION
Until now, the [Srtool Workflow](https://github.com/paritytech/cumulus/actions/workflows/srtool.yml) was started only manually. 
This PR additionnally triggers the build to ensure the runtimes keep building when new changes are pushed to the following branches:
- master
- release branches