### PR TITLE
fix benchmarks output dir creation

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -211,9 +211,9 @@ benchmarks:
   <<:                              *collect-artifacts
   <<:                              *benchmarks-refs
   script:
-    - ./scripts/benchmarks-ci.sh statemine > ./artifacts/bench-statemine.log
-    - ./scripts/benchmarks-ci.sh statemint > ./artifacts/bench-statemint.log
-    - ./scripts/benchmarks-ci.sh westmint > ./artifacts/bench-westmint.log
+    - ./scripts/ci/benchmarks-ci.sh statemine > ./artifacts/bench-statemine.log
+    - ./scripts/ci/benchmarks-ci.sh statemint > ./artifacts/bench-statemint.log
+    - ./scripts/ci/benchmarks-ci.sh westmint > ./artifacts/bench-westmint.log
     - git status
     - export BRANCHNAME="weights-${CI_COMMIT_BRANCH}"
     # Set git config

--- a/scripts/ci/benchmarks-ci.sh
+++ b/scripts/ci/benchmarks-ci.sh
@@ -21,6 +21,8 @@ pallets=(
 	frame_system
 )
 
+mkdir -p $benhcmarkOutput
+
 for p in ${pallets[@]}
 do
 	./artifacts/polkadot-parachain benchmark pallet \


### PR DESCRIPTION
Fix `benchmarks-ci.sh` failure `Error: Io(Os { code: 2, kind: NotFound, message: "No such file or directory" })`

Appears that `polkadot-parachain benchmark` failing when target output dir is not present on the filesystem.

Similar to https://github.com/paritytech/cumulus/pull/1312 but fixes `master`