### PR TITLE
bump txn versions due to reduced calls

### DIFF
--- a/parachains/runtimes/assets/statemine/src/lib.rs
+++ b/parachains/runtimes/assets/statemine/src/lib.rs
@@ -87,7 +87,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_version: 9220,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
-	transaction_version: 6,
+	transaction_version: 7,
 	state_version: 0,
 };
 

--- a/parachains/runtimes/assets/statemint/src/lib.rs
+++ b/parachains/runtimes/assets/statemint/src/lib.rs
@@ -117,7 +117,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_version: 9220,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
-	transaction_version: 6,
+	transaction_version: 7,
 	state_version: 0,
 };
 

--- a/parachains/runtimes/assets/westmint/src/lib.rs
+++ b/parachains/runtimes/assets/westmint/src/lib.rs
@@ -85,7 +85,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_version: 9220,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
-	transaction_version: 6,
+	transaction_version: 7,
 	state_version: 0,
 };
 


### PR DESCRIPTION
We need to bump transaction versions due to reduced calls. Based on Extrinsic ordering check: #1288 