### PR TITLE
Add / Remove migrations

### DIFF
--- a/polkadot-parachains/statemine/src/lib.rs
+++ b/polkadot-parachains/statemine/src/lib.rs
@@ -785,18 +785,8 @@ pub type Executive = frame_executive::Executive<
 	frame_system::ChainContext<Runtime>,
 	Runtime,
 	AllPalletsWithSystem,
-	(RemoveCollectiveFlip, UniquesV1Migration),
+	UniquesV1Migration,
 >;
-
-pub struct RemoveCollectiveFlip;
-impl frame_support::traits::OnRuntimeUpgrade for RemoveCollectiveFlip {
-	fn on_runtime_upgrade() -> Weight {
-		use frame_support::storage::migration;
-		// Remove the storage value `RandomMaterial` from removed pallet `RandomnessCollectiveFlip`
-		migration::remove_storage_prefix(b"RandomnessCollectiveFlip", b"RandomMaterial", b"");
-		<Runtime as frame_system::Config>::DbWeight::get().writes(1)
-	}
-}
 
 pub struct UniquesV1Migration;
 impl frame_support::traits::OnRuntimeUpgrade for UniquesV1Migration {

--- a/polkadot-parachains/westmint/src/lib.rs
+++ b/polkadot-parachains/westmint/src/lib.rs
@@ -769,16 +769,13 @@ pub type Executive = frame_executive::Executive<
 	frame_system::ChainContext<Runtime>,
 	Runtime,
 	AllPalletsWithSystem,
-	RemoveCollectiveFlip,
+	UniquesV1Migration,
 >;
 
-pub struct RemoveCollectiveFlip;
-impl frame_support::traits::OnRuntimeUpgrade for RemoveCollectiveFlip {
+pub struct UniquesV1Migration;
+impl frame_support::traits::OnRuntimeUpgrade for UniquesV1Migration {
 	fn on_runtime_upgrade() -> Weight {
-		use frame_support::storage::migration;
-		// Remove the storage value `RandomMaterial` from removed pallet `RandomnessCollectiveFlip`
-		migration::remove_storage_prefix(b"RandomnessCollectiveFlip", b"RandomMaterial", b"");
-		<Runtime as frame_system::Config>::DbWeight::get().writes(1)
+		pallet_uniques::migration::migrate_to_v1::<Runtime, _, Uniques>()
 	}
 }
 


### PR DESCRIPTION
`RemoveCollectiveFlip` was already run in the previous release: 
- https://github.com/paritytech/cumulus/blob/release-statemine-v6.0.1/polkadot-parachains/statemine/src/lib.rs#L783-L794
- https://github.com/paritytech/cumulus/blob/release-statemine-v6.0.1/polkadot-parachains/westmint/src/lib.rs#L770-L781

`UniquesV1Migration` is missing for Westmint:
- https://github.com/paritytech/cumulus/blob/release-parachains-v7.0.0/polkadot-parachains/westmint/src/lib.rs#L772
