### PR TITLE
Support running relay chain full node as non-collator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2093,7 +2093,7 @@ dependencies = [
  "futures-timer",
  "jsonrpsee 0.9.0",
  "parity-scale-codec",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.0",
  "polkadot-service",
  "sc-client-api",
  "sc-rpc-api",

--- a/client/relay-chain-inprocess-interface/src/lib.rs
+++ b/client/relay-chain-inprocess-interface/src/lib.rs
@@ -360,14 +360,9 @@ pub fn build_inprocess_relay_chain(
 	parachain_config: &Configuration,
 	telemetry_worker_handle: Option<TelemetryWorkerHandle>,
 	task_manager: &mut TaskManager,
-) -> Result<(Arc<(dyn RelayChainInterface + 'static)>, Option<CollatorPair>), polkadot_service::Error>
-{
+) -> RelayChainResult<(Arc<(dyn RelayChainInterface + 'static)>, Option<CollatorPair>)> {
 	let (full_node, collator_key) =
-		build_polkadot_full_node(polkadot_config, parachain_config, telemetry_worker_handle)
-			.map_err(|e| match e {
-				polkadot_service::Error::Sub(x) => x,
-				s => format!("{}", s).into(),
-			})?;
+		build_polkadot_full_node(polkadot_config, parachain_config, telemetry_worker_handle)?;
 
 	let sync_oracle: Box<dyn SyncOracle + Send + Sync> = Box::new(full_node.network.clone());
 	let sync_oracle = Arc::new(Mutex::new(sync_oracle));

--- a/client/relay-chain-inprocess-interface/src/lib.rs
+++ b/client/relay-chain-inprocess-interface/src/lib.rs
@@ -325,42 +325,49 @@ impl ExecuteWithClient for RelayChainInProcessInterfaceBuilder {
 #[sc_tracing::logging::prefix_logs_with("Relaychain")]
 fn build_polkadot_full_node(
 	config: Configuration,
+	parachain_config: &Configuration,
 	telemetry_worker_handle: Option<TelemetryWorkerHandle>,
-) -> Result<(NewFull<polkadot_client::Client>, CollatorPair), polkadot_service::Error> {
+) -> Result<(NewFull<polkadot_client::Client>, Option<CollatorPair>), polkadot_service::Error> {
 	let is_light = matches!(config.role, Role::Light);
 	if is_light {
 		Err(polkadot_service::Error::Sub("Light client not supported.".into()))
 	} else {
-		let collator_key = CollatorPair::generate().0;
+		let (is_collator, maybe_collator_key) = if parachain_config.role.is_authority() {
+			let collator_key = CollatorPair::generate().0;
+			(polkadot_service::IsCollator::Yes(collator_key.clone()), Some(collator_key))
+		} else {
+			(polkadot_service::IsCollator::No, None)
+		};
 
 		let relay_chain_full_node = polkadot_service::build_full(
 			config,
-			polkadot_service::IsCollator::Yes(collator_key.clone()),
+			is_collator,
 			None,
 			true,
 			None,
 			telemetry_worker_handle,
-			false,
+			true,
 			polkadot_service::RealOverseerGen,
 		)?;
 
-		Ok((relay_chain_full_node, collator_key))
+		Ok((relay_chain_full_node, maybe_collator_key))
 	}
 }
 
 /// Builds a relay chain interface by constructing a full relay chain node
 pub fn build_inprocess_relay_chain(
 	polkadot_config: Configuration,
+	parachain_config: &Configuration,
 	telemetry_worker_handle: Option<TelemetryWorkerHandle>,
 	task_manager: &mut TaskManager,
-) -> Result<(Arc<(dyn RelayChainInterface + 'static)>, CollatorPair), polkadot_service::Error> {
+) -> Result<(Arc<(dyn RelayChainInterface + 'static)>, Option<CollatorPair>), polkadot_service::Error>
+{
 	let (full_node, collator_key) =
-		build_polkadot_full_node(polkadot_config, telemetry_worker_handle).map_err(
-			|e| match e {
+		build_polkadot_full_node(polkadot_config, parachain_config, telemetry_worker_handle)
+			.map_err(|e| match e {
 				polkadot_service::Error::Sub(x) => x,
 				s => format!("{}", s).into(),
-			},
-		)?;
+			})?;
 
 	let sync_oracle: Box<dyn SyncOracle + Send + Sync> = Box::new(full_node.network.clone());
 	let sync_oracle = Arc::new(Mutex::new(sync_oracle));
@@ -370,6 +377,7 @@ pub fn build_inprocess_relay_chain(
 		sync_oracle,
 		overseer_handle: full_node.overseer_handle.clone(),
 	};
+
 	task_manager.add_child(full_node.task_manager);
 
 	Ok((relay_chain_interface_builder.build(), collator_key))

--- a/client/relay-chain-rpc-interface/Cargo.toml
+++ b/client/relay-chain-rpc-interface/Cargo.toml
@@ -22,7 +22,7 @@ sc-rpc-api = { git = "https://github.com/paritytech/substrate", branch = "master
 futures = "0.3.21"
 futures-timer = "3.0.2"
 parity-scale-codec = "3.0.0"
-parking_lot = "0.11.1"
+parking_lot = "0.12.0"
 jsonrpsee = { version = "0.9.0", features = ["client"] }
 tracing = "0.1.25"
 async-trait = "0.1.52"

--- a/parachain-template/node/src/service.rs
+++ b/parachain-template/node/src/service.rs
@@ -166,6 +166,7 @@ where
 
 async fn build_relay_chain_interface(
 	polkadot_config: Configuration,
+	parachain_config: &Configuration,
 	telemetry_worker_handle: Option<TelemetryWorkerHandle>,
 	task_manager: &mut TaskManager,
 	collator_options: CollatorOptions,
@@ -176,10 +177,11 @@ async fn build_relay_chain_interface(
 		None => {
 			let relay_chain_local = build_inprocess_relay_chain(
 				polkadot_config,
+				parachain_config,
 				telemetry_worker_handle,
 				task_manager,
 			)?;
-			Ok((relay_chain_local.0, Some(relay_chain_local.1)))
+			Ok((relay_chain_local.0, relay_chain_local.1))
 		},
 	}
 }
@@ -267,6 +269,7 @@ where
 
 	let (relay_chain_interface, collator_key) = build_relay_chain_interface(
 		polkadot_config,
+		&parachain_config,
 		telemetry_worker_handle,
 		&mut task_manager,
 		collator_options.clone(),

--- a/parachain-template/node/src/service.rs
+++ b/parachain-template/node/src/service.rs
@@ -174,15 +174,12 @@ async fn build_relay_chain_interface(
 	match collator_options.relay_chain_rpc_url {
 		Some(relay_chain_url) =>
 			Ok((Arc::new(RelayChainRPCInterface::new(relay_chain_url).await?) as Arc<_>, None)),
-		None => {
-			let relay_chain_local = build_inprocess_relay_chain(
-				polkadot_config,
-				parachain_config,
-				telemetry_worker_handle,
-				task_manager,
-			)?;
-			Ok((relay_chain_local.0, relay_chain_local.1))
-		},
+		None => build_inprocess_relay_chain(
+			polkadot_config,
+			parachain_config,
+			telemetry_worker_handle,
+			task_manager,
+		),
 	}
 }
 

--- a/polkadot-parachains/src/service.rs
+++ b/polkadot-parachains/src/service.rs
@@ -287,6 +287,7 @@ where
 
 async fn build_relay_chain_interface(
 	polkadot_config: Configuration,
+	parachain_config: &Configuration,
 	telemetry_worker_handle: Option<TelemetryWorkerHandle>,
 	task_manager: &mut TaskManager,
 	collator_options: CollatorOptions,
@@ -297,10 +298,11 @@ async fn build_relay_chain_interface(
 		None => {
 			let relay_chain_local = build_inprocess_relay_chain(
 				polkadot_config,
+				parachain_config,
 				telemetry_worker_handle,
 				task_manager,
 			)?;
-			Ok((relay_chain_local.0, Some(relay_chain_local.1)))
+			Ok((relay_chain_local.0, relay_chain_local.1))
 		},
 	}
 }
@@ -386,6 +388,7 @@ where
 
 	let (relay_chain_interface, collator_key) = build_relay_chain_interface(
 		polkadot_config,
+		&parachain_config,
 		telemetry_worker_handle,
 		&mut task_manager,
 		collator_options.clone(),
@@ -571,6 +574,7 @@ where
 	let mut task_manager = params.task_manager;
 	let (relay_chain_interface, collator_key) = build_relay_chain_interface(
 		polkadot_config,
+		&parachain_config,
 		telemetry_worker_handle,
 		&mut task_manager,
 		collator_options.clone(),
@@ -1372,6 +1376,7 @@ where
 
 	let (relay_chain_interface, collator_key) = build_relay_chain_interface(
 		polkadot_config,
+		&parachain_config,
 		telemetry_worker_handle,
 		&mut task_manager,
 		collator_options.clone(),

--- a/polkadot-parachains/src/service.rs
+++ b/polkadot-parachains/src/service.rs
@@ -295,15 +295,12 @@ async fn build_relay_chain_interface(
 	match collator_options.relay_chain_rpc_url {
 		Some(relay_chain_url) =>
 			Ok((Arc::new(RelayChainRPCInterface::new(relay_chain_url).await?) as Arc<_>, None)),
-		None => {
-			let relay_chain_local = build_inprocess_relay_chain(
-				polkadot_config,
-				parachain_config,
-				telemetry_worker_handle,
-				task_manager,
-			)?;
-			Ok((relay_chain_local.0, relay_chain_local.1))
-		},
+		None => build_inprocess_relay_chain(
+			polkadot_config,
+			parachain_config,
+			telemetry_worker_handle,
+			task_manager,
+		),
 	}
 }
 


### PR DESCRIPTION
- Fixes #928 
- If someone starts a parachain full node, we now use `IsCollator::No`, but still start the overseer with the option introduced in https://github.com/paritytech/polkadot/issues/4763 
- update parking_lot to 0.12.0 which we use in other locations of this project