### PR TITLE
Fix broken links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ beautiful and functional.
 
 ## Consensus
 
-[`cumulus-consensus`](consensus) is a
+[`cumulus-consensus`](https://github.com/paritytech/cumulus/tree/master/client/consensus) is a
 [consensus engine](https://docs.substrate.io/v3/advanced/consensus) for Substrate
 that follows a Polkadot
 [relay chain](https://wiki.polkadot.network/docs/en/learn-architecture#relay-chain). This will run
@@ -28,7 +28,7 @@ and treat as best.
 ## Collator
 
 A Polkadot [collator](https://wiki.polkadot.network/docs/en/learn-collator) for the parachain is
-implemented by [`cumulus-collator`](collator).
+implemented by [`cumulus-collator`](https://github.com/paritytech/cumulus/tree/master/client/collator).
 
 # Statemint 🪙
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ beautiful and functional.
 
 ## Consensus
 
-[`cumulus-consensus`](https://github.com/paritytech/cumulus/tree/master/client/consensus) is a
+[`parachain-consensus`](https://github.com/paritytech/cumulus/blob/master/client/consensus/common/src/parachain_consensus.rs) is a
 [consensus engine](https://docs.substrate.io/v3/advanced/consensus) for Substrate
 that follows a Polkadot
 [relay chain](https://wiki.polkadot.network/docs/en/learn-architecture#relay-chain). This will run

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ and treat as best.
 ## Collator
 
 A Polkadot [collator](https://wiki.polkadot.network/docs/en/learn-collator) for the parachain is
-implemented by [`cumulus-collator`](https://github.com/paritytech/cumulus/tree/master/client/collator).
+implemented by the `polkadot-collator` binary.
 
 # Statemint 🪙
 


### PR DESCRIPTION
I _think_ that's where these hyperlinks are intended to link to.