### PR TITLE
Add instructions for running Docker images on M1

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Otherwise you can compile it with
 ```bash
 docker run --rm -it -w /shellhere/cumulus \
                     -v $(pwd):/shellhere/cumulus \
-                    paritytech/ci-linux:production cargo build --release --locked -p polkadot-parachain
+                    --platform=linux/amd64 paritytech/ci-linux:production cargo build --release --locked -p polkadot-parachain
 sudo chown -R $(id -u):$(id -g) target/
 ```
 


### PR DESCRIPTION
By specifying the `--platform=linux/amd64 ` flag, the image can run on M1 computers otherwise with the current instructions the images fail to run on M1 hardware.