### PR TITLE
fix: map cli option `--runtime_cache_size`

### DIFF
--- a/client/cli/src/lib.rs
+++ b/client/cli/src/lib.rs
@@ -248,6 +248,10 @@ impl sc_cli::CliConfiguration for NormalizedRunCmd {
 		self.base.max_runtime_instances()
 	}
 
+	fn runtime_cache_size(&self) -> sc_cli::Result<u8> {
+		self.base.runtime_cache_size()
+	}
+
 	fn base_path(&self) -> sc_cli::Result<Option<BasePath>> {
 		self.base.base_path()
 	}


### PR DESCRIPTION
The new cli  option `--runtime-cache-size` introduced in https://github.com/paritytech/substrate/pull/10177 does not work for parachains.

This PR adds the necessary mapping to `NormalizedRunCmd`