### PR TITLE
ci: fix broken reference to rococo srtool digest

### DIFF
--- a/.github/workflows/release-02_create-draft.yml
+++ b/.github/workflows/release-02_create-draft.yml
@@ -120,7 +120,7 @@ jobs:
           WESTMINT_DIGEST: ${{ github.workspace}}/westmint-srtool-json/westmint_srtool_output.json
           STATEMINE_DIGEST: ${{ github.workspace}}/statemine-srtool-json/statemine_srtool_output.json
           STATEMINT_DIGEST: ${{ github.workspace}}/statemint-srtool-json/statemint_srtool_output.json
-          ROCOCO_DIGEST: ${{ github.workspace}}/rococo-parachain-srtool-json/rococo-parachain_srtool_output.json
+          ROCOCO_PARA_DIGEST: ${{ github.workspace}}/rococo-parachain-srtool-json/rococo-parachain_srtool_output.json
           REF1: ${{ github.event.inputs.ref1 }}
           REF2: ${{ github.event.inputs.ref2 }}
           PRE_RELEASE: ${{ github.event.inputs.pre_release }}
@@ -132,7 +132,7 @@ jobs:
           ls -al $WESTMINT_DIGEST
           ls -al $STATEMINE_DIGEST
           ls -al $STATEMINT_DIGEST
-          ls -al $ROCOCO_DIGEST
+          ls -al $ROCOCO_PARA_DIGEST
 
           echo "The diff will be computed from $REF1 to $REF2"
           cd cumulus/scripts/changelog


### PR DESCRIPTION
This fixes scripts/changelog/bin/changelog being unable to find the srtool digest for rococo-parachain.

[Current example of CI breakage](https://github.com/paritytech/cumulus/runs/5020707952?check_suite_focus=true), see step "Generate release notes" 