### PR TITLE
Fix missing relay chain telemetry node name (issue #556)

### DIFF
--- a/parachain-template/node/src/command.rs
+++ b/parachain-template/node/src/command.rs
@@ -283,9 +283,16 @@ pub fn run() -> Result<()> {
 				let genesis_state = format!("0x{:?}", HexDisplay::from(&block.header().encode()));
 
 				let tokio_handle = config.tokio_handle.clone();
-				let polkadot_config =
+				let mut polkadot_config =
 					SubstrateCli::create_configuration(&polkadot_cli, &polkadot_cli, tokio_handle)
 						.map_err(|err| format!("Relay chain argument error: {}", err))?;
+
+				// Fix missing node name
+				let tokio_handle = config.tokio_handle.clone();
+				let polkadot_config_node_name =
+					SubstrateCli::create_configuration(&polkadot_cli, &polkadot_cli.base.base, tokio_handle)
+						.map_err(|err| format!("Relay chain argument error: {}", err))?;
+				polkadot_config.network.node_name = polkadot_config_node_name.network.node_name;
 
 				info!("Parachain id: {:?}", id);
 				info!("Parachain Account: {}", parachain_account);

--- a/polkadot-parachains/src/command.rs
+++ b/polkadot-parachains/src/command.rs
@@ -515,9 +515,16 @@ pub fn run() -> Result<()> {
 				let genesis_state = format!("0x{:?}", HexDisplay::from(&block.header().encode()));
 
 				let tokio_handle = config.tokio_handle.clone();
-				let polkadot_config =
+				let mut polkadot_config =
 					SubstrateCli::create_configuration(&polkadot_cli, &polkadot_cli, tokio_handle)
 						.map_err(|err| format!("Relay chain argument error: {}", err))?;
+
+				// Fix missing node name
+				let tokio_handle = config.tokio_handle.clone();
+				let polkadot_config_node_name =
+					SubstrateCli::create_configuration(&polkadot_cli, &polkadot_cli.base.base, tokio_handle)
+						.map_err(|err| format!("Relay chain argument error: {}", err))?;
+				polkadot_config.network.node_name = polkadot_config_node_name.network.node_name;
 
 				info!("Parachain id: {:?}", id);
 				info!("Parachain Account: {}", parachain_account);


### PR DESCRIPTION
I believe this fixes #556, but I'm sure there must be a cleaner option...  My first rust / substrate PR - feedback and suggestions would be most welcome.


Essentially, the first (original) call to SubstrateCli::create_configuration seems to be appropriately setting most of the relay chain node parameters, including using default that don't clash with the parachain side, but it sets the node name to an auto-generated value.  The second (added) call to SubstrateCli::create_configuration sets the node name according to the --name flag (or an another auto-generated value), but most of the other parameters are not appropriate for the relay chain connection.

I couldn't work out a way to move the "name" value in polkadot_cli to a place where the first call would find it, and all the other fixes I could think of either required changes to other crates or reproducing code from those crates in this function.  I wanted to avoid doing either of those.  Adding just the section of code needed would be a bit more computationally efficient but, since this code is only called once at node startup, I thought that probably wasn't a concern - reusing known-good functionality seemed better.

I think I found the only two places in the repo that needed updating.