### PR TITLE
Fix relay chain node name

### DIFF
--- a/parachain-template/node/src/command.rs
+++ b/parachain-template/node/src/command.rs
@@ -432,4 +432,8 @@ impl CliConfiguration<Self> for RelayChainCli {
 	) -> Result<Option<sc_telemetry::TelemetryEndpoints>> {
 		self.base.base.telemetry_endpoints(chain_spec)
 	}
+
+	fn node_name(&self) -> Result<String> {
+		self.base.base.node_name()
+	}
 }

--- a/polkadot-parachains/src/command.rs
+++ b/polkadot-parachains/src/command.rs
@@ -714,4 +714,8 @@ impl CliConfiguration<Self> for RelayChainCli {
 	) -> Result<Option<sc_telemetry::TelemetryEndpoints>> {
 		self.base.base.telemetry_endpoints(chain_spec)
 	}
+
+	fn node_name(&self) -> Result<String> {
+		self.base.base.node_name()
+	}
 }


### PR DESCRIPTION
Before this fix the relay chain node name was always a random generated, because we did not had
implemented all the required methods of the `CliConfiguration` trait.

Closes: https://github.com/paritytech/cumulus/issues/556