### PR TITLE
Bump collator version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6828,7 +6828,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot-collator"
-version = "5.1.0"
+version = "5.2.0"
 dependencies = [
  "assert_cmd",
  "async-trait",

--- a/polkadot-parachains/Cargo.toml
+++ b/polkadot-parachains/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polkadot-collator"
-version = "5.1.0"
+version = "5.2.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 build = "build.rs"
 edition = "2021"


### PR DESCRIPTION
Merging back v7 changes: bump collator version

(part of https://github.com/paritytech/cumulus/issues/969 )