### PR TITLE
Fix parachain-template-runtime build fail

### DIFF
--- a/parachain-template/runtime/Cargo.toml
+++ b/parachain-template/runtime/Cargo.toml
@@ -104,6 +104,7 @@ std = [
 	"frame-executive/std",
 	"frame-support/std",
 	"frame-system/std",
+	"frame-system-rpc-runtime-api/std",
 	"pallet-aura/std",
 	"pallet-authorship/std",
 	"pallet-balances/std",


### PR DESCRIPTION
sync solution from #887

Command cargo build -p parachain-template-runtime was broken. 