### PR TITLE
ci: fix bash quoting in docker ci

### DIFF
--- a/.github/workflows/release-10_docker.yml
+++ b/.github/workflows/release-10_docker.yml
@@ -24,18 +24,18 @@ jobs:
 
       - name: Fetch files from release
         run: |
-          echo Repo: ${{ github.event.repository.full_name }}
+          echo "Repo: ${{ github.event.repository.full_name }}"
 
-          echo Name: ${{ github.event.release.name }}
-          echo Tag: ${{ github.event.release.tag_name }}
-          echo Draft: ${{ github.event.release.draft }}
-          echo Prerelease: ${{ github.event.release.prerelease }}
-          echo Assets: ${{ github.event.release.assets }}
+          echo "Name: ${{ github.event.release.name }}"
+          echo "Tag: ${{ github.event.release.tag_name }}
+          echo "Draft: ${{ github.event.release.draft }}"
+          echo "Prerelease: ${{ github.event.release.prerelease }}"
+          echo "Assets: ${{ github.event.release.assets }}"
 
           for f in $BINARY $BINARY.asc $BINARY.sha256; do
             URL="https://github.com/${{ github.event.repository.full_name }}/releases/download/${{ github.event.release.tag_name }}/$f"
             echo " - Fetching $f from $URL"
-            wget $URL -O $f
+            wget "$URL" -O "$f"
           done
           chmod a+x $BINARY
           ls -al


### PR DESCRIPTION
Current docker ci is broken due to bash issues when release notes contain special characters, this change quotes those strings to fix that issue.

See also https://github.com/paritytech/cumulus/runs/5140919334