### PR TITLE
bringing back repo checkout and adding a temp dir to avoid name duplication between binary and repo dir

### DIFF
--- a/.github/workflows/extrinsic-ordering-check-from-bin.yml
+++ b/.github/workflows/extrinsic-ordering-check-from-bin.yml
@@ -26,7 +26,7 @@ jobs:
       BIN_URL: ${{github.event.inputs.binary_url}}
       REF_URL: ${{github.event.inputs.reference_url}}
       BIN: node-bin
-      BIN_PATH: ./tmp/node-bin
+      BIN_PATH: ./tmp/$BIN
 
     steps:    
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
@@ -36,7 +36,7 @@ jobs:
           echo Creating a temp dir to download and run binary
           mkdir -p tmp
           echo Fetching $BIN_URL
-          wget $BIN_URL -O tmp/node-bin
+          wget $BIN_URL -O $BIN_PATH
           chmod a+x $BIN_PATH
           $BIN_PATH --version
 

--- a/.github/workflows/extrinsic-ordering-check-from-bin.yml
+++ b/.github/workflows/extrinsic-ordering-check-from-bin.yml
@@ -26,9 +26,14 @@ jobs:
       BIN_URL: ${{github.event.inputs.binary_url}}
       REF_URL: ${{github.event.inputs.reference_url}}
 
-    steps:
+    steps:    
+      - uses: actions/checkout@v3
+
       - name: Fetch binary
         run: |
+          echo Creating a temp dir to download and run binary
+          mkdir -p tmp
+          cd tmp
           echo Fetching $BIN_URL
           wget $BIN_URL
           chmod a+x polkadot-parachain

--- a/.github/workflows/extrinsic-ordering-check-from-bin.yml
+++ b/.github/workflows/extrinsic-ordering-check-from-bin.yml
@@ -23,10 +23,10 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CHAIN: ${{github.event.inputs.chain}}
-      BIN_URL: ${{github.event.inputs.binary_url}}
-      REF_URL: ${{github.event.inputs.reference_url}}
       BIN: node-bin
       BIN_PATH: ./tmp/$BIN
+      BIN_URL: ${{github.event.inputs.binary_url}}
+      REF_URL: ${{github.event.inputs.reference_url}}
 
     steps:    
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2

--- a/.github/workflows/extrinsic-ordering-check-from-bin.yml
+++ b/.github/workflows/extrinsic-ordering-check-from-bin.yml
@@ -25,7 +25,8 @@ jobs:
       CHAIN: ${{github.event.inputs.chain}}
       BIN_URL: ${{github.event.inputs.binary_url}}
       REF_URL: ${{github.event.inputs.reference_url}}
-      BIN: ./tmp/node-bin
+      BIN: node-bin
+      BIN_PATH: ./tmp/node-bin
 
     steps:    
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
@@ -36,17 +37,17 @@ jobs:
           mkdir -p tmp
           echo Fetching $BIN_URL
           wget $BIN_URL -O tmp/node-bin
-          chmod a+x $BIN
-          $BIN --version
+          chmod a+x $BIN_PATH
+          $BIN_PATH --version
 
       - name: Start local node
         run: |
           echo Running on $CHAIN
-          $BIN --chain=$CHAIN -- --chain polkadot-local &
+          $BIN_PATH --chain=$CHAIN -- --chain polkadot-local &
 
       - name: Prepare output
         run: |
-          VERSION=$($BIN --version)
+          VERSION=$($BIN_PATH --version)
           echo "Metadata comparison:" >> output.txt
           echo "Date: $(date)" >> output.txt
           echo "Reference: $REF_URL" >> output.txt
@@ -74,7 +75,7 @@ jobs:
 
       - name: Stop our local node
         run: |
-          pkill node-bin
+          pkill $BIN
         continue-on-error: true
 
       - name: Save output as artifact

--- a/.github/workflows/extrinsic-ordering-check-from-bin.yml
+++ b/.github/workflows/extrinsic-ordering-check-from-bin.yml
@@ -25,6 +25,7 @@ jobs:
       CHAIN: ${{github.event.inputs.chain}}
       BIN_URL: ${{github.event.inputs.binary_url}}
       REF_URL: ${{github.event.inputs.reference_url}}
+      BIN: ./tmp/node-bin
 
     steps:    
       - uses: actions/checkout@v3
@@ -33,20 +34,19 @@ jobs:
         run: |
           echo Creating a temp dir to download and run binary
           mkdir -p tmp
-          cd tmp
           echo Fetching $BIN_URL
-          wget $BIN_URL
-          chmod a+x polkadot-parachain
-          ./polkadot-parachain --version
+          wget $BIN_URL -O tmp/node-bin
+          chmod a+x $BIN
+          $BIN --version
 
       - name: Start local node
         run: |
           echo Running on $CHAIN
-          ./polkadot-parachain --chain=$CHAIN -- --chain polkadot-local &
+          $BIN --chain=$CHAIN -- --chain polkadot-local &
 
       - name: Prepare output
         run: |
-          VERSION=$(./polkadot-parachain --version)
+          VERSION=$($BIN --version)
           echo "Metadata comparison:" >> output.txt
           echo "Date: $(date)" >> output.txt
           echo "Reference: $REF_URL" >> output.txt
@@ -74,7 +74,7 @@ jobs:
 
       - name: Stop our local node
         run: |
-          pkill polkadot-parachain
+          pkill node-bin
         continue-on-error: true
 
       - name: Save output as artifact


### PR DESCRIPTION
As it turned out we still do need to checkout a repo to be able to use scripts later in pipeline. That's why we need to introduce a temp dir where we download and run binary.

reverting changes from [1296](https://github.com/paritytech/cumulus/pull/1296)