### PR TITLE
Statemint Should Not Recognise DOT Reserves

### DIFF
--- a/parachain-template/runtime/src/xcm_config.rs
+++ b/parachain-template/runtime/src/xcm_config.rs
@@ -127,24 +127,27 @@ impl ShouldExecute for DenyReserveTransferToRelayChain {
 				InitiateReserveWithdraw {
 					reserve: MultiLocation { parents: 1, interior: Here },
 					..
-				} | DepositReserveAsset { dest: MultiLocation { parents: 1, interior: Here }, .. } |
-					TransferReserveAsset {
-						dest: MultiLocation { parents: 1, interior: Here },
-						..
-					}
+				} |
+				DepositReserveAsset { dest: MultiLocation { parents: 1, interior: Here }, .. } |
+				TransferReserveAsset {
+					dest: MultiLocation { parents: 1, interior: Here },
+					..
+				}
 			)
 		}) {
 			return Err(()) // Deny
 		}
 
-		// allow reserve transfers to arrive from relay chain
+		// Deny reserve transfers to arrive from the Relay Chain. This should never hit if
+		// `IsReserve` is configured properly.
 		if matches!(origin, MultiLocation { parents: 1, interior: Here }) &&
 			message.0.iter().any(|inst| matches!(inst, ReserveAssetDeposited { .. }))
 		{
 			log::warn!(
 				target: "xcm::barriers",
-				"Unexpected ReserveAssetDeposited from the relay chain",
+				"Unexpected ReserveAssetDeposited from the Relay Chain",
 			);
+			return Err(()) // Deny
 		}
 		// Permit everything else
 		Ok(())

--- a/parachain-template/runtime/src/xcm_config.rs
+++ b/parachain-template/runtime/src/xcm_config.rs
@@ -127,19 +127,18 @@ impl ShouldExecute for DenyReserveTransferToRelayChain {
 				InitiateReserveWithdraw {
 					reserve: MultiLocation { parents: 1, interior: Here },
 					..
-				} |
-				DepositReserveAsset { dest: MultiLocation { parents: 1, interior: Here }, .. } |
-				TransferReserveAsset {
-					dest: MultiLocation { parents: 1, interior: Here },
-					..
-				}
+				} | DepositReserveAsset { dest: MultiLocation { parents: 1, interior: Here }, .. } |
+					TransferReserveAsset {
+						dest: MultiLocation { parents: 1, interior: Here },
+						..
+					}
 			)
 		}) {
 			return Err(()) // Deny
 		}
 
-		// Deny reserve transfers to arrive from the Relay Chain. This should never hit if
-		// `IsReserve` is configured properly.
+		// An unexpected reserve transfers has arrived from the Relay Chain. Generally, `IsReserve`
+		// should not allow this, but we just log it here.
 		if matches!(origin, MultiLocation { parents: 1, interior: Here }) &&
 			message.0.iter().any(|inst| matches!(inst, ReserveAssetDeposited { .. }))
 		{
@@ -147,7 +146,6 @@ impl ShouldExecute for DenyReserveTransferToRelayChain {
 				target: "xcm::barriers",
 				"Unexpected ReserveAssetDeposited from the Relay Chain",
 			);
-			return Err(()) // Deny
 		}
 		// Permit everything else
 		Ok(())

--- a/parachain-template/runtime/src/xcm_config.rs
+++ b/parachain-template/runtime/src/xcm_config.rs
@@ -137,7 +137,7 @@ impl ShouldExecute for DenyReserveTransferToRelayChain {
 			return Err(()) // Deny
 		}
 
-		// An unexpected reserve transfers has arrived from the Relay Chain. Generally, `IsReserve`
+		// An unexpected reserve transfer has arrived from the Relay Chain. Generally, `IsReserve`
 		// should not allow this, but we just log it here.
 		if matches!(origin, MultiLocation { parents: 1, interior: Here }) &&
 			message.0.iter().any(|inst| matches!(inst, ReserveAssetDeposited { .. }))

