### PR TITLE
--json-file param is nicer.

### DIFF
--- a/scripts/benchmarks.sh
+++ b/scripts/benchmarks.sh
@@ -35,7 +35,7 @@ do
 		--extrinsic='*' \
 		--steps=$steps  \
 		--repeat=$repeat \
-		--json \
+		--json-file=./bench-statemine.json \
         --header=./file_header.txt \
 		--output=$statemineOutput
 
@@ -47,7 +47,7 @@ do
 		--extrinsic='*' \
 		--steps=$steps  \
 		--repeat=$repeat \
-		--json \
+		--json-file=./bench-statemint.json \
         --header=./file_header.txt \
 		--output=$statemintOutput
 
@@ -59,7 +59,7 @@ do
 		--extrinsic='*' \
 		--steps=$steps  \
 		--repeat=$repeat \
-		--json \
+		--json-file=./bench-westmint.json \
         --header=./file_header.txt \
 		--output=$westmintOutput
 done


### PR DESCRIPTION
As suggested by comment [here](https://github.com/paritytech/cumulus/pull/1012): to use `--json-file`