### PR TITLE
Improve conflict detection between cli flags

### DIFF
--- a/client/cli/src/lib.rs
+++ b/client/cli/src/lib.rs
@@ -151,7 +151,13 @@ pub struct RunCmd {
 		parse(try_from_str),
 		validator = validate_relay_chain_url,
 		conflicts_with = "collator",
-		conflicts_with = "validator"
+		conflicts_with = "validator",
+		conflicts_with = "alice",
+		conflicts_with = "bob",
+		conflicts_with = "charlie",
+		conflicts_with = "dave",
+		conflicts_with = "eve",
+		conflicts_with = "ferdie"
 	)]
 	pub relay_chain_rpc_url: Option<Url>,
 }


### PR DESCRIPTION
Improves usability and avoids confusion, as the named flags implicitly include `--collator`