### PR TITLE
Update proc-macro2 to 1.0.36

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8040,9 +8040,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.34"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f84e92c0f7c9d58328b85a78557813e4bd845130db68d7184635344399423b1"
+checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
  "unicode-xid",
 ]
@@ -11606,7 +11606,7 @@ dependencies = [
  "chrono",
  "lazy_static",
  "matchers",
- "parking_lot 0.10.2",
+ "parking_lot 0.11.2",
  "regex",
  "serde",
  "serde_json",

--- a/pallets/parachain-system/proc-macro/Cargo.toml
+++ b/pallets/parachain-system/proc-macro/Cargo.toml
@@ -10,7 +10,7 @@ proc-macro = true
 
 [dependencies]
 syn = "1.0.81"
-proc-macro2 = "1.0.27"
+proc-macro2 = "1.0.36"
 quote = "1.0.9"
 proc-macro-crate = "1.0.0"
 


### PR DESCRIPTION
Think maybe we should get dependabot working on this repo so that we don't have to manually update crates.