### PR TITLE
Change Rococo Para id from 1000 to 2000

### DIFF
--- a/polkadot-parachains/src/chain_spec.rs
+++ b/polkadot-parachains/src/chain_spec.rs
@@ -91,7 +91,7 @@ pub fn get_chain_spec() -> ChainSpec {
 					get_account_id_from_seed::<sr25519::Public>("Eve//stash"),
 					get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"),
 				],
-				1000.into(),
+				2000.into(),
 			)
 		},
 		Vec::new(),
@@ -99,7 +99,7 @@ pub fn get_chain_spec() -> ChainSpec {
 		None,
 		None,
 		None,
-		Extensions { relay_chain: "westend".into(), para_id: 1000 },
+		Extensions { relay_chain: "westend".into(), para_id: 2000 },
 	)
 }
 


### PR DESCRIPTION
Right now there is not an easy way of running a Community Parachain collator type (id >= 2000 and not 1000) without generating the `chain-spec-raw.json`.

Rococo parachain is set to 1000, but we don't really have a "Rockmine" Common Good parachain (and we could use Westmint for that purpose if needed).

I'd like to change the Rococo Parachain id to 2000, so then I could easily tests scenarios such as opening HRMP channels between Common Good parachain & Community parachain or any kind of interaction between them.

The Rococo Parachain collator could be run just with the `--chain=""` command attribute