### PR TITLE
Ensure bad datastream cannot cause problems2

### DIFF
--- a/pallets/xcmp-queue/src/lib.rs
+++ b/pallets/xcmp-queue/src/lib.rs
@@ -520,7 +520,7 @@ impl<T: Config> Pallet<T> {
 									let e =
 										Event::OverweightEnqueued(sender, sent_at, index, required);
 									Self::deposit_event(e);
-								}
+								},
 								Err(XcmError::WeightLimitReached(required))
 									if required <= max_weight =>
 								{
@@ -528,7 +528,7 @@ impl<T: Config> Pallet<T> {
 									// too heavy. We leave it around for next time and bail.
 									remaining_fragments = last_remaining_fragments;
 									break
-								}
+								},
 								Err(_) => {
 									// Message looks invalid; don't attempt to retry
 								},


### PR DESCRIPTION
Is `decode_and_advance_with_depth_limit` guaranteed to always consume some of the input? I feel like we should do the same as #701 and add a guard and fail if the buffer was not reduced in size to be on the safe side (or failing that make it clear in the doc of that function that it must uphold that invariant).

(`if let` has been turned into a `match` and guard `if remaining_fragments.len() < last_remaining_fragments.len()` added.)