### PR TITLE
service_overweight not operational dispatch

### DIFF
--- a/pallets/xcmp-queue/src/lib.rs
+++ b/pallets/xcmp-queue/src/lib.rs
@@ -130,7 +130,7 @@ pub mod pallet {
 		///
 		/// Events:
 		/// - `OverweightServiced`: On success.
-		#[pallet::weight((weight_limit.saturating_add(1_000_000), DispatchClass::Operational,))]
+		#[pallet::weight(weight_limit.saturating_add(1_000_000))]
 		pub fn service_overweight(
 			origin: OriginFor<T>,
 			index: OverweightIndex,


### PR DESCRIPTION
This puts the dispatch level back to what it was for service_overweight.
I mistakenly added it in https://github.com/paritytech/cumulus/pull/982
(The other comments mentioned in the PR will be fixed in a separate PR as those relate to improvements/bugfixes of existing code)