### PR TITLE
[ci] Fix `benchmarks-build`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -202,7 +202,7 @@ benchmarks-build:
   script:
     - time cargo build --profile production --locked --features runtime-benchmarks
     - mkdir artifacts
-    - cp $CARGO_TARGET_DIR/production/polkadot-collator ./artifacts/
+    - cp target/production/polkadot-collator ./artifacts/
 
 benchmarks:
   stage:                           benchmarks-run


### PR DESCRIPTION
The `benchmarks-build` job didn't work, because `$CARGO_TARGET_DIR` variable was deleted