### PR TITLE
ci: fix publish-runtimes for parachains containing - in name

### DIFF
--- a/.github/workflows/release-02_create-draft.yml
+++ b/.github/workflows/release-02_create-draft.yml
@@ -192,6 +192,12 @@ jobs:
           echo "Found version: >$runtime_ver<"
           echo "::set-output name=runtime_ver::$runtime_ver"
 
+      - name: Fix parachain runtime name
+        id: fix-runtime-path
+        run: |
+          cd "$RUNTIME_DIR"
+          mv "$(sed 's/-parachain/_parachain/' <<< ${{ matrix.runtime }})_runtime.compact.compressed.wasm" "${{ matrix.runtime }}_runtime.compact.compressed.wasm" || true
+
       - name: Upload compressed ${{ matrix.runtime }} wasm
         uses: actions/upload-release-asset@v1
         env:


### PR DESCRIPTION
rust outputs these with underscores, so `rococo-parachain` ends up as `rococo_parachain`, this breaks assumptions in the ci publish-runtimes step of release-02_create-draft, so we move it back to where it's expected