--- a/parachains/common/src/xcm_config.rs
+++ b/parachains/common/src/xcm_config.rs
@@ -42,24 +42,27 @@ impl ShouldExecute for DenyReserveTransferToRelayChain {
 				InitiateReserveWithdraw {
 					reserve: MultiLocation { parents: 1, interior: Here },
 					..
-				} | DepositReserveAsset { dest: MultiLocation { parents: 1, interior: Here }, .. } |
-					TransferReserveAsset {
-						dest: MultiLocation { parents: 1, interior: Here },
-						..
-					}
+				} |
+				DepositReserveAsset { dest: MultiLocation { parents: 1, interior: Here }, .. } |
+				TransferReserveAsset {
+					dest: MultiLocation { parents: 1, interior: Here },
+					..
+				}
 			)
 		}) {
 			return Err(()) // Deny
 		}
 
-		// allow reserve transfers to arrive from relay chain
+		// Deny reserve transfers to arrive from the Relay Chain. This should never hit if
+		// `IsReserve` is configured properly.
 		if matches!(origin, MultiLocation { parents: 1, interior: Here }) &&
 			message.0.iter().any(|inst| matches!(inst, ReserveAssetDeposited { .. }))
 		{
 			log::warn!(
 				target: "xcm::barrier",
-				"Unexpected ReserveAssetDeposited from the relay chain",
+				"Rejected ReserveAssetDeposited from the Relay Chain",
 			);
+			return Err(()) // Deny
 		}
 		// Permit everything else
 		Ok(())

--- a/parachains/common/src/xcm_config.rs
+++ b/parachains/common/src/xcm_config.rs
@@ -52,7 +52,7 @@ impl ShouldExecute for DenyReserveTransferToRelayChain {
 			return Err(()) // Deny
 		}
 
-		// An unexpected reserve transfers has arrived from the Relay Chain. Generally, `IsReserve`
+		// An unexpected reserve transfer has arrived from the Relay Chain. Generally, `IsReserve`
 		// should not allow this, but we just log it here.
 		if matches!(origin, MultiLocation { parents: 1, interior: Here }) &&
 			message.0.iter().any(|inst| matches!(inst, ReserveAssetDeposited { .. }))

--- a/parachains/common/src/xcm_config.rs
+++ b/parachains/common/src/xcm_config.rs
@@ -42,27 +42,25 @@ impl ShouldExecute for DenyReserveTransferToRelayChain {
 				InitiateReserveWithdraw {
 					reserve: MultiLocation { parents: 1, interior: Here },
 					..
-				} |
-				DepositReserveAsset { dest: MultiLocation { parents: 1, interior: Here }, .. } |
-				TransferReserveAsset {
-					dest: MultiLocation { parents: 1, interior: Here },
-					..
-				}
+				} | DepositReserveAsset { dest: MultiLocation { parents: 1, interior: Here }, .. } |
+					TransferReserveAsset {
+						dest: MultiLocation { parents: 1, interior: Here },
+						..
+					}
 			)
 		}) {
 			return Err(()) // Deny
 		}
 
-		// Deny reserve transfers to arrive from the Relay Chain. This should never hit if
-		// `IsReserve` is configured properly.
+		// An unexpected reserve transfers has arrived from the Relay Chain. Generally, `IsReserve`
+		// should not allow this, but we just log it here.
 		if matches!(origin, MultiLocation { parents: 1, interior: Here }) &&
 			message.0.iter().any(|inst| matches!(inst, ReserveAssetDeposited { .. }))
 		{
 			log::warn!(
 				target: "xcm::barrier",
-				"Rejected ReserveAssetDeposited from the Relay Chain",
+				"Unexpected ReserveAssetDeposited from the Relay Chain",
 			);
-			return Err(()) // Deny
 		}
 		// Permit everything else
 		Ok(())

