### PR TITLE
canvas: Run migrations defined by `pallet-contracts`

### DIFF
--- a/polkadot-parachains/canvas-kusama/src/contracts.rs
+++ b/polkadot-parachains/canvas-kusama/src/contracts.rs
@@ -2,7 +2,7 @@ use crate::{
 	constants::currency::deposit, Balance, Balances, Call, Event, RandomnessCollectiveFlip,
 	Runtime, RuntimeBlockWeights, Timestamp,
 };
-use frame_support::{parameter_types, traits::Nothing, weights::Weight};
+use frame_support::{parameter_types, traits::{Nothing, OnRuntimeUpgrade}, weights::Weight};
 use pallet_contracts::{
 	weights::{SubstrateWeight, WeightInfo},
 	Config, DefaultAddressGenerator, Frame, Schedule,
@@ -51,4 +51,11 @@ impl Config for Runtime {
 	type Schedule = MySchedule;
 	type CallStack = [Frame<Self>; 31];
 	type AddressGenerator = DefaultAddressGenerator;
+}
+
+pub struct Migrations;
+impl OnRuntimeUpgrade for Migrations {
+	fn on_runtime_upgrade() -> Weight {
+		pallet_contracts::migration::migrate::<Runtime>()
+	}
 }

--- a/polkadot-parachains/canvas-kusama/src/contracts.rs
+++ b/polkadot-parachains/canvas-kusama/src/contracts.rs
@@ -2,7 +2,11 @@ use crate::{
 	constants::currency::deposit, Balance, Balances, Call, Event, RandomnessCollectiveFlip,
 	Runtime, RuntimeBlockWeights, Timestamp,
 };
-use frame_support::{parameter_types, traits::{Nothing, OnRuntimeUpgrade}, weights::Weight};
+use frame_support::{
+	parameter_types,
+	traits::{Nothing, OnRuntimeUpgrade},
+	weights::Weight,
+};
 use pallet_contracts::{
 	weights::{SubstrateWeight, WeightInfo},
 	Config, DefaultAddressGenerator, Frame, Schedule,

--- a/polkadot-parachains/canvas-kusama/src/lib.rs
+++ b/polkadot-parachains/canvas-kusama/src/lib.rs
@@ -97,6 +97,7 @@ pub type Executive = frame_executive::Executive<
 	frame_system::ChainContext<Runtime>,
 	Runtime,
 	AllPalletsWithSystem,
+	contracts::Migrations,
 >;
 
 impl_opaque_keys! {


### PR DESCRIPTION
We expect some storage changes during the existence on rococo. Run the storage migrations defined in `pallet-contracts` in order to allow runtime upgrades without resetting the chain.