### PR TITLE
Refactor some types in XCMP queue

### DIFF
--- a/pallets/xcmp-queue/src/lib.rs
+++ b/pallets/xcmp-queue/src/lib.rs
@@ -198,7 +198,7 @@ pub struct OutboundChannelDetails {
 	recipient: ParaId,
 	/// The state of the channel.
 	state: OutboundState,
-	/// Whether or not any signals exists in this channel.
+	/// Whether or not any signals exist in this channel.
 	signals_exist: bool,
 	/// The index of the first outbound message.
 	first_index: u16,

--- a/pallets/xcmp-queue/src/lib.rs
+++ b/pallets/xcmp-queue/src/lib.rs
@@ -124,6 +124,8 @@ pub mod pallet {
 
 	/// Status of the inbound XCMP channels.
 	#[pallet::storage]
+	// Whenever there is a need for a storage migration, remove this prefix renaming and migrate
+	// the storage item name to InboundChannelStatus
 	#[pallet::storage_prefix = "InboundXcmpStatus"]
 	pub(super) type InboundChannelStatus<T: Config> =
 		StorageValue<_, Vec<InboundChannelDetails>, ValueQuery>;
@@ -147,6 +149,8 @@ pub mod pallet {
 	/// case of the need to send a high-priority signal message this block.
 	/// The bool is true if there is a signal message waiting to be sent.
 	#[pallet::storage]
+	// Whenever there is a need for a storage migration, remove this prefix renaming and migrate
+	// the storage item name to OutboundChannelStatus
 	#[pallet::storage_prefix = "OutboundXcmpStatus"]
 	pub(super) type OutboundChannelStatus<T: Config> =
 		StorageValue<_, Vec<OutboundChannelDetails>, ValueQuery>;

--- a/pallets/xcmp-queue/src/lib.rs
+++ b/pallets/xcmp-queue/src/lib.rs
@@ -177,19 +177,32 @@ pub enum OutboundState {
 	Suspended,
 }
 
+/// Struct containing detailed information about the inbound channel.
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, TypeInfo)]
 pub struct InboundChannelDetails {
+	/// The `ParaId` of the parachain that this channel is connected with.
 	sender: ParaId,
+	/// The state of the channel.
 	state: InboundState,
+	/// The ordered metadata of each inbound message.
+	///
+	/// Contains info about the relay block number that the message was sent at, and the format
+	/// of the incoming message.
 	message_metadata: Vec<(RelayBlockNumber, XcmpMessageFormat)>,
 }
 
+/// Struct containing detailed information about the outbound channel.
 #[derive(Clone, Eq, PartialEq, Encode, Decode, TypeInfo)]
 pub struct OutboundChannelDetails {
+	/// The `ParaId` of the parachain that this channel is connected with.
 	recipient: ParaId,
+	/// The state of the channel.
 	state: OutboundState,
+	/// Whether or not any signals exists in this channel.
 	signals_exist: bool,
+	/// The index of the first outbound message.
 	first_index: u16,
+	/// The index of the last outbound message.
 	last_index: u16,
 }
 

--- a/pallets/xcmp-queue/src/lib.rs
+++ b/pallets/xcmp-queue/src/lib.rs
@@ -124,6 +124,7 @@ pub mod pallet {
 
 	/// Status of the inbound XCMP channels.
 	#[pallet::storage]
+	#[pallet::storage_prefix = "InboundXcmpStatus"]
 	pub(super) type InboundChannelStatus<T: Config> =
 		StorageValue<_, Vec<InboundChannelDetails>, ValueQuery>;
 
@@ -146,6 +147,7 @@ pub mod pallet {
 	/// case of the need to send a high-priority signal message this block.
 	/// The bool is true if there is a signal message waiting to be sent.
 	#[pallet::storage]
+	#[pallet::storage_prefix = "OutboundXcmpStatus"]
 	pub(super) type OutboundChannelStatus<T: Config> =
 		StorageValue<_, Vec<OutboundChannelDetails>, ValueQuery>;
 


### PR DESCRIPTION
Because seeing `.1` and `.2` irks me to no end.

Mostly renames, but also contains some helper methods to construct a new type using the builder pattern.