### PR TITLE
Fix panic in `pallet-collator-selection` benchmarking

### DIFF
--- a/pallets/collator-selection/src/benchmarking.rs
+++ b/pallets/collator-selection/src/benchmarking.rs
@@ -84,12 +84,14 @@ fn validator<T: Config + session::Config>(c: u32) -> (T::AccountId, <T as sessio
 	(create_funded_user::<T>("candidate", c, 1000), keys::<T>(c))
 }
 
-fn register_validators<T: Config + session::Config>(count: u32) {
+fn register_validators<T: Config + session::Config>(count: u32) -> Vec<T::AccountId> {
 	let validators = (0..count).map(|c| validator::<T>(c)).collect::<Vec<_>>();
 
-	for (who, keys) in validators {
+	for (who, keys) in validators.clone() {
 		<session::Pallet<T>>::set_keys(RawOrigin::Signed(who).into(), keys, Vec::new()).unwrap();
 	}
+
+	return validators.into_iter().map(|(who, _)| who).collect()
 }
 
 fn register_candidates<T: Config>(count: u32) {
@@ -107,7 +109,7 @@ benchmarks! {
 
 	set_invulnerables {
 		let b in 1 .. T::MaxInvulnerables::get();
-		let new_invulnerables = (0..b).map(|c| account("candidate", c, SEED)).collect::<Vec<_>>();
+		let new_invulnerables = register_validators::<T>(b);
 		let origin = T::UpdateOrigin::successful_origin();
 	}: {
 		assert_ok!(
@@ -150,7 +152,7 @@ benchmarks! {
 		<CandidacyBond<T>>::put(T::Currency::minimum_balance());
 		<DesiredCandidates<T>>::put(c + 1);
 
-		register_validators::<T>(c);
+		let _ = register_validators::<T>(c);
 		register_candidates::<T>(c);
 
 		let caller: T::AccountId = whitelisted_caller();
@@ -174,7 +176,7 @@ benchmarks! {
 		<CandidacyBond<T>>::put(T::Currency::minimum_balance());
 		<DesiredCandidates<T>>::put(c);
 
-		register_validators::<T>(c);
+		let _ = register_validators::<T>(c);
 		register_candidates::<T>(c);
 
 		let leaving = <Candidates<T>>::get().last().unwrap().who.clone();
@@ -212,7 +214,7 @@ benchmarks! {
 		<DesiredCandidates<T>>::put(c);
 		frame_system::Pallet::<T>::set_block_number(0u32.into());
 
-		register_validators::<T>(c);
+		let _ = register_validators::<T>(c);
 		register_candidates::<T>(c);
 
 		let new_block: T::BlockNumber = 1800u32.into();

--- a/pallets/collator-selection/src/benchmarking.rs
+++ b/pallets/collator-selection/src/benchmarking.rs
@@ -91,7 +91,7 @@ fn register_validators<T: Config + session::Config>(count: u32) -> Vec<T::Accoun
 		<session::Pallet<T>>::set_keys(RawOrigin::Signed(who).into(), keys, Vec::new()).unwrap();
 	}
 
-	return validators.into_iter().map(|(who, _)| who).collect()
+	validators.into_iter().map(|(who, _)| who).collect()
 }
 
 fn register_candidates<T: Config>(count: u32) {
@@ -152,7 +152,7 @@ benchmarks! {
 		<CandidacyBond<T>>::put(T::Currency::minimum_balance());
 		<DesiredCandidates<T>>::put(c + 1);
 
-		let _ = register_validators::<T>(c);
+		register_validators::<T>(c);
 		register_candidates::<T>(c);
 
 		let caller: T::AccountId = whitelisted_caller();
@@ -176,7 +176,7 @@ benchmarks! {
 		<CandidacyBond<T>>::put(T::Currency::minimum_balance());
 		<DesiredCandidates<T>>::put(c);
 
-		let _ = register_validators::<T>(c);
+		register_validators::<T>(c);
 		register_candidates::<T>(c);
 
 		let leaving = <Candidates<T>>::get().last().unwrap().who.clone();
@@ -214,7 +214,7 @@ benchmarks! {
 		<DesiredCandidates<T>>::put(c);
 		frame_system::Pallet::<T>::set_block_number(0u32.into());
 
-		let _ = register_validators::<T>(c);
+		register_validators::<T>(c);
 		register_candidates::<T>(c);
 
 		let new_block: T::BlockNumber = 1800u32.into();


### PR DESCRIPTION
resolves #1062 

This PR tries to fix the error by returning validator accounts in `register_validators` and using them in the `set_invulnerables` benchmarking.