### PR TITLE
Default not implemented for non-std builds for PersistedValidationData

### DIFF
--- a/pallets/parachain-system/src/lib.rs
+++ b/pallets/parachain-system/src/lib.rs
@@ -1049,7 +1049,7 @@ impl<T: Config> BlockNumberProvider for RelaychainBlockNumberProvider<T> {
 	}
 	#[cfg(feature = "runtime-benchmarks")]
 	fn set_block_number(block: Self::BlockNumber) {
-		let mut validation_data = Pallet::<T>::validation_data().unwrap_or(
+		let mut validation_data = Pallet::<T>::validation_data().unwrap_or_else(||
 			// PersistedValidationData does not impl default in non-std
 			PersistedValidationData {
 				parent_head: vec![].into(),

--- a/pallets/parachain-system/src/lib.rs
+++ b/pallets/parachain-system/src/lib.rs
@@ -321,7 +321,7 @@ pub mod pallet {
 				.read_upgrade_go_ahead_signal()
 				.expect("Invalid upgrade go ahead signal");
 			match upgrade_go_ahead_signal {
-				Some(relay_chain::v1::UpgradeGoAhead::GoAhead) => {
+				Some(relay_chain::v2::UpgradeGoAhead::GoAhead) => {
 					assert!(
 						<PendingValidationCode<T>>::exists(),
 						"No new validation function found in storage, GoAhead signal is not expected",
@@ -332,7 +332,7 @@ pub mod pallet {
 					<T::OnSystemEvent as OnSystemEvent>::on_validation_code_applied();
 					Self::deposit_event(Event::ValidationFunctionApplied(vfp.relay_parent_number));
 				},
-				Some(relay_chain::v1::UpgradeGoAhead::Abort) => {
+				Some(relay_chain::v2::UpgradeGoAhead::Abort) => {
 					<PendingValidationCode<T>>::kill();
 					Self::deposit_event(Event::ValidationFunctionDiscarded);
 				},
@@ -483,7 +483,7 @@ pub mod pallet {
 	/// set after the inherent.
 	#[pallet::storage]
 	pub(super) type UpgradeRestrictionSignal<T: Config> =
-		StorageValue<_, Option<relay_chain::v1::UpgradeRestriction>, ValueQuery>;
+		StorageValue<_, Option<relay_chain::v2::UpgradeRestriction>, ValueQuery>;
 
 	/// The state proof for the last relay parent block.
 	///
@@ -542,7 +542,7 @@ pub mod pallet {
 	/// This will be cleared in `on_initialize` of each new block.
 	#[pallet::storage]
 	pub(super) type HrmpWatermark<T: Config> =
-		StorageValue<_, relay_chain::v2::BlockNumber, ValueQuery>;
+		StorageValue<_, relay_chain::v1::BlockNumber, ValueQuery>;
 
 	/// HRMP messages that were sent in a block.
 	///
@@ -790,7 +790,7 @@ impl<T: Config> Pallet<T> {
 	fn process_inbound_horizontal_messages(
 		ingress_channels: &[(ParaId, cumulus_primitives_core::AbridgedHrmpChannel)],
 		horizontal_messages: BTreeMap<ParaId, Vec<InboundHrmpMessage>>,
-		relay_parent_number: relay_chain::v2::BlockNumber,
+		relay_parent_number: relay_chain::v1::BlockNumber,
 	) -> Weight {
 		// First, check that all submitted messages are sent from channels that exist. The
 		// channel exists if its MQC head is present in `vfp.hrmp_mqc_heads`.

--- a/pallets/parachain-system/src/lib.rs
+++ b/pallets/parachain-system/src/lib.rs
@@ -1056,8 +1056,7 @@ impl<T: Config> BlockNumberProvider for RelaychainBlockNumberProvider<T> {
 				relay_parent_number: Default::default(),
 				max_pov_size: Default::default(),
 				relay_parent_storage_root: Default::default(),
-			}
-		);
+			});
 		validation_data.relay_parent_number = block;
 		ValidationData::<T>::put(validation_data)
 	}

--- a/pallets/parachain-system/src/lib.rs
+++ b/pallets/parachain-system/src/lib.rs
@@ -542,7 +542,7 @@ pub mod pallet {
 	/// This will be cleared in `on_initialize` of each new block.
 	#[pallet::storage]
 	pub(super) type HrmpWatermark<T: Config> =
-		StorageValue<_, relay_chain::v1::BlockNumber, ValueQuery>;
+		StorageValue<_, relay_chain::v2::BlockNumber, ValueQuery>;
 
 	/// HRMP messages that were sent in a block.
 	///
@@ -790,7 +790,7 @@ impl<T: Config> Pallet<T> {
 	fn process_inbound_horizontal_messages(
 		ingress_channels: &[(ParaId, cumulus_primitives_core::AbridgedHrmpChannel)],
 		horizontal_messages: BTreeMap<ParaId, Vec<InboundHrmpMessage>>,
-		relay_parent_number: relay_chain::v1::BlockNumber,
+		relay_parent_number: relay_chain::v2::BlockNumber,
 	) -> Weight {
 		// First, check that all submitted messages are sent from channels that exist. The
 		// channel exists if its MQC head is present in `vfp.hrmp_mqc_heads`.

--- a/pallets/parachain-system/src/lib.rs
+++ b/pallets/parachain-system/src/lib.rs
@@ -321,7 +321,7 @@ pub mod pallet {
 				.read_upgrade_go_ahead_signal()
 				.expect("Invalid upgrade go ahead signal");
 			match upgrade_go_ahead_signal {
-				Some(relay_chain::v2::UpgradeGoAhead::GoAhead) => {
+				Some(relay_chain::v1::UpgradeGoAhead::GoAhead) => {
 					assert!(
 						<PendingValidationCode<T>>::exists(),
 						"No new validation function found in storage, GoAhead signal is not expected",
@@ -332,7 +332,7 @@ pub mod pallet {
 					<T::OnSystemEvent as OnSystemEvent>::on_validation_code_applied();
 					Self::deposit_event(Event::ValidationFunctionApplied(vfp.relay_parent_number));
 				},
-				Some(relay_chain::v2::UpgradeGoAhead::Abort) => {
+				Some(relay_chain::v1::UpgradeGoAhead::Abort) => {
 					<PendingValidationCode<T>>::kill();
 					Self::deposit_event(Event::ValidationFunctionDiscarded);
 				},
@@ -483,7 +483,7 @@ pub mod pallet {
 	/// set after the inherent.
 	#[pallet::storage]
 	pub(super) type UpgradeRestrictionSignal<T: Config> =
-		StorageValue<_, Option<relay_chain::v2::UpgradeRestriction>, ValueQuery>;
+		StorageValue<_, Option<relay_chain::v1::UpgradeRestriction>, ValueQuery>;
 
 	/// The state proof for the last relay parent block.
 	///
@@ -542,7 +542,7 @@ pub mod pallet {
 	/// This will be cleared in `on_initialize` of each new block.
 	#[pallet::storage]
 	pub(super) type HrmpWatermark<T: Config> =
-		StorageValue<_, relay_chain::v2::BlockNumber, ValueQuery>;
+		StorageValue<_, relay_chain::v1::BlockNumber, ValueQuery>;
 
 	/// HRMP messages that were sent in a block.
 	///
@@ -790,7 +790,7 @@ impl<T: Config> Pallet<T> {
 	fn process_inbound_horizontal_messages(
 		ingress_channels: &[(ParaId, cumulus_primitives_core::AbridgedHrmpChannel)],
 		horizontal_messages: BTreeMap<ParaId, Vec<InboundHrmpMessage>>,
-		relay_parent_number: relay_chain::v2::BlockNumber,
+		relay_parent_number: relay_chain::v1::BlockNumber,
 	) -> Weight {
 		// First, check that all submitted messages are sent from channels that exist. The
 		// channel exists if its MQC head is present in `vfp.hrmp_mqc_heads`.
@@ -1049,7 +1049,15 @@ impl<T: Config> BlockNumberProvider for RelaychainBlockNumberProvider<T> {
 	}
 	#[cfg(feature = "runtime-benchmarks")]
 	fn set_block_number(block: Self::BlockNumber) {
-		let mut validation_data = Pallet::<T>::validation_data().unwrap_or_default();
+		let mut validation_data = Pallet::<T>::validation_data().unwrap_or(
+			// PersistedValidationData does not impl default in non-std
+			PersistedValidationData {
+				parent_head: vec![].into(),
+				relay_parent_number: Default::default(),
+				max_pov_size: Default::default(),
+				relay_parent_storage_root: Default::default(),
+			}
+		);
 		validation_data.relay_parent_number = block;
 		ValidationData::<T>::put(validation_data)
 	}


### PR DESCRIPTION
cc @bkchr sorry to bother you again about the same thing. When going to benchmark moonbase I realized that PersistedValidationData does not implement default for non-std builds, so we cannot really use unwrap_or_default. Instead I need to initialize manually each of the fields :(.

Here is the fix. I tested the benchmark and it works with this fix. Again, sorry for not realizing about this before!