### PR TITLE
Fix rules for benchmarks and publish

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -48,7 +48,7 @@ variables:
     - if: $CI_PIPELINE_SOURCE == "web" &&
           $CI_COMMIT_REF_NAME == "master"                           # run from web and on master branch
     - if: $CI_PIPELINE_SOURCE == "web" &&
-          $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # run from web and on v* tag (i.e. v1.0, v2.1rc1)
+          $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # run from web and on version tag (i.e. v1.0, v2.1rc1)
     - if: $CI_PIPELINE_SOURCE == "schedule"
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
 
@@ -56,7 +56,7 @@ variables:
 .benchmarks-manual-refs:           &benchmarks-manual-refs
   rules:
     - if: $CI_PIPELINE_SOURCE == "web" &&
-          $CI_COMMIT_REF_NAME =~ /^release-parachains-v[0-9]+\.[0-9]+.*$/              # run from web and on branch release-parachains-v* (1.0, 2.1rc1)
+          $CI_COMMIT_REF_NAME =~ /^release-parachains-v[0-9]+\.[0-9]+.*$/              # run from web and on branch release-parachains-v* (i.e. 1.0, 2.1rc1)
       when: manual
     - if: $CI_COMMIT_REF_NAME =~ /^release-parachains-v[0-9]+\.[0-9]+.*$/              # i.e. release-parachains-v1.0, release-parachains-v2.1rc1
       when: manual
@@ -65,7 +65,7 @@ variables:
 .benchmarks-refs:                  &benchmarks-refs
   rules:
     - if: $CI_PIPELINE_SOURCE == "web" &&
-          $CI_COMMIT_REF_NAME =~ /^release-parachains-v[0-9]+\.[0-9]+.*$/              # run from web and on branch release-parachains-v* (1.0, 2.1rc1)
+          $CI_COMMIT_REF_NAME =~ /^release-parachains-v[0-9]+\.[0-9]+.*$/              # run from web and on branch release-parachains-v* (i.e. 1.0, 2.1rc1)
     - if: $CI_COMMIT_REF_NAME =~ /^release-parachains-v[0-9]+\.[0-9]+.*$/              # i.e. release-parachains-v1.0, release-parachains-v2.1rc1
 
 .docker-env:                       &docker-env

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -46,7 +46,8 @@ variables:
 .publish-refs:                     &publish-refs
   rules:
     - if: $CI_PIPELINE_SOURCE == "web" && $CI_COMMIT_REF_NAME == "master"
-    - if: $CI_PIPELINE_SOURCE == "web" && $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/
+    - if: $CI_PIPELINE_SOURCE == "web" &&
+          $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
     - if: $CI_PIPELINE_SOURCE == "schedule"
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
 
@@ -54,7 +55,7 @@ variables:
 .benchmarks-manual-refs:           &benchmarks-manual-refs
   rules:
     - if: $CI_PIPELINE_SOURCE == "web" &&
-          $CI_COMMIT_REF_NAME =~ /^release-parachains-v[0-9]+\.[0-9]+.*$/
+          $CI_COMMIT_REF_NAME =~ /^release-parachains-v[0-9]+\.[0-9]+.*$/              # run from web and on branch release-parachains-v* (1.0, 2.1rc1)
       when: manual
     - if: $CI_COMMIT_REF_NAME =~ /^release-parachains-v[0-9]+\.[0-9]+.*$/              # i.e. release-parachains-v1.0, release-parachains-v2.1rc1
       when: manual
@@ -63,7 +64,7 @@ variables:
 .benchmarks-refs:                  &benchmarks-refs
   rules:
     - if: $CI_PIPELINE_SOURCE == "web" &&
-          $CI_COMMIT_REF_NAME =~ /^release-parachains-v[0-9]+\.[0-9]+.*$/
+          $CI_COMMIT_REF_NAME =~ /^release-parachains-v[0-9]+\.[0-9]+.*$/              # run from web and on branch release-parachains-v* (1.0, 2.1rc1)
     - if: $CI_COMMIT_REF_NAME =~ /^release-parachains-v[0-9]+\.[0-9]+.*$/              # i.e. release-parachains-v1.0, release-parachains-v2.1rc1
 
 .docker-env:                       &docker-env

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -45,8 +45,8 @@ variables:
 
 .publish-refs:                     &publish-refs
   rules:
-    - if: $CI_PIPELINE_SOURCE == "web" &&
-          $CI_COMMIT_REF_NAME !~ /^release-parachains-v[0-9]+\.[0-9]+.*$/
+    - if: $CI_PIPELINE_SOURCE == "web" && $CI_COMMIT_REF_NAME == "master"
+    - if: $CI_PIPELINE_SOURCE == "web" && $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/
     - if: $CI_PIPELINE_SOURCE == "schedule"
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -45,21 +45,26 @@ variables:
 
 .publish-refs:                     &publish-refs
   rules:
-    - if: $CI_PIPELINE_SOURCE == "web"
+    - if: $CI_PIPELINE_SOURCE == "web" &&
+          $CI_COMMIT_REF_NAME !~ /^release-parachains-v[0-9]+\.[0-9]+.*$/
     - if: $CI_PIPELINE_SOURCE == "schedule"
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
 
 # run benchmarks manually only on release-parachains-v* branch
 .benchmarks-manual-refs:           &benchmarks-manual-refs
   rules:
+    - if: $CI_PIPELINE_SOURCE == "web" &&
+          $CI_COMMIT_REF_NAME =~ /^release-parachains-v[0-9]+\.[0-9]+.*$/
+      when: manual
     - if: $CI_COMMIT_REF_NAME =~ /^release-parachains-v[0-9]+\.[0-9]+.*$/              # i.e. release-parachains-v1.0, release-parachains-v2.1rc1
       when: manual
 
 # run benchmarks only on release-parachains-v* branch
 .benchmarks-refs:                  &benchmarks-refs
   rules:
+    - if: $CI_PIPELINE_SOURCE == "web" &&
+          $CI_COMMIT_REF_NAME =~ /^release-parachains-v[0-9]+\.[0-9]+.*$/
     - if: $CI_COMMIT_REF_NAME =~ /^release-parachains-v[0-9]+\.[0-9]+.*$/              # i.e. release-parachains-v1.0, release-parachains-v2.1rc1
-      when: manual
 
 .docker-env:                       &docker-env
   image:                           "${CI_IMAGE}"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -45,9 +45,10 @@ variables:
 
 .publish-refs:                     &publish-refs
   rules:
-    - if: $CI_PIPELINE_SOURCE == "web" && $CI_COMMIT_REF_NAME == "master"
     - if: $CI_PIPELINE_SOURCE == "web" &&
-          $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
+          $CI_COMMIT_REF_NAME == "master"                           # run from web and on master branch
+    - if: $CI_PIPELINE_SOURCE == "web" &&
+          $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # run from web and on v* tag (i.e. v1.0, v2.1rc1)
     - if: $CI_PIPELINE_SOURCE == "schedule"
     - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
 


### PR DESCRIPTION
Fixed manual execution benchmarks from web, also added additional condition to run `Publish` only on `master` and tags `v*` from web

Part of https://github.com/paritytech/ci_cd/issues/260