### PR TITLE
Bump transaction version for release 700

### DIFF
--- a/polkadot-parachains/statemine/src/lib.rs
+++ b/polkadot-parachains/statemine/src/lib.rs
@@ -94,7 +94,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_version: 700,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
-	transaction_version: 4,
+	transaction_version: 5,
 	state_version: 0,
 };
 

--- a/polkadot-parachains/statemint/src/lib.rs
+++ b/polkadot-parachains/statemint/src/lib.rs
@@ -95,7 +95,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_version: 700,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
-	transaction_version: 4,
+	transaction_version: 5,
 	state_version: 0,
 };
 

--- a/polkadot-parachains/westmint/src/lib.rs
+++ b/polkadot-parachains/westmint/src/lib.rs
@@ -94,7 +94,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_version: 700,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
-	transaction_version: 4,
+	transaction_version: 5,
 	state_version: 0,
 };
 


### PR DESCRIPTION
There are some changes to the transaction structures in this statemine/statemint release so it requires a new transaction version.