### PR TITLE
fix: remove duplicate event of pallet_balances

### DIFF
--- a/polkadot-parachains/parachains-common/src/impls.rs
+++ b/polkadot-parachains/parachains-common/src/impls.rs
@@ -44,7 +44,6 @@ where
 	<R as frame_system::Config>::Event: From<pallet_balances::Event<R>>,
 {
 	fn on_nonzero_unbalanced(amount: NegativeImbalance<R>) {
-		let numeric_amount = amount.peek();
 		let staking_pot = <pallet_collator_selection::Pallet<R>>::account_id();
 		<pallet_balances::Pallet<R>>::resolve_creating(&staking_pot, amount);
 	}

--- a/polkadot-parachains/parachains-common/src/impls.rs
+++ b/polkadot-parachains/parachains-common/src/impls.rs
@@ -47,10 +47,6 @@ where
 		let numeric_amount = amount.peek();
 		let staking_pot = <pallet_collator_selection::Pallet<R>>::account_id();
 		<pallet_balances::Pallet<R>>::resolve_creating(&staking_pot, amount);
-		<frame_system::Pallet<R>>::deposit_event(pallet_balances::Event::Deposit {
-			who: staking_pot,
-			amount: numeric_amount,
-		});
 	}
 }
 


### PR DESCRIPTION
https://github.com/paritytech/substrate/blob/master/frame/support/src/traits/tokens/currency.rs#L158
https://github.com/paritytech/substrate/blob/master/frame/balances/src/lib.rs#L1647

Since 0.9.12 of substrate, there is no need for a separate of balances event in runtime.