### PR TITLE
Remove migrations that have been executed

### DIFF
--- a/polkadot-parachains/statemine/src/lib.rs
+++ b/polkadot-parachains/statemine/src/lib.rs
@@ -602,15 +602,8 @@ pub type Executive = frame_executive::Executive<
 	frame_system::ChainContext<Runtime>,
 	Runtime,
 	AllPalletsWithSystem,
-	UniquesV1Migration,
+	(),
 >;
-
-pub struct UniquesV1Migration;
-impl frame_support::traits::OnRuntimeUpgrade for UniquesV1Migration {
-	fn on_runtime_upgrade() -> Weight {
-		pallet_uniques::migration::migrate_to_v1::<Runtime, _, Uniques>()
-	}
-}
 
 #[cfg(feature = "runtime-benchmarks")]
 #[macro_use]

--- a/polkadot-parachains/westmint/src/lib.rs
+++ b/polkadot-parachains/westmint/src/lib.rs
@@ -594,15 +594,8 @@ pub type Executive = frame_executive::Executive<
 	frame_system::ChainContext<Runtime>,
 	Runtime,
 	AllPalletsWithSystem,
-	UniquesV1Migration,
+	(),
 >;
-
-pub struct UniquesV1Migration;
-impl frame_support::traits::OnRuntimeUpgrade for UniquesV1Migration {
-	fn on_runtime_upgrade() -> Weight {
-		pallet_uniques::migration::migrate_to_v1::<Runtime, _, Uniques>()
-	}
-}
 
 #[cfg(feature = "runtime-benchmarks")]
 #[macro_use]


### PR DESCRIPTION
Remove migrations that have been executed on statemine and westmint

(part of https://github.com/paritytech/cumulus/issues/969 )