### PR TITLE
Set statemin runtime versions to 700

### DIFF
--- a/polkadot-parachains/statemine/src/lib.rs
+++ b/polkadot-parachains/statemine/src/lib.rs
@@ -91,7 +91,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("statemine"),
 	impl_name: create_runtime_str!("statemine"),
 	authoring_version: 1,
-	spec_version: 601,
+	spec_version: 700,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 4,

--- a/polkadot-parachains/statemint/src/lib.rs
+++ b/polkadot-parachains/statemint/src/lib.rs
@@ -92,7 +92,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("statemint"),
 	impl_name: create_runtime_str!("statemint"),
 	authoring_version: 1,
-	spec_version: 601,
+	spec_version: 700,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 4,

--- a/polkadot-parachains/westmint/src/lib.rs
+++ b/polkadot-parachains/westmint/src/lib.rs
@@ -91,7 +91,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("westmint"),
 	impl_name: create_runtime_str!("westmint"),
 	authoring_version: 1,
-	spec_version: 601,
+	spec_version: 700,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 4,


### PR DESCRIPTION
Note I have left rococo and seedling versions alone from the original commit ( https://github.com/paritytech/cumulus/commit/7881fe6a16498a949bdc6e892a7aee2365a51c06 ) because I don't think we should be bumping them.

(part of https://github.com/paritytech/cumulus/issues/969 )