### PR TITLE
Runtime Documentation

### DIFF
--- a/parachains/README.md
+++ b/parachains/README.md
@@ -1,0 +1,22 @@
+# Parachains
+
+This directory is the home of Parity-developed parachain runtimes. This directory is _runtime
+focused,_ and does not include builds of parachain _nodes._
+
+The general internal structure is:
+
+- `chain-specs`: Chain specs for the runtimes contained in its sibling dir `runtimes`.
+- `common`: Common configurations, `impl`s, etc. used by several parachain runtimes.
+- `pallets`: FRAME pallets that are specific to parachains.
+- `runtimes`: The entry point for parachain runtimes.
+
+## Common Good Parachains
+
+This directory includes many, but is not limited to,
+[common good parachains](https://wiki.polkadot.network/docs/learn-common-goods). Likewise, not all
+common good parachains are in this repo.
+
+## Releases
+
+The project maintainers generally try to release a set of parachain runtimes for each Polkadot
+Relay Chain runtime release.

--- a/parachains/README.md
+++ b/parachains/README.md
@@ -12,7 +12,7 @@ The general internal structure is:
 
 ## Common Good Parachains
 
-This directory includes many, but is not limited to,
+The `runtimes` directory includes many, but is not limited to,
 [common good parachains](https://wiki.polkadot.network/docs/learn-common-goods). Likewise, not all
 common good parachains are in this repo.
 

--- a/parachains/README.md
+++ b/parachains/README.md
@@ -1,7 +1,7 @@
 # Parachains
 
 This directory is the home of Parity-developed parachain runtimes. This directory is _runtime
-focused,_ and does not include builds of parachain _nodes._
+focused_, and does not include builds of parachain _nodes_.
 
 The general internal structure is:
 

--- a/parachains/runtimes/assets/README.md
+++ b/parachains/runtimes/assets/README.md
@@ -11,6 +11,15 @@ Statemint allows users to:
   asset to justify the existance of accounts sans DOT/KSM.
 - Pay transaction fees using sufficient assets.
 - Transfer (and approve transfer) assets.
+- Interact with the chain via its transactional API or XCM.
 
 Statemint must stay fully aligned with the Relay Chain it is connected to. As such, it will accept
 the Relay Chain's governance origins as its own.
+
+See
+[this article](https://www.parity.io/blog/statemint-generic-assets-chain-proposing-a-common-good-parachain-to-polkadot-governance/)
+for a higher level description.
+
+Wallets, custodians, etc. should see
+[the Polkadot Wiki's Integration Guide](https://wiki.polkadot.network/docs/build-integrate-assets)
+for details about support.

--- a/parachains/runtimes/assets/README.md
+++ b/parachains/runtimes/assets/README.md
@@ -1,0 +1,16 @@
+# Assets Parachain
+
+Implementation of _Statemint,_ a blockchain to support generic assets in the Polkadot and Kusama
+networks.
+
+Statemint allows users to:
+
+- Deploy promise-backed assets, both fungible and non-fungible, with a DOT/KSM deposit.
+- Set admin roles to manage assets and asset classes.
+- Register assets as "self-sufficient" if the Relay Chain agrees, i.e. gain the ability for an
+  asset to justify the existance of accounts sans DOT/KSM.
+- Pay transaction fees using sufficient assets.
+- Transfer (and approve transfer) assets.
+
+Statemint must stay fully aligned with the Relay Chain it is connected to. As such, it will accept
+the Relay Chain's governance origins as its own.

--- a/parachains/runtimes/assets/README.md
+++ b/parachains/runtimes/assets/README.md
@@ -17,7 +17,7 @@ Statemint must stay fully aligned with the Relay Chain it is connected to. As su
 the Relay Chain's governance origins as its own.
 
 See
-[this article](https://www.parity.io/blog/statemint-generic-assets-chain-proposing-a-common-good-parachain-to-polkadot-governance/)
+[the article on Statemint as common good parachain](https://www.parity.io/blog/statemint-generic-assets-chain-proposing-a-common-good-parachain-to-polkadot-governance/)
 for a higher level description.
 
 Wallets, custodians, etc. should see

--- a/parachains/runtimes/assets/README.md
+++ b/parachains/runtimes/assets/README.md
@@ -1,6 +1,6 @@
 # Assets Parachain
 
-Implementation of _Statemint,_ a blockchain to support generic assets in the Polkadot and Kusama
+Implementation of _Statemint_, a blockchain to support generic assets in the Polkadot and Kusama
 networks.
 
 Statemint allows users to:

--- a/parachains/runtimes/assets/statemine/src/lib.rs
+++ b/parachains/runtimes/assets/statemine/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2021 Parity Technologies (UK) Ltd.
+// Copyright (C) 2021-2022 Parity Technologies (UK) Ltd.
 // SPDX-License-Identifier: Apache-2.0
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/parachains/runtimes/assets/statemine/src/lib.rs
+++ b/parachains/runtimes/assets/statemine/src/lib.rs
@@ -13,7 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Statemine runtime.
+//! # Statemine Runtime
+//!
+//! Statemine is the canary network for its Polkadot cousin, Statemint.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![recursion_limit = "256"]

--- a/parachains/runtimes/assets/statemint/src/lib.rs
+++ b/parachains/runtimes/assets/statemint/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2021 Parity Technologies (UK) Ltd.
+// Copyright (C) 2021-2022 Parity Technologies (UK) Ltd.
 // SPDX-License-Identifier: Apache-2.0
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/parachains/runtimes/assets/statemint/src/lib.rs
+++ b/parachains/runtimes/assets/statemint/src/lib.rs
@@ -13,7 +13,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Statemint runtime.
+//! # Statemint Runtime
+//!
+//! Statemint is a parachain that provides an interface to create, manage, and use assets, both
+//! fungible and non-fungible.
+//!
+//! ## Native Balances
+//!
+//! Statemint uses its parent DOT token as its native asset.
+//!
+//! ## Governance
+//!
+//! As a common good parachain, Statemint defers its governance (namely, its `Root` origin), to its
+//! Relay Chain parent, Polkadot.
+//!
+//! ## XCM
+//!
+//! Because Statemint is fully under the control of the Relay Chain, it is meant to be a
+//! `TrustedTeleporter`. It can also serve as a reserve location to other parachains for DOT as well
+//! as other local assets.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![recursion_limit = "256"]

--- a/parachains/runtimes/assets/statemint/src/lib.rs
+++ b/parachains/runtimes/assets/statemint/src/lib.rs
@@ -15,19 +15,32 @@
 
 //! # Statemint Runtime
 //!
-//! Statemint is a parachain that provides an interface to create, manage, and use assets, both
-//! fungible and non-fungible.
+//! Statemint is a parachain that provides an interface to create, manage, and use assets. Assets
+//! may be fungible or non-fungible.
 //!
-//! ## Native Balances
+//! ## Assets
+//!
+//! - Fungibles: Configuration of `pallet-assets`.
+//! - Non-Fungibles (NFTs): Configuration of `pallet-uniques`.
+//!
+//! ## Other Functionality
+//!
+//! ### Native Balances
 //!
 //! Statemint uses its parent DOT token as its native asset.
 //!
-//! ## Governance
+//! ### Governance
 //!
 //! As a common good parachain, Statemint defers its governance (namely, its `Root` origin), to its
 //! Relay Chain parent, Polkadot.
 //!
-//! ## XCM
+//! ### Collator Selection
+//!
+//! Statemint uses `pallet-collator-selection`, a simple first-come-first-served registration
+//! system where collators can reserve a small bond to join the block producer set. There is no
+//! slashing.
+//!
+//! ### XCM
 //!
 //! Because Statemint is fully under the control of the Relay Chain, it is meant to be a
 //! `TrustedTeleporter`. It can also serve as a reserve location to other parachains for DOT as well

--- a/parachains/runtimes/assets/westmint/src/lib.rs
+++ b/parachains/runtimes/assets/westmint/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2021 Parity Technologies (UK) Ltd.
+// Copyright (C) 2021-2022 Parity Technologies (UK) Ltd.
 // SPDX-License-Identifier: Apache-2.0
 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/parachains/runtimes/assets/westmint/src/lib.rs
+++ b/parachains/runtimes/assets/westmint/src/lib.rs
@@ -13,7 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Westmint runtime.
+//! # Westmint Runtime
+//!
+//! Westmint is the testnet for Statemint.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![recursion_limit = "256"]

--- a/parachains/runtimes/contracts/contracts-rococo/src/lib.rs
+++ b/parachains/runtimes/contracts/contracts-rococo/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2021 Parity Technologies (UK) Ltd.
+// Copyright (C) 2018-2022 Parity Technologies (UK) Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
 //
 // This program is free software: you can redistribute it and/or modify

--- a/parachains/runtimes/contracts/contracts-rococo/src/lib.rs
+++ b/parachains/runtimes/contracts/contracts-rococo/src/lib.rs
@@ -14,6 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+//! # Contracts Parachain
+//!
+//! A parachain for using FRAME's `pallet-contracts` and ink! contracts.
+
 #![cfg_attr(not(feature = "std"), no_std)]
 #![recursion_limit = "256"]
 

--- a/parachains/runtimes/starters/seedling/src/lib.rs
+++ b/parachains/runtimes/starters/seedling/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 Parity Technologies (UK) Ltd.
+// Copyright 2019-2022 Parity Technologies (UK) Ltd.
 // This file is part of Cumulus.
 
 // Cumulus is free software: you can redistribute it and/or modify

--- a/parachains/runtimes/starters/seedling/src/lib.rs
+++ b/parachains/runtimes/starters/seedling/src/lib.rs
@@ -14,6 +14,11 @@
 // You should have received a copy of the GNU General Public License
 // along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
 
+//! # Seedling Runtime
+//!
+//! Seedling is a parachain meant to help parachain auction winners migrate a blockchain from
+//! another consensus system (including its own) into the consensus system of a given Relay Chain.
+
 #![cfg_attr(not(feature = "std"), no_std)]
 // `construct_runtime!` does a lot of recursion and requires us to increase the limit to 256.
 #![recursion_limit = "256"]

--- a/parachains/runtimes/starters/seedling/src/lib.rs
+++ b/parachains/runtimes/starters/seedling/src/lib.rs
@@ -17,7 +17,7 @@
 //! # Seedling Runtime
 //!
 //! Seedling is a parachain meant to help parachain auction winners migrate a blockchain from
-//! another consensus system (including its own) into the consensus system of a given Relay Chain.
+//! another consensus system into the consensus system of a given Relay Chain.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 // `construct_runtime!` does a lot of recursion and requires us to increase the limit to 256.

--- a/parachains/runtimes/starters/shell/src/lib.rs
+++ b/parachains/runtimes/starters/shell/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 Parity Technologies (UK) Ltd.
+// Copyright 2019-2022 Parity Technologies (UK) Ltd.
 // This file is part of Cumulus.
 
 // Cumulus is free software: you can redistribute it and/or modify
@@ -18,6 +18,8 @@
 //!
 //! The Shell runtime defines a minimal parachain. It can listen for a downward message authorizing
 //! an upgrade into another parachain.
+//!
+//! Generally (so far) only used as the first parachain on a Relay.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 // `construct_runtime!` does a lot of recursion and requires us to increase the limit to 256.

--- a/parachains/runtimes/starters/shell/src/lib.rs
+++ b/parachains/runtimes/starters/shell/src/lib.rs
@@ -14,6 +14,12 @@
 // You should have received a copy of the GNU General Public License
 // along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
 
+//! # Shell Runtime
+//!
+//! The Shell runtime defines a lightweight parachain with almost no user interface. It can be used
+//! to test parachain block inclusion and finalization on a Relay Chain and listen for a downward
+//! message authorizing an upgrade into another parachain.
+
 #![cfg_attr(not(feature = "std"), no_std)]
 // `construct_runtime!` does a lot of recursion and requires us to increase the limit to 256.
 #![recursion_limit = "256"]

--- a/parachains/runtimes/starters/shell/src/lib.rs
+++ b/parachains/runtimes/starters/shell/src/lib.rs
@@ -16,9 +16,8 @@
 
 //! # Shell Runtime
 //!
-//! The Shell runtime defines a lightweight parachain with almost no user interface. It can be used
-//! to test parachain block inclusion and finalization on a Relay Chain and listen for a downward
-//! message authorizing an upgrade into another parachain.
+//! The Shell runtime defines a minimal parachain. It can listen for a downward message authorizing
+//! an upgrade into another parachain.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 // `construct_runtime!` does a lot of recursion and requires us to increase the limit to 256.

--- a/parachains/runtimes/testing/rococo-parachain/src/lib.rs
+++ b/parachains/runtimes/testing/rococo-parachain/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 Parity Technologies (UK) Ltd.
+// Copyright 2019-2022 Parity Technologies (UK) Ltd.
 // This file is part of Cumulus.
 
 // Cumulus is free software: you can redistribute it and/or modify


### PR DESCRIPTION
Each runtime in `parachains/runtimes` should have documentation with it justifying its existence. Many teams use this repo for many purposes (e.g. production Statemint, devex templates, Rococo testing). Having clear rationale for each runtime's existence should help avoid confusion like in https://github.com/paritytech/cumulus/pull/1223. 