--- a/parachains/runtimes/assets/statemine/src/xcm_config.rs
+++ b/parachains/runtimes/assets/statemine/src/xcm_config.rs
@@ -162,7 +162,9 @@ impl xcm_executor::Config for XcmConfig {
 	type XcmSender = XcmRouter;
 	type AssetTransactor = AssetTransactors;
 	type OriginConverter = XcmOriginToTransactDispatchOrigin;
-	// Statemine does not recognize a reserve location for KSM. Users should teleport instead.
+	// Statemine does not recognize a reserve location for any asset. This does not prevent
+	// Statemine acting _as_ a reserve location for KSM and assets created under `pallet-assets`.
+	// For KSM, users must use teleport where allowed (e.g. with the Relay Chain).
 	type IsReserve = ();
 	type IsTeleporter = NativeAsset; // <- should be enough to allow teleportation of KSM
 	type LocationInverter = LocationInverter<Ancestry>;

--- a/parachains/runtimes/assets/statemine/src/xcm_config.rs
+++ b/parachains/runtimes/assets/statemine/src/xcm_config.rs
@@ -162,7 +162,8 @@ impl xcm_executor::Config for XcmConfig {
 	type XcmSender = XcmRouter;
 	type AssetTransactor = AssetTransactors;
 	type OriginConverter = XcmOriginToTransactDispatchOrigin;
-	type IsReserve = NativeAsset;
+	// Statemine does not recognize a reserve location for KSM. Users should teleport instead.
+	type IsReserve = ();
 	type IsTeleporter = NativeAsset; // <- should be enough to allow teleportation of KSM
 	type LocationInverter = LocationInverter<Ancestry>;
 	type Barrier = Barrier;

--- a/parachains/runtimes/assets/statemint/src/xcm_config.rs
+++ b/parachains/runtimes/assets/statemint/src/xcm_config.rs
@@ -162,7 +162,8 @@ impl xcm_executor::Config for XcmConfig {
 	type XcmSender = XcmRouter;
 	type AssetTransactor = AssetTransactors;
 	type OriginConverter = XcmOriginToTransactDispatchOrigin;
-	type IsReserve = NativeAsset;
+	// Statemint does not recognize a reserve location for DOT. Users should teleport instead.
+	type IsReserve = ();
 	type IsTeleporter = NativeAsset; // <- should be enough to allow teleportation of DOT
 	type LocationInverter = LocationInverter<Ancestry>;
 	type Barrier = Barrier;

--- a/parachains/runtimes/assets/statemint/src/xcm_config.rs
+++ b/parachains/runtimes/assets/statemint/src/xcm_config.rs
@@ -162,7 +162,9 @@ impl xcm_executor::Config for XcmConfig {
 	type XcmSender = XcmRouter;
 	type AssetTransactor = AssetTransactors;
 	type OriginConverter = XcmOriginToTransactDispatchOrigin;
-	// Statemint does not recognize a reserve location for DOT. Users should teleport instead.
+	// Statemint does not recognize a reserve location for any asset. This does not prevent
+	// Statemint acting _as_ a reserve location for DOT and assets created under `pallet-assets`.
+	// For DOT, users must use teleport where allowed (e.g. with the Relay Chain).
 	type IsReserve = ();
 	type IsTeleporter = NativeAsset; // <- should be enough to allow teleportation of DOT
 	type LocationInverter = LocationInverter<Ancestry>;

--- a/parachains/runtimes/assets/westmint/src/xcm_config.rs
+++ b/parachains/runtimes/assets/westmint/src/xcm_config.rs
@@ -158,7 +158,8 @@ impl xcm_executor::Config for XcmConfig {
 	type XcmSender = XcmRouter;
 	type AssetTransactor = AssetTransactors;
 	type OriginConverter = XcmOriginToTransactDispatchOrigin;
-	type IsReserve = NativeAsset;
+	// Westmint does not recognize a reserve location for WND. Users should teleport instead.
+	type IsReserve = ();
 	type IsTeleporter = NativeAsset; // <- should be enough to allow teleportation of WND
 	type LocationInverter = LocationInverter<Ancestry>;
 	type Barrier = Barrier;

--- a/parachains/runtimes/assets/westmint/src/xcm_config.rs
+++ b/parachains/runtimes/assets/westmint/src/xcm_config.rs
@@ -158,7 +158,9 @@ impl xcm_executor::Config for XcmConfig {
 	type XcmSender = XcmRouter;
 	type AssetTransactor = AssetTransactors;
 	type OriginConverter = XcmOriginToTransactDispatchOrigin;
-	// Westmint does not recognize a reserve location for WND. Users should teleport instead.
+	// Westmint does not recognize a reserve location for any asset. This does not prevent
+	// Westmint acting _as_ a reserve location for WND and assets created under `pallet-assets`.
+	// For WND, users must use teleport where allowed (e.g. with the Relay Chain).
 	type IsReserve = ();
 	type IsTeleporter = NativeAsset; // <- should be enough to allow teleportation of WND
 	type LocationInverter = LocationInverter<Ancestry>;


### PR DESCRIPTION
Users and applications should use `teleport` to send DOT/KSM between the Relay Chain and Statemint.

A future improvement would be to recognise reserve locations for other assets, like parachain native assets, described in https://github.com/paritytech/cumulus/issues/1317