### PR TITLE
[ci] update review rules

### DIFF
--- a/.github/pr-custom-review.yml
+++ b/.github/pr-custom-review.yml
@@ -19,10 +19,18 @@ rules:
     check_type: changed_files
     condition:
       include: .*
-      exclude: ^polkadot-parachains/(statemine|statemint)/src/[^/]+\.rs$
+      exclude: ^polkadot-parachains/(statemine|statemint)/src/[^/]+\.rs$|^\.gitlab-ci\.yml|^scripts/ci/.*|^\.github/.*
     min_approvals: 2
     teams:
       - core-devs
+
+  - name: CI team
+    check_type: changed_files
+    condition:
+      include: ^\.gitlab-ci\.yml|^scripts/ci/.*|^\.github/.*
+    min_approvals: 2
+    teams:
+      - ci
 
 prevent-review-request:
   teams:

--- a/.github/pr-custom-review.yml
+++ b/.github/pr-custom-review.yml
@@ -19,6 +19,7 @@ rules:
     check_type: changed_files
     condition:
       include: .*
+      # excluding files from 'Runtime files' and 'CI team' rules
       exclude: ^polkadot-parachains/(statemine|statemint)/src/[^/]+\.rs$|^\.gitlab-ci\.yml|^scripts/ci/.*|^\.github/.*
     min_approvals: 2
     teams:


### PR DESCRIPTION
This PR update `pr-custom-review` rules according to https://github.com/paritytech/ci_cd/issues/405

* removes mandatory approval by the @paritytech/core-devs team of CI files `.gitlab-ci.yml`, `.github/.*`, `scripts/ci/.*`
* introduces new approval rule for the CI related stuff  `.gitlab-ci.yml`, `.github/.*`, `scripts/ci/.*` by @paritytech/ci team