### PR TITLE
Make sure when storage is empty we set the block number

### DIFF
--- a/pallets/parachain-system/src/lib.rs
+++ b/pallets/parachain-system/src/lib.rs
@@ -1049,9 +1049,8 @@ impl<T: Config> BlockNumberProvider for RelaychainBlockNumberProvider<T> {
 	}
 	#[cfg(feature = "runtime-benchmarks")]
 	fn set_block_number(block: Self::BlockNumber) {
-		if let Some(mut validation_data) = Pallet::<T>::validation_data() {
-			validation_data.relay_parent_number = block;
-			ValidationData::<T>::put(validation_data)
-		}
+		let mut validation_data = Pallet::<T>::validation_data().unwrap_or_default();
+		validation_data.relay_parent_number = block;
+		ValidationData::<T>::put(validation_data)
 	}
 }


### PR DESCRIPTION
I made a PR yesterday that only updated the relay number if the ValidationData was non-empty, but we run into cases where we need also to update it if its empty. This PR fixes this.

The previous PR https://github.com/paritytech/cumulus/pull/1187