### PR TITLE
deleted unnecessary repo checkout to fix fetch binary step

### DIFF
--- a/.github/workflows/extrinsic-ordering-check-from-bin.yml
+++ b/.github/workflows/extrinsic-ordering-check-from-bin.yml
@@ -27,7 +27,6 @@ jobs:
       REF_URL: ${{github.event.inputs.reference_url}}
 
     steps:
-      - uses: actions/checkout@v3
 
       - name: Fetch binary
         run: |

--- a/.github/workflows/extrinsic-ordering-check-from-bin.yml
+++ b/.github/workflows/extrinsic-ordering-check-from-bin.yml
@@ -27,7 +27,6 @@ jobs:
       REF_URL: ${{github.event.inputs.reference_url}}
 
     steps:
-
       - name: Fetch binary
         run: |
           echo Fetching $BIN_URL


### PR DESCRIPTION
Context: due to the renaming of the client from `polkadot-collator` to `polkadot-parachain`, fetch the binaries conflicted with the `polkadot-parachain` folder of the repo. But checking out the repo is not required for this workflow.

No repo => no conflict :)