### PR TITLE
Hide unwanted hashes for parachain runtimes

### DIFF
--- a/scripts/ci/changelog/templates/runtime.md.tera
+++ b/scripts/ci/changelog/templates/runtime.md.tera
@@ -10,18 +10,18 @@
 {%- endif %}
 
 {%- set comp_ratio = 100 - (runtime.data.runtimes.compressed.subwasm.compression.size_compressed / runtime.data.runtimes.compressed.subwasm.compression.size_decompressed *100) %}
-<!-- commit : {{ runtime.data.commit }} -->
-<!-- tag    : {{ runtime.data.tag }} -->
-<!-- branch : {{ runtime.data.branch }} -->
-<!-- pkg    : {{ runtime.data.pkg }} -->
+<!-- commit             : {{ runtime.data.commit }} -->
+<!-- tag                : {{ runtime.data.tag }} -->
+<!-- branch             : {{ runtime.data.branch }} -->
+<!-- pkg                : {{ runtime.data.pkg }} -->
+<!-- system.setCode     : {{ runtime.data.runtimes.compressed.subwasm.proposal_hash }} -->
+<!-- authorizeUpgrade   : {{ runtime.data.runtimes.compressed.subwasm.parachain_authorize_upgrade_hash }} -->
 
 ```
 🏋️ Runtime Size:		{{ runtime.data.runtimes.compressed.subwasm.size | filesizeformat }} ({{ runtime.data.runtimes.compressed.subwasm.size }} bytes)
 🔥 Core Version:		{{ runtime.data.runtimes.compressed.subwasm.core_version }}
 🗜 Compressed:			{{ compressed }}: {{ comp_ratio | round(method="ceil", precision=2) }}%
 🎁 Metadata version:		V{{ runtime.data.runtimes.compressed.subwasm.metadata_version }}
-🗳️ system.setCode hash:		{{ runtime.data.runtimes.compressed.subwasm.proposal_hash }}
-🗳️ authorizeUpgrade hash:	{{ runtime.data.runtimes.compressed.subwasm.parachain_authorize_upgrade_hash }}
 #️⃣ Blake2-256 hash:		{{ runtime.data.runtimes.compressed.subwasm.blake2_256 }}
 📦 IPFS:			{{ runtime.data.runtimes.compressed.subwasm.ipfs_hash }}
 ```


### PR DESCRIPTION
This PR renders the cumulus runtimes as:

```
🏋️ Runtime Size:		651.85 KB (667493 bytes)
🔥 Core Version:		statemine-601 (statemine-0.tx4.au1)
🗜 Compressed:			Yes: 77.07%
🎁 Metadata version:		V14
#️⃣ Blake2-256 hash:		0x107c1bfb7a0e0b1d5a9a283be8b7ce782672099ab2aa881392d141173748cf5d
📦 IPFS:			QmcziqCFvbFr8mh3oRPS1wWNMHZBgJDzsjMk1KDkw7DA6v
```

instead of the previous:
```
🏋️ Runtime Size:		651.85 KB (667493 bytes)
🔥 Core Version:		statemine-601 (statemine-0.tx4.au1)
🗜 Compressed:			Yes: 77.07%
🎁 Metadata version:		V14
🗳️ system.setCode hash:		0x9663230d1468b395ebc02f63da0efb3cb0acb97d920e8395afa2c5bf937e31f0
🗳️ authorizeUpgrade hash:	0x87131b07d387638df843a93a21b90b46cb44ab48c69ead728903ac134aef4a61
#️⃣ Blake2-256 hash:		0x107c1bfb7a0e0b1d5a9a283be8b7ce782672099ab2aa881392d141173748cf5d
📦 IPFS:			QmcziqCFvbFr8mh3oRPS1wWNMHZBgJDzsjMk1KDkw7DA6v
```
