### PR TITLE
Lower all Assets / NFT deposits by 10x

### DIFF
--- a/parachains/runtimes/assets/statemine/src/constants.rs
+++ b/parachains/runtimes/assets/statemine/src/constants.rs
@@ -26,8 +26,8 @@ pub mod currency {
 	pub const MILLICENTS: Balance = constants::currency::MILLICENTS;
 
 	pub const fn deposit(items: u32, bytes: u32) -> Balance {
-		// map to 1/10 of what the kusama relay chain charges (v9020)
-		constants::currency::deposit(items, bytes) / 10
+		// map to 1/100 of what the kusama relay chain charges (v9020)
+		constants::currency::deposit(items, bytes) / 100
 	}
 }
 

--- a/parachains/runtimes/assets/statemine/src/lib.rs
+++ b/parachains/runtimes/assets/statemine/src/lib.rs
@@ -210,7 +210,7 @@ impl pallet_transaction_payment::Config for Runtime {
 }
 
 parameter_types! {
-	pub const AssetDeposit: Balance = UNITS; // 1 UNIT deposit to create asset
+	pub const AssetDeposit: Balance = UNITS / 10; // 1 / 10 UNITS deposit to create asset
 	pub const AssetAccountDeposit: Balance = deposit(1, 16);
 	pub const ApprovalDeposit: Balance = EXISTENTIAL_DEPOSIT;
 	pub const AssetsStringLimit: u32 = 50;
@@ -507,8 +507,8 @@ impl pallet_asset_tx_payment::Config for Runtime {
 }
 
 parameter_types! {
-	pub const CollectionDeposit: Balance = UNITS; // 1 UNIT deposit to create asset class
-	pub const ItemDeposit: Balance = UNITS / 100; // 1/100 UNIT deposit to create asset instance
+	pub const CollectionDeposit: Balance = UNITS / 10; // 1 / 10 UNIT deposit to create asset class
+	pub const ItemDeposit: Balance = UNITS / 1_000; // 1 / 1000 UNIT deposit to create asset instance
 	pub const KeyLimit: u32 = 32;	// Max 32 bytes per key
 	pub const ValueLimit: u32 = 64;	// Max 64 bytes per value
 	pub const UniquesMetadataDepositBase: Balance = deposit(1, 129);

--- a/parachains/runtimes/assets/statemint/src/constants.rs
+++ b/parachains/runtimes/assets/statemint/src/constants.rs
@@ -26,8 +26,8 @@ pub mod currency {
 	pub const MILLICENTS: Balance = constants::currency::MILLICENTS;
 
 	pub const fn deposit(items: u32, bytes: u32) -> Balance {
-		// 1/10 of Polkadot v9010
-		constants::currency::deposit(items, bytes) / 10
+		// 1/100 of Polkadot v9010
+		constants::currency::deposit(items, bytes) / 100
 	}
 }
 

--- a/parachains/runtimes/assets/statemint/src/lib.rs
+++ b/parachains/runtimes/assets/statemint/src/lib.rs
@@ -240,7 +240,7 @@ impl pallet_transaction_payment::Config for Runtime {
 }
 
 parameter_types! {
-	pub const AssetDeposit: Balance = UNITS / 10; // 1 / 10 UNITS deposit to create asset
+	pub const AssetDeposit: Balance = 10 * UNITS; // 10 UNITS deposit to create fungible asset class
 	pub const AssetAccountDeposit: Balance = deposit(1, 16);
 	pub const ApprovalDeposit: Balance = EXISTENTIAL_DEPOSIT;
 	pub const AssetsStringLimit: u32 = 50;
@@ -537,8 +537,8 @@ impl pallet_asset_tx_payment::Config for Runtime {
 }
 
 parameter_types! {
-	pub const CollectionDeposit: Balance = UNITS / 10; // 1 / 10 UNIT deposit to create asset class
-	pub const ItemDeposit: Balance = UNITS / 1_000; // 1 / 1000 UNIT deposit to create asset instance
+	pub const CollectionDeposit: Balance = 10 * UNITS; // 10 UNIT deposit to create uniques class
+	pub const ItemDeposit: Balance = UNITS / 100; // 1 / 100 UNIT deposit to create uniques instance
 	pub const KeyLimit: u32 = 32;	// Max 32 bytes per key
 	pub const ValueLimit: u32 = 64;	// Max 64 bytes per value
 	pub const UniquesMetadataDepositBase: Balance = deposit(1, 129);

--- a/parachains/runtimes/assets/statemint/src/lib.rs
+++ b/parachains/runtimes/assets/statemint/src/lib.rs
@@ -240,7 +240,7 @@ impl pallet_transaction_payment::Config for Runtime {
 }
 
 parameter_types! {
-	pub const AssetDeposit: Balance = 100 * DOLLARS; // 100 DOLLARS deposit to create asset
+	pub const AssetDeposit: Balance = UNITS / 10; // 1 / 10 UNITS deposit to create asset
 	pub const AssetAccountDeposit: Balance = deposit(1, 16);
 	pub const ApprovalDeposit: Balance = EXISTENTIAL_DEPOSIT;
 	pub const AssetsStringLimit: u32 = 50;
@@ -537,8 +537,8 @@ impl pallet_asset_tx_payment::Config for Runtime {
 }
 
 parameter_types! {
-	pub const CollectionDeposit: Balance = UNITS; // 1 UNIT deposit to create asset class
-	pub const ItemDeposit: Balance = UNITS / 100; // 1/100 UNIT deposit to create asset instance
+	pub const CollectionDeposit: Balance = UNITS / 10; // 1 / 10 UNIT deposit to create asset class
+	pub const ItemDeposit: Balance = UNITS / 1_000; // 1 / 1000 UNIT deposit to create asset instance
 	pub const KeyLimit: u32 = 32;	// Max 32 bytes per key
 	pub const ValueLimit: u32 = 64;	// Max 64 bytes per value
 	pub const UniquesMetadataDepositBase: Balance = deposit(1, 129);

--- a/parachains/runtimes/assets/westmint/src/constants.rs
+++ b/parachains/runtimes/assets/westmint/src/constants.rs
@@ -26,8 +26,8 @@ pub mod currency {
 	pub const GRAND: Balance = constants::currency::GRAND;
 
 	pub const fn deposit(items: u32, bytes: u32) -> Balance {
-		// 1/10 of Westend testnet
-		constants::currency::deposit(items, bytes) / 10
+		// 1/100 of Westend testnet
+		constants::currency::deposit(items, bytes) / 100
 	}
 }
 

--- a/parachains/runtimes/assets/westmint/src/lib.rs
+++ b/parachains/runtimes/assets/westmint/src/lib.rs
@@ -208,8 +208,8 @@ impl pallet_transaction_payment::Config for Runtime {
 }
 
 parameter_types! {
-	pub const AssetDeposit: Balance = 1 * UNITS; // 1 WND deposit to create asset
-	pub const AssetAccountDeposit: Balance = 1 * UNITS; // 1 WND for an asset account
+	pub const AssetDeposit: Balance = UNITS / 10; // 1 / 10 WND deposit to create asset
+	pub const AssetAccountDeposit: Balance = deposit(1, 16);
 	pub const ApprovalDeposit: Balance = EXISTENTIAL_DEPOSIT;
 	pub const AssetsStringLimit: u32 = 50;
 	/// Key = 32 bytes, Value = 36 bytes (32+1+1+1+1)
@@ -497,8 +497,8 @@ impl pallet_asset_tx_payment::Config for Runtime {
 }
 
 parameter_types! {
-	pub const CollectionDeposit: Balance = UNITS; // 1 UNIT deposit to create asset class
-	pub const ItemDeposit: Balance = UNITS / 100; // 1/100 UNIT deposit to create asset instance
+	pub const CollectionDeposit: Balance = UNITS / 10; // 1 / 10 UNIT deposit to create asset class
+	pub const ItemDeposit: Balance = UNITS / 1_000; // 1 / 1000 UNIT deposit to create asset instance
 	pub const KeyLimit: u32 = 32;	// Max 32 bytes per key
 	pub const ValueLimit: u32 = 64;	// Max 64 bytes per value
 	pub const UniquesMetadataDepositBase: Balance = deposit(1, 129);

--- a/parachains/runtimes/contracts/contracts-rococo/src/constants.rs
+++ b/parachains/runtimes/contracts/contracts-rococo/src/constants.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 pub mod currency {
-	use rococo_runtime_constants as constants;
+	use polkadot_runtime_constants as constants;
 	use polkadot_core_primitives::Balance;
 
 	/// The existential deposit. Set to 1/10 of its parent Relay Chain.
@@ -26,7 +26,7 @@ pub mod currency {
 	pub const MILLICENTS: Balance = constants::currency::MILLICENTS;
 
 	pub const fn deposit(items: u32, bytes: u32) -> Balance {
-		// map to 1/100 of what the rococo relay chain charges (v9020)
+		// map to 1/100 of what the polkadot relay chain charges (v9020)
 		constants::currency::deposit(items, bytes) / 100
 	}
 }

--- a/parachains/runtimes/contracts/contracts-rococo/src/constants.rs
+++ b/parachains/runtimes/contracts/contracts-rococo/src/constants.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 pub mod currency {
-	use polkadot_runtime_constants as constants;
+	use kusama_runtime_constants as constants;
 	use polkadot_core_primitives::Balance;
 
 	/// The existential deposit. Set to 1/10 of its parent Relay Chain.
@@ -26,7 +26,7 @@ pub mod currency {
 	pub const MILLICENTS: Balance = constants::currency::MILLICENTS;
 
 	pub const fn deposit(items: u32, bytes: u32) -> Balance {
-		// map to 1/100 of what the polkadot relay chain charges (v9020)
+		// map to 1/100 of what the kusama relay chain charges (v9020)
 		constants::currency::deposit(items, bytes) / 100
 	}
 }

--- a/parachains/runtimes/contracts/contracts-rococo/src/constants.rs
+++ b/parachains/runtimes/contracts/contracts-rococo/src/constants.rs
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 pub mod currency {
-	use kusama_runtime_constants as constants;
+	use rococo_runtime_constants as constants;
 	use polkadot_core_primitives::Balance;
 
 	/// The existential deposit. Set to 1/10 of its parent Relay Chain.
@@ -26,8 +26,8 @@ pub mod currency {
 	pub const MILLICENTS: Balance = constants::currency::MILLICENTS;
 
 	pub const fn deposit(items: u32, bytes: u32) -> Balance {
-		// map to 1/10 of what the kusama relay chain charges (v9020)
-		constants::currency::deposit(items, bytes) / 10
+		// map to 1/100 of what the rococo relay chain charges (v9020)
+		constants::currency::deposit(items, bytes) / 100
 	}
 }
 


### PR DESCRIPTION
This PR lowers all the deposits of Statemine, Statemint, Westmint, and Contracts-Rococo by 10x.

This was decided based on a high level analysis of the cost of NFT deposits compared to other platforms.

This can always be adjusted later back up if needed.

Also fixes an issue where `contracts-rococo` did not use Rococo deposits.