### PR TITLE
Decouple protocol level from application level for XCM

### DIFF
--- a/pallets/xcm/src/lib.rs
+++ b/pallets/xcm/src/lib.rs
@@ -191,3 +191,15 @@ where
 		_ => Err(BadOrigin),
 	}
 }
+
+/// A sink that takes `VersionedXcm`'s and sends them to the specified `VersionedMultilocation`
+pub trait XcmSink<Call> {
+	fn send(recv: VersionedMultiLocation, msg: VersionedXcm<Call>) -> Result<(), ()>;
+}
+
+/// A handler that processes XCMs provided from the protocol layer. The message handler is allowed to consume at most
+/// `free_weight` Weight.
+pub trait XcmMessageHandler<Call, Weight> {
+	/// Handles the message and returns the Weight consumed by this call.
+	fn handle_message(origin: VersionedMultiLocation, msg: VersionedXcm<Call>, free_weight: Weight) -> Weight;
+}


### PR DESCRIPTION
**NOTE:** This PR is not meant to be seen as "the code that is meant to be included" but rather I am using the PR mechanism as it makes explaining the changes and where they could apply in the codebase more easily understandable than if I wrote it down in an issue.

## Receiving Side
Currently, the protocol level of XCM on the receiving side (namely `cumulus-pallet-xcmp-queue`, `cumulus-pallet-dmp-queue`) passes the received XCM directly into the executor provided by the pallet. 

Instead of doing this, I was curious to see if there are any chance to bring in a trait of the following definition: 

```rust
/// A handler that processes XCMs provided from the protocol layer. The message handler is allowed to consume at most
/// `free_weight` Weight.
pub trait XcmMessageHandler<Call, Weight> {
	/// Handles the message and returns the Weight consumed by this call.
	fn handle_message(origin: VersionedMultiLocation, msg: VersionedXcm<Call>, free_weight: Weight) -> Weight;
}
```

I see the following benefits here (arguably might not apply as I am not aware of future changes and the reasonings behind the current approach): 
* Allows parachains to process XCMs of multiple versions as we are passing the `Versioned*` types here.
* Allows parachains to have full control over their executor's errors and how to handle them.
* Decouple the protocol layer from the application layer (My personal opinion is that the protocol queue should not decide how to handle `WeightLimitReached` but rather take care of protocol stuff, like the `Signals`, errors on closed/congested channels).


## Sending Side
Currently, the trait definition of the sending side of the application level is defined as (using the version aware `SendXcm` trait of latest)

```rust
pub trait SendXcm {
	/// Send an XCM `message` to a given `destination`.
	///
	/// If it is not a destination which can be reached with this type but possibly could by others, then it *MUST*
	/// return `CannotReachDestination`. Any other error will cause the tuple implementation to exit early without
	/// trying other type fields.
	fn send_xcm(destination: impl Into<MultiLocation>, message: Xcm<()>) -> SendResult;
}
```

and implemented by the protocol layer (namely `struct ParentAsUmP` and `cumulus-pallet-xcmp-queue`. 
Would it be possible to rathe have the protocol level implement the following trait 

```rust
/// A sink that takes `VersionedXcm`'s and sends them to the specified `VersionedMultilocation`
pub trait XcmSink<Call> {
        // Not sure about the return type though, as the current error is version aware...
	fn send(recv: VersionedMultiLocation, msg: VersionedXcm<Call>) -> Result<(), ()>;
}
```

I see the following benefits here (arguably might not apply as I am not aware of future changes and the reasonings behind the current approach): 
* Protocol layer is able to send different versions of XCM (I understand that the executor must be version aware and the `SendXcm` represents this restriction for the executor, but I think that the protocol level should be able to send older and newer versions of XCMs)