### PR TITLE
Run the release branch check on the cumulus code releases as well

### DIFF
--- a/.github/workflows/release-01_branch-check.yml
+++ b/.github/workflows/release-01_branch-check.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - release-**v[0-9]+.[0-9]+.[0-9]+ # client
       - release-**v[0-9]+               # runtimes
+      - polkadot-v[0-9]+.[0-9]+.[0-9]+  # cumulus code
 
   workflow_dispatch:
 
@@ -15,7 +16,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      
+
       - name: Run check
         shell: bash
         run: ./scripts/ci/github/check-rel-br

--- a/scripts/ci/github/check-rel-br
+++ b/scripts/ci/github/check-rel-br
@@ -13,7 +13,7 @@ REPO=$(echo "$grv" | cut -d ' ' -f1 | cut -d$'\t' -f2 | cut -d '/' -f2 | cut -d 
 echo "[+] Detected repo: $REPO"
 
 BRANCH=$(git branch --show-current)
-if ! [[ "$BRANCH" =~ ^release.*$ ]]; then
+if ! [[ "$BRANCH" =~ ^release.*$ || "$BRANCH" =~ ^polkadot.*$ ]]; then
     echo "This script is meant to run only on a RELEASE branch."
     echo "Try one of the following branch:"
     git branch -r --format "%(refname:short)" --sort=-committerdate | grep -Ei '/?release' | head


### PR DESCRIPTION
So far, the cumulus code releases (branches `polkadot-v*`) were not checked with the new `check-rel-br` script.
This PR changes that to add the extra check.