### PR TITLE
Fix CODEOWNERS syntax

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -19,9 +19,9 @@
 # CI
 /.github/ @paritytech/ci @chevdor
 /.gitlab-ci.yml @paritytech/ci
-/scripts/ci @paritytech/ci
-/scripts/github @paritytech/ci @chevdor
+/scripts/ci/ @paritytech/ci
+/scripts/github/ @paritytech/ci @chevdor
 /scripts/extrinsic-ordering-filter.sh @paritytech/ci @chevdor
 
 # CHANGELOG
-/scripts/changelog @chevdor
+/scripts/changelog/ @chevdor


### PR DESCRIPTION
Unfortunately I made mistake in my previous [PR](https://github.com/paritytech/cumulus/pull/778).
`CODEOWNERS` syntax requires `/` in a suffix when you're trying to refer to directory and its content. Otherwise it will be treated as a single file.
This PR fixes it.