### PR TITLE
Fix client workflow

### DIFF
--- a/.github/workflows/release-02_create-draft.yml
+++ b/.github/workflows/release-02_create-draft.yml
@@ -157,7 +157,7 @@ jobs:
         run: |
           find ${{env.GITHUB_WORKSPACE}} -type f -name "*-srtool-digest.json"
 
-          if [ "$RELEASE_TYPE" == "client" ]; then
+          if [ "$RELEASE_TYPE" != "client" ]; then
             ls -al $SHELL_DIGEST || true
             ls -al $WESTMINT_DIGEST || true
             ls -al $STATEMINE_DIGEST || true


### PR DESCRIPTION
We want to list the runtime digests for NON client releases, not the other way around 🤦 