### PR TITLE
Implement set_block_number for runtime-bencmarks in RelayBlockNumberP…

### DIFF
--- a/pallets/parachain-system/Cargo.toml
+++ b/pallets/parachain-system/Cargo.toml
@@ -73,3 +73,7 @@ std = [
 	"sp-trie/std",
 	"xcm/std"
 ]
+
+runtime-benchmarks = [
+	"sp-runtime/runtime-benchmarks"
+]

--- a/pallets/parachain-system/src/lib.rs
+++ b/pallets/parachain-system/src/lib.rs
@@ -1047,4 +1047,11 @@ impl<T: Config> BlockNumberProvider for RelaychainBlockNumberProvider<T> {
 			.map(|d| d.relay_parent_number)
 			.unwrap_or_default()
 	}
+	#[cfg(feature = "runtime-benchmarks")]
+	fn set_block_number(block: Self::BlockNumber) {
+		if let Some(mut validation_data) = Pallet::<T>::validation_data() {
+			validation_data.relay_parent_number = block;
+			ValidationData::<T>::put(validation_data)
+		}
+	}
 }


### PR DESCRIPTION
Implement set_block_number to for runtime-benchmark fetaures in RelayBlockNumberProvider. This is important to benchmark https://github.com/PureStake/nimbus/tree/main/pallets/author-inherent. where we need the slot to be increasing for benchmarking  `kick_off_authorship_validation`