### PR TITLE
Add dependabot config file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    labels: ["A2-insubstantial", "B0-silent", "C1-low 📌"]
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This PR adds config file for [dependabot](https://github.com/dependabot).
Closes https://github.com/paritytech/ci_cd/issues/308 and #1003 

After merging additional step required from repository admin - enable **Dependabot security updates** and **Dependabot alerts** in repository settings **Code security and analysis**
