### PR TITLE
create .github/pr-custom-review.yml

### DIFF
--- a/.github/pr-custom-review.yml
+++ b/.github/pr-custom-review.yml
@@ -1,0 +1,29 @@
+# 🔒 PROTECTED: Changes to locks-review-team should be approved by the current locks-review-team
+locks-review-team: cumulus-locks-review
+team-leads-team: polkadot-review
+action-review-team: ci
+
+rules:
+  - name: Runtime files
+    check_type: changed_files
+    condition: ^polkadot-parachains/(statemine|statemint)/src/[^/]+\.rs$
+    all_distinct:
+      - min_approvals: 1
+        teams:
+          - cumulus-locks-review
+      - min_approvals: 1
+        teams:
+          - polkadot-review
+
+  - name: Core developers
+    check_type: changed_files
+    condition:
+      include: .*
+      exclude: ^polkadot-parachains/(statemine|statemint)/src/[^/]+\.rs$
+    min_approvals: 2
+    teams:
+      - core-devs
+
+prevent_review_request:
+  teams:
+    - core-devs


### PR DESCRIPTION
:warning: The inclusion of pr-custom-review.yml does not incur immediate application of its rules. This file will start to be used only after the GitHub workflow is added, as demonstrated by https://github.com/paritytech/substrate/pull/10951/files.

---

This PR implements the requirements discussed in https://github.com/paritytech/pr-custom-review/pull/67. Feel free to comment there for any disagreements.

The missing requirement is implemented as a [built-in check](https://github.com/paritytech/pr-custom-review/tree/5814820aa0e5d35412f31dc02f9d130a8b138cae#built-in-checks), therefore it should not be included here.

Creates .github/pr-custom-review.yml

- Syntax in accordance to https://github.com/paritytech/pr-custom-review/tree/5814820aa0e5d35412f31dc02f9d130a8b138cae#configuration-syntax

- Rules in accordance to https://github.com/paritytech/pr-custom-review/pull/67/files#diff-54ea723241231828f6cea5e58275577fb2860c25d321b75dac6e01c75e5c831b