### PR TITLE
Allow manual start

### DIFF
--- a/.github/workflows/release-01_rc-automation.yml
+++ b/.github/workflows/release-01_rc-automation.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - release-**v[0-9]+.[0-9]+.[0-9]+
+  workflow_dispatch:
+  
 jobs:
   tag_rc:
     runs-on: ubuntu-latest


### PR DESCRIPTION
A quick workaround that allows started the RC workflow when it fails to start as it should.