### PR TITLE
Skip runtime migrations for the client release

### DIFF
--- a/scripts/ci/changelog/templates/change.md.tera
+++ b/scripts/ci/changelog/templates/change.md.tera
@@ -25,7 +25,6 @@
 {%- set audit = "" -%}
 {%- endif -%}
 #}
-
 {%- if c.html_url is containing("polkadot") -%}
 {%- set repo = dot -%}
 {%- elif c.html_url is containing("cumulus") -%}
@@ -35,11 +34,11 @@
 {%- else -%}
 {%- set repo = "   " -%}
 {%- endif -%}
-
+{# #}
 {%- if c.meta.T and c.meta.T.value == 6 -%}
 {%- set xcm = " [✉️ XCM]" -%}
 {%- else -%}
 {%- set xcm = "" -%}
 {%- endif -%}
 {{- repo }} {{ audit }}[`#{{c.number}}`]({{c.html_url}}) {{- prio }} - {{ c.title | capitalize | truncate(length=60, end="…") }}{{xcm }}
-{%- endmacro change -%}
+{%- endmacro change %}

--- a/scripts/ci/changelog/templates/debug.md.tera
+++ b/scripts/ci/changelog/templates/debug.md.tera
@@ -1,5 +1,4 @@
 {%- set to_ignore = changes | filter(attribute="meta.B.value", value=0) %}
-
 <!--
 ## Debug
 

--- a/scripts/ci/changelog/templates/host_functions.md.tera
+++ b/scripts/ci/changelog/templates/host_functions.md.tera
@@ -1,4 +1,5 @@
 {%- import "change.md.tera" as m_c -%}
+
 {%- set_global host_fn_count = 0 -%}
 
 {# We loop first to count the number of host functions but we do not display anything yet #}

--- a/scripts/ci/changelog/templates/template.md.tera
+++ b/scripts/ci/changelog/templates/template.md.tera
@@ -18,22 +18,19 @@ This release contains the changes from `{{ env.REF1 }}` to `{{ env.REF2 }}`.
 
 {# We check for host function first because no matter what the priority is, #}
 {# we will force it to HIGH if at least one host function was detected. #}
+
 {% include "host_functions.md.tera" -%}
-
 {% include "global_priority.md.tera" -%}
-
 {% include "compiler.md.tera" -%}
-
 {% include "migrations-db.md.tera" -%}
-
-{% include "migrations-runtime.md.tera" -%}
 
 {% if env.RELEASE_TYPE and env.RELEASE_TYPE == "client" %}
 <!-- skipping runtime data for RELEASE_TYPE = {{ env.RELEASE_TYPE }} -->
 {% else %}
+{% include "migrations-runtime.md.tera" -%}
+
 {% include "runtimes.md.tera" -%}
 {% endif %}
 
 {% include "changes.md.tera" -%}
-
 {% include "docker_image.md.tera" -%}


### PR DESCRIPTION
Also removes a bunch of empty lines for a nice output