### PR TITLE
Upgrade spec_version to `9230` and bump `transaction_version` for assets parachains.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7690,7 +7690,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot-parachain"
-version = "0.9.220"
+version = "0.9.230"
 dependencies = [
  "assert_cmd",
  "async-trait",

--- a/parachains/runtimes/assets/statemine/src/lib.rs
+++ b/parachains/runtimes/assets/statemine/src/lib.rs
@@ -317,61 +317,57 @@ impl InstanceFilter<Call> for ProxyType {
 	fn filter(&self, c: &Call) -> bool {
 		match self {
 			ProxyType::Any => true,
-			ProxyType::NonTransfer => {
-				!matches!(c, Call::Balances { .. } | Call::Assets { .. } | Call::Uniques { .. })
-			},
+			ProxyType::NonTransfer =>
+				!matches!(c, Call::Balances { .. } | Call::Assets { .. } | Call::Uniques { .. }),
 			ProxyType::CancelProxy => matches!(
 				c,
-				Call::Proxy(pallet_proxy::Call::reject_announcement { .. })
-					| Call::Utility { .. }
-					| Call::Multisig { .. }
+				Call::Proxy(pallet_proxy::Call::reject_announcement { .. }) |
+					Call::Utility { .. } | Call::Multisig { .. }
 			),
 			ProxyType::Assets => {
 				matches!(
 					c,
-					Call::Assets { .. }
-						| Call::Utility { .. } | Call::Multisig { .. }
-						| Call::Uniques { .. }
+					Call::Assets { .. } |
+						Call::Utility { .. } | Call::Multisig { .. } |
+						Call::Uniques { .. }
 				)
 			},
 			ProxyType::AssetOwner => matches!(
 				c,
-				Call::Assets(pallet_assets::Call::create { .. })
-					| Call::Assets(pallet_assets::Call::destroy { .. })
-					| Call::Assets(pallet_assets::Call::transfer_ownership { .. })
-					| Call::Assets(pallet_assets::Call::set_team { .. })
-					| Call::Assets(pallet_assets::Call::set_metadata { .. })
-					| Call::Assets(pallet_assets::Call::clear_metadata { .. })
-					| Call::Uniques(pallet_uniques::Call::create { .. })
-					| Call::Uniques(pallet_uniques::Call::destroy { .. })
-					| Call::Uniques(pallet_uniques::Call::transfer_ownership { .. })
-					| Call::Uniques(pallet_uniques::Call::set_team { .. })
-					| Call::Uniques(pallet_uniques::Call::set_metadata { .. })
-					| Call::Uniques(pallet_uniques::Call::set_attribute { .. })
-					| Call::Uniques(pallet_uniques::Call::set_collection_metadata { .. })
-					| Call::Uniques(pallet_uniques::Call::clear_metadata { .. })
-					| Call::Uniques(pallet_uniques::Call::clear_attribute { .. })
-					| Call::Uniques(pallet_uniques::Call::clear_collection_metadata { .. })
-					| Call::Uniques(pallet_uniques::Call::set_collection_max_supply { .. })
-					| Call::Utility { .. }
-					| Call::Multisig { .. }
+				Call::Assets(pallet_assets::Call::create { .. }) |
+					Call::Assets(pallet_assets::Call::destroy { .. }) |
+					Call::Assets(pallet_assets::Call::transfer_ownership { .. }) |
+					Call::Assets(pallet_assets::Call::set_team { .. }) |
+					Call::Assets(pallet_assets::Call::set_metadata { .. }) |
+					Call::Assets(pallet_assets::Call::clear_metadata { .. }) |
+					Call::Uniques(pallet_uniques::Call::create { .. }) |
+					Call::Uniques(pallet_uniques::Call::destroy { .. }) |
+					Call::Uniques(pallet_uniques::Call::transfer_ownership { .. }) |
+					Call::Uniques(pallet_uniques::Call::set_team { .. }) |
+					Call::Uniques(pallet_uniques::Call::set_metadata { .. }) |
+					Call::Uniques(pallet_uniques::Call::set_attribute { .. }) |
+					Call::Uniques(pallet_uniques::Call::set_collection_metadata { .. }) |
+					Call::Uniques(pallet_uniques::Call::clear_metadata { .. }) |
+					Call::Uniques(pallet_uniques::Call::clear_attribute { .. }) |
+					Call::Uniques(pallet_uniques::Call::clear_collection_metadata { .. }) |
+					Call::Uniques(pallet_uniques::Call::set_collection_max_supply { .. }) |
+					Call::Utility { .. } | Call::Multisig { .. }
 			),
 			ProxyType::AssetManager => matches!(
 				c,
-				Call::Assets(pallet_assets::Call::mint { .. })
-					| Call::Assets(pallet_assets::Call::burn { .. })
-					| Call::Assets(pallet_assets::Call::freeze { .. })
-					| Call::Assets(pallet_assets::Call::thaw { .. })
-					| Call::Assets(pallet_assets::Call::freeze_asset { .. })
-					| Call::Assets(pallet_assets::Call::thaw_asset { .. })
-					| Call::Uniques(pallet_uniques::Call::mint { .. })
-					| Call::Uniques(pallet_uniques::Call::burn { .. })
-					| Call::Uniques(pallet_uniques::Call::freeze { .. })
-					| Call::Uniques(pallet_uniques::Call::thaw { .. })
-					| Call::Uniques(pallet_uniques::Call::freeze_collection { .. })
-					| Call::Uniques(pallet_uniques::Call::thaw_collection { .. })
-					| Call::Utility { .. }
-					| Call::Multisig { .. }
+				Call::Assets(pallet_assets::Call::mint { .. }) |
+					Call::Assets(pallet_assets::Call::burn { .. }) |
+					Call::Assets(pallet_assets::Call::freeze { .. }) |
+					Call::Assets(pallet_assets::Call::thaw { .. }) |
+					Call::Assets(pallet_assets::Call::freeze_asset { .. }) |
+					Call::Assets(pallet_assets::Call::thaw_asset { .. }) |
+					Call::Uniques(pallet_uniques::Call::mint { .. }) |
+					Call::Uniques(pallet_uniques::Call::burn { .. }) |
+					Call::Uniques(pallet_uniques::Call::freeze { .. }) |
+					Call::Uniques(pallet_uniques::Call::thaw { .. }) |
+					Call::Uniques(pallet_uniques::Call::freeze_collection { .. }) |
+					Call::Uniques(pallet_uniques::Call::thaw_collection { .. }) |
+					Call::Utility { .. } | Call::Multisig { .. }
 			),
 			ProxyType::Collator => matches!(
 				c,

--- a/parachains/runtimes/assets/statemine/src/lib.rs
+++ b/parachains/runtimes/assets/statemine/src/lib.rs
@@ -84,10 +84,10 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("statemine"),
 	impl_name: create_runtime_str!("statemine"),
 	authoring_version: 1,
-	spec_version: 9220,
+	spec_version: 9230,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
-	transaction_version: 6,
+	transaction_version: 7,
 	state_version: 0,
 };
 
@@ -317,57 +317,61 @@ impl InstanceFilter<Call> for ProxyType {
 	fn filter(&self, c: &Call) -> bool {
 		match self {
 			ProxyType::Any => true,
-			ProxyType::NonTransfer =>
-				!matches!(c, Call::Balances { .. } | Call::Assets { .. } | Call::Uniques { .. }),
+			ProxyType::NonTransfer => {
+				!matches!(c, Call::Balances { .. } | Call::Assets { .. } | Call::Uniques { .. })
+			},
 			ProxyType::CancelProxy => matches!(
 				c,
-				Call::Proxy(pallet_proxy::Call::reject_announcement { .. }) |
-					Call::Utility { .. } | Call::Multisig { .. }
+				Call::Proxy(pallet_proxy::Call::reject_announcement { .. })
+					| Call::Utility { .. }
+					| Call::Multisig { .. }
 			),
 			ProxyType::Assets => {
 				matches!(
 					c,
-					Call::Assets { .. } |
-						Call::Utility { .. } | Call::Multisig { .. } |
-						Call::Uniques { .. }
+					Call::Assets { .. }
+						| Call::Utility { .. } | Call::Multisig { .. }
+						| Call::Uniques { .. }
 				)
 			},
 			ProxyType::AssetOwner => matches!(
 				c,
-				Call::Assets(pallet_assets::Call::create { .. }) |
-					Call::Assets(pallet_assets::Call::destroy { .. }) |
-					Call::Assets(pallet_assets::Call::transfer_ownership { .. }) |
-					Call::Assets(pallet_assets::Call::set_team { .. }) |
-					Call::Assets(pallet_assets::Call::set_metadata { .. }) |
-					Call::Assets(pallet_assets::Call::clear_metadata { .. }) |
-					Call::Uniques(pallet_uniques::Call::create { .. }) |
-					Call::Uniques(pallet_uniques::Call::destroy { .. }) |
-					Call::Uniques(pallet_uniques::Call::transfer_ownership { .. }) |
-					Call::Uniques(pallet_uniques::Call::set_team { .. }) |
-					Call::Uniques(pallet_uniques::Call::set_metadata { .. }) |
-					Call::Uniques(pallet_uniques::Call::set_attribute { .. }) |
-					Call::Uniques(pallet_uniques::Call::set_collection_metadata { .. }) |
-					Call::Uniques(pallet_uniques::Call::clear_metadata { .. }) |
-					Call::Uniques(pallet_uniques::Call::clear_attribute { .. }) |
-					Call::Uniques(pallet_uniques::Call::clear_collection_metadata { .. }) |
-					Call::Uniques(pallet_uniques::Call::set_collection_max_supply { .. }) |
-					Call::Utility { .. } | Call::Multisig { .. }
+				Call::Assets(pallet_assets::Call::create { .. })
+					| Call::Assets(pallet_assets::Call::destroy { .. })
+					| Call::Assets(pallet_assets::Call::transfer_ownership { .. })
+					| Call::Assets(pallet_assets::Call::set_team { .. })
+					| Call::Assets(pallet_assets::Call::set_metadata { .. })
+					| Call::Assets(pallet_assets::Call::clear_metadata { .. })
+					| Call::Uniques(pallet_uniques::Call::create { .. })
+					| Call::Uniques(pallet_uniques::Call::destroy { .. })
+					| Call::Uniques(pallet_uniques::Call::transfer_ownership { .. })
+					| Call::Uniques(pallet_uniques::Call::set_team { .. })
+					| Call::Uniques(pallet_uniques::Call::set_metadata { .. })
+					| Call::Uniques(pallet_uniques::Call::set_attribute { .. })
+					| Call::Uniques(pallet_uniques::Call::set_collection_metadata { .. })
+					| Call::Uniques(pallet_uniques::Call::clear_metadata { .. })
+					| Call::Uniques(pallet_uniques::Call::clear_attribute { .. })
+					| Call::Uniques(pallet_uniques::Call::clear_collection_metadata { .. })
+					| Call::Uniques(pallet_uniques::Call::set_collection_max_supply { .. })
+					| Call::Utility { .. }
+					| Call::Multisig { .. }
 			),
 			ProxyType::AssetManager => matches!(
 				c,
-				Call::Assets(pallet_assets::Call::mint { .. }) |
-					Call::Assets(pallet_assets::Call::burn { .. }) |
-					Call::Assets(pallet_assets::Call::freeze { .. }) |
-					Call::Assets(pallet_assets::Call::thaw { .. }) |
-					Call::Assets(pallet_assets::Call::freeze_asset { .. }) |
-					Call::Assets(pallet_assets::Call::thaw_asset { .. }) |
-					Call::Uniques(pallet_uniques::Call::mint { .. }) |
-					Call::Uniques(pallet_uniques::Call::burn { .. }) |
-					Call::Uniques(pallet_uniques::Call::freeze { .. }) |
-					Call::Uniques(pallet_uniques::Call::thaw { .. }) |
-					Call::Uniques(pallet_uniques::Call::freeze_collection { .. }) |
-					Call::Uniques(pallet_uniques::Call::thaw_collection { .. }) |
-					Call::Utility { .. } | Call::Multisig { .. }
+				Call::Assets(pallet_assets::Call::mint { .. })
+					| Call::Assets(pallet_assets::Call::burn { .. })
+					| Call::Assets(pallet_assets::Call::freeze { .. })
+					| Call::Assets(pallet_assets::Call::thaw { .. })
+					| Call::Assets(pallet_assets::Call::freeze_asset { .. })
+					| Call::Assets(pallet_assets::Call::thaw_asset { .. })
+					| Call::Uniques(pallet_uniques::Call::mint { .. })
+					| Call::Uniques(pallet_uniques::Call::burn { .. })
+					| Call::Uniques(pallet_uniques::Call::freeze { .. })
+					| Call::Uniques(pallet_uniques::Call::thaw { .. })
+					| Call::Uniques(pallet_uniques::Call::freeze_collection { .. })
+					| Call::Uniques(pallet_uniques::Call::thaw_collection { .. })
+					| Call::Utility { .. }
+					| Call::Multisig { .. }
 			),
 			ProxyType::Collator => matches!(
 				c,

--- a/parachains/runtimes/assets/statemint/src/lib.rs
+++ b/parachains/runtimes/assets/statemint/src/lib.rs
@@ -114,10 +114,10 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("statemint"),
 	impl_name: create_runtime_str!("statemint"),
 	authoring_version: 1,
-	spec_version: 9220,
+	spec_version: 9230,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
-	transaction_version: 6,
+	transaction_version: 7,
 	state_version: 0,
 };
 
@@ -347,57 +347,61 @@ impl InstanceFilter<Call> for ProxyType {
 	fn filter(&self, c: &Call) -> bool {
 		match self {
 			ProxyType::Any => true,
-			ProxyType::NonTransfer =>
-				!matches!(c, Call::Balances { .. } | Call::Assets { .. } | Call::Uniques { .. }),
+			ProxyType::NonTransfer => {
+				!matches!(c, Call::Balances { .. } | Call::Assets { .. } | Call::Uniques { .. })
+			},
 			ProxyType::CancelProxy => matches!(
 				c,
-				Call::Proxy(pallet_proxy::Call::reject_announcement { .. }) |
-					Call::Utility { .. } | Call::Multisig { .. }
+				Call::Proxy(pallet_proxy::Call::reject_announcement { .. })
+					| Call::Utility { .. }
+					| Call::Multisig { .. }
 			),
 			ProxyType::Assets => {
 				matches!(
 					c,
-					Call::Assets { .. } |
-						Call::Utility { .. } | Call::Multisig { .. } |
-						Call::Uniques { .. }
+					Call::Assets { .. }
+						| Call::Utility { .. } | Call::Multisig { .. }
+						| Call::Uniques { .. }
 				)
 			},
 			ProxyType::AssetOwner => matches!(
 				c,
-				Call::Assets(pallet_assets::Call::create { .. }) |
-					Call::Assets(pallet_assets::Call::destroy { .. }) |
-					Call::Assets(pallet_assets::Call::transfer_ownership { .. }) |
-					Call::Assets(pallet_assets::Call::set_team { .. }) |
-					Call::Assets(pallet_assets::Call::set_metadata { .. }) |
-					Call::Assets(pallet_assets::Call::clear_metadata { .. }) |
-					Call::Uniques(pallet_uniques::Call::create { .. }) |
-					Call::Uniques(pallet_uniques::Call::destroy { .. }) |
-					Call::Uniques(pallet_uniques::Call::transfer_ownership { .. }) |
-					Call::Uniques(pallet_uniques::Call::set_team { .. }) |
-					Call::Uniques(pallet_uniques::Call::set_metadata { .. }) |
-					Call::Uniques(pallet_uniques::Call::set_attribute { .. }) |
-					Call::Uniques(pallet_uniques::Call::set_collection_metadata { .. }) |
-					Call::Uniques(pallet_uniques::Call::clear_metadata { .. }) |
-					Call::Uniques(pallet_uniques::Call::clear_attribute { .. }) |
-					Call::Uniques(pallet_uniques::Call::clear_collection_metadata { .. }) |
-					Call::Uniques(pallet_uniques::Call::set_collection_max_supply { .. }) |
-					Call::Utility { .. } | Call::Multisig { .. }
+				Call::Assets(pallet_assets::Call::create { .. })
+					| Call::Assets(pallet_assets::Call::destroy { .. })
+					| Call::Assets(pallet_assets::Call::transfer_ownership { .. })
+					| Call::Assets(pallet_assets::Call::set_team { .. })
+					| Call::Assets(pallet_assets::Call::set_metadata { .. })
+					| Call::Assets(pallet_assets::Call::clear_metadata { .. })
+					| Call::Uniques(pallet_uniques::Call::create { .. })
+					| Call::Uniques(pallet_uniques::Call::destroy { .. })
+					| Call::Uniques(pallet_uniques::Call::transfer_ownership { .. })
+					| Call::Uniques(pallet_uniques::Call::set_team { .. })
+					| Call::Uniques(pallet_uniques::Call::set_metadata { .. })
+					| Call::Uniques(pallet_uniques::Call::set_attribute { .. })
+					| Call::Uniques(pallet_uniques::Call::set_collection_metadata { .. })
+					| Call::Uniques(pallet_uniques::Call::clear_metadata { .. })
+					| Call::Uniques(pallet_uniques::Call::clear_attribute { .. })
+					| Call::Uniques(pallet_uniques::Call::clear_collection_metadata { .. })
+					| Call::Uniques(pallet_uniques::Call::set_collection_max_supply { .. })
+					| Call::Utility { .. }
+					| Call::Multisig { .. }
 			),
 			ProxyType::AssetManager => matches!(
 				c,
-				Call::Assets(pallet_assets::Call::mint { .. }) |
-					Call::Assets(pallet_assets::Call::burn { .. }) |
-					Call::Assets(pallet_assets::Call::freeze { .. }) |
-					Call::Assets(pallet_assets::Call::thaw { .. }) |
-					Call::Assets(pallet_assets::Call::freeze_asset { .. }) |
-					Call::Assets(pallet_assets::Call::thaw_asset { .. }) |
-					Call::Uniques(pallet_uniques::Call::mint { .. }) |
-					Call::Uniques(pallet_uniques::Call::burn { .. }) |
-					Call::Uniques(pallet_uniques::Call::freeze { .. }) |
-					Call::Uniques(pallet_uniques::Call::thaw { .. }) |
-					Call::Uniques(pallet_uniques::Call::freeze_collection { .. }) |
-					Call::Uniques(pallet_uniques::Call::thaw_collection { .. }) |
-					Call::Utility { .. } | Call::Multisig { .. }
+				Call::Assets(pallet_assets::Call::mint { .. })
+					| Call::Assets(pallet_assets::Call::burn { .. })
+					| Call::Assets(pallet_assets::Call::freeze { .. })
+					| Call::Assets(pallet_assets::Call::thaw { .. })
+					| Call::Assets(pallet_assets::Call::freeze_asset { .. })
+					| Call::Assets(pallet_assets::Call::thaw_asset { .. })
+					| Call::Uniques(pallet_uniques::Call::mint { .. })
+					| Call::Uniques(pallet_uniques::Call::burn { .. })
+					| Call::Uniques(pallet_uniques::Call::freeze { .. })
+					| Call::Uniques(pallet_uniques::Call::thaw { .. })
+					| Call::Uniques(pallet_uniques::Call::freeze_collection { .. })
+					| Call::Uniques(pallet_uniques::Call::thaw_collection { .. })
+					| Call::Utility { .. }
+					| Call::Multisig { .. }
 			),
 			ProxyType::Collator => matches!(
 				c,

--- a/parachains/runtimes/assets/statemint/src/lib.rs
+++ b/parachains/runtimes/assets/statemint/src/lib.rs
@@ -347,61 +347,57 @@ impl InstanceFilter<Call> for ProxyType {
 	fn filter(&self, c: &Call) -> bool {
 		match self {
 			ProxyType::Any => true,
-			ProxyType::NonTransfer => {
-				!matches!(c, Call::Balances { .. } | Call::Assets { .. } | Call::Uniques { .. })
-			},
+			ProxyType::NonTransfer =>
+				!matches!(c, Call::Balances { .. } | Call::Assets { .. } | Call::Uniques { .. }),
 			ProxyType::CancelProxy => matches!(
 				c,
-				Call::Proxy(pallet_proxy::Call::reject_announcement { .. })
-					| Call::Utility { .. }
-					| Call::Multisig { .. }
+				Call::Proxy(pallet_proxy::Call::reject_announcement { .. }) |
+					Call::Utility { .. } | Call::Multisig { .. }
 			),
 			ProxyType::Assets => {
 				matches!(
 					c,
-					Call::Assets { .. }
-						| Call::Utility { .. } | Call::Multisig { .. }
-						| Call::Uniques { .. }
+					Call::Assets { .. } |
+						Call::Utility { .. } | Call::Multisig { .. } |
+						Call::Uniques { .. }
 				)
 			},
 			ProxyType::AssetOwner => matches!(
 				c,
-				Call::Assets(pallet_assets::Call::create { .. })
-					| Call::Assets(pallet_assets::Call::destroy { .. })
-					| Call::Assets(pallet_assets::Call::transfer_ownership { .. })
-					| Call::Assets(pallet_assets::Call::set_team { .. })
-					| Call::Assets(pallet_assets::Call::set_metadata { .. })
-					| Call::Assets(pallet_assets::Call::clear_metadata { .. })
-					| Call::Uniques(pallet_uniques::Call::create { .. })
-					| Call::Uniques(pallet_uniques::Call::destroy { .. })
-					| Call::Uniques(pallet_uniques::Call::transfer_ownership { .. })
-					| Call::Uniques(pallet_uniques::Call::set_team { .. })
-					| Call::Uniques(pallet_uniques::Call::set_metadata { .. })
-					| Call::Uniques(pallet_uniques::Call::set_attribute { .. })
-					| Call::Uniques(pallet_uniques::Call::set_collection_metadata { .. })
-					| Call::Uniques(pallet_uniques::Call::clear_metadata { .. })
-					| Call::Uniques(pallet_uniques::Call::clear_attribute { .. })
-					| Call::Uniques(pallet_uniques::Call::clear_collection_metadata { .. })
-					| Call::Uniques(pallet_uniques::Call::set_collection_max_supply { .. })
-					| Call::Utility { .. }
-					| Call::Multisig { .. }
+				Call::Assets(pallet_assets::Call::create { .. }) |
+					Call::Assets(pallet_assets::Call::destroy { .. }) |
+					Call::Assets(pallet_assets::Call::transfer_ownership { .. }) |
+					Call::Assets(pallet_assets::Call::set_team { .. }) |
+					Call::Assets(pallet_assets::Call::set_metadata { .. }) |
+					Call::Assets(pallet_assets::Call::clear_metadata { .. }) |
+					Call::Uniques(pallet_uniques::Call::create { .. }) |
+					Call::Uniques(pallet_uniques::Call::destroy { .. }) |
+					Call::Uniques(pallet_uniques::Call::transfer_ownership { .. }) |
+					Call::Uniques(pallet_uniques::Call::set_team { .. }) |
+					Call::Uniques(pallet_uniques::Call::set_metadata { .. }) |
+					Call::Uniques(pallet_uniques::Call::set_attribute { .. }) |
+					Call::Uniques(pallet_uniques::Call::set_collection_metadata { .. }) |
+					Call::Uniques(pallet_uniques::Call::clear_metadata { .. }) |
+					Call::Uniques(pallet_uniques::Call::clear_attribute { .. }) |
+					Call::Uniques(pallet_uniques::Call::clear_collection_metadata { .. }) |
+					Call::Uniques(pallet_uniques::Call::set_collection_max_supply { .. }) |
+					Call::Utility { .. } | Call::Multisig { .. }
 			),
 			ProxyType::AssetManager => matches!(
 				c,
-				Call::Assets(pallet_assets::Call::mint { .. })
-					| Call::Assets(pallet_assets::Call::burn { .. })
-					| Call::Assets(pallet_assets::Call::freeze { .. })
-					| Call::Assets(pallet_assets::Call::thaw { .. })
-					| Call::Assets(pallet_assets::Call::freeze_asset { .. })
-					| Call::Assets(pallet_assets::Call::thaw_asset { .. })
-					| Call::Uniques(pallet_uniques::Call::mint { .. })
-					| Call::Uniques(pallet_uniques::Call::burn { .. })
-					| Call::Uniques(pallet_uniques::Call::freeze { .. })
-					| Call::Uniques(pallet_uniques::Call::thaw { .. })
-					| Call::Uniques(pallet_uniques::Call::freeze_collection { .. })
-					| Call::Uniques(pallet_uniques::Call::thaw_collection { .. })
-					| Call::Utility { .. }
-					| Call::Multisig { .. }
+				Call::Assets(pallet_assets::Call::mint { .. }) |
+					Call::Assets(pallet_assets::Call::burn { .. }) |
+					Call::Assets(pallet_assets::Call::freeze { .. }) |
+					Call::Assets(pallet_assets::Call::thaw { .. }) |
+					Call::Assets(pallet_assets::Call::freeze_asset { .. }) |
+					Call::Assets(pallet_assets::Call::thaw_asset { .. }) |
+					Call::Uniques(pallet_uniques::Call::mint { .. }) |
+					Call::Uniques(pallet_uniques::Call::burn { .. }) |
+					Call::Uniques(pallet_uniques::Call::freeze { .. }) |
+					Call::Uniques(pallet_uniques::Call::thaw { .. }) |
+					Call::Uniques(pallet_uniques::Call::freeze_collection { .. }) |
+					Call::Uniques(pallet_uniques::Call::thaw_collection { .. }) |
+					Call::Utility { .. } | Call::Multisig { .. }
 			),
 			ProxyType::Collator => matches!(
 				c,

--- a/parachains/runtimes/assets/westmint/src/lib.rs
+++ b/parachains/runtimes/assets/westmint/src/lib.rs
@@ -82,10 +82,10 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("westmint"),
 	impl_name: create_runtime_str!("westmint"),
 	authoring_version: 1,
-	spec_version: 9220,
+	spec_version: 9230,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
-	transaction_version: 6,
+	transaction_version: 7,
 	state_version: 0,
 };
 
@@ -312,57 +312,61 @@ impl InstanceFilter<Call> for ProxyType {
 	fn filter(&self, c: &Call) -> bool {
 		match self {
 			ProxyType::Any => true,
-			ProxyType::NonTransfer =>
-				!matches!(c, Call::Balances { .. } | Call::Assets { .. } | Call::Uniques { .. }),
+			ProxyType::NonTransfer => {
+				!matches!(c, Call::Balances { .. } | Call::Assets { .. } | Call::Uniques { .. })
+			},
 			ProxyType::CancelProxy => matches!(
 				c,
-				Call::Proxy(pallet_proxy::Call::reject_announcement { .. }) |
-					Call::Utility { .. } | Call::Multisig { .. }
+				Call::Proxy(pallet_proxy::Call::reject_announcement { .. })
+					| Call::Utility { .. }
+					| Call::Multisig { .. }
 			),
 			ProxyType::Assets => {
 				matches!(
 					c,
-					Call::Assets { .. } |
-						Call::Utility { .. } | Call::Multisig { .. } |
-						Call::Uniques { .. }
+					Call::Assets { .. }
+						| Call::Utility { .. } | Call::Multisig { .. }
+						| Call::Uniques { .. }
 				)
 			},
 			ProxyType::AssetOwner => matches!(
 				c,
-				Call::Assets(pallet_assets::Call::create { .. }) |
-					Call::Assets(pallet_assets::Call::destroy { .. }) |
-					Call::Assets(pallet_assets::Call::transfer_ownership { .. }) |
-					Call::Assets(pallet_assets::Call::set_team { .. }) |
-					Call::Assets(pallet_assets::Call::set_metadata { .. }) |
-					Call::Assets(pallet_assets::Call::clear_metadata { .. }) |
-					Call::Uniques(pallet_uniques::Call::create { .. }) |
-					Call::Uniques(pallet_uniques::Call::destroy { .. }) |
-					Call::Uniques(pallet_uniques::Call::transfer_ownership { .. }) |
-					Call::Uniques(pallet_uniques::Call::set_team { .. }) |
-					Call::Uniques(pallet_uniques::Call::set_metadata { .. }) |
-					Call::Uniques(pallet_uniques::Call::set_attribute { .. }) |
-					Call::Uniques(pallet_uniques::Call::set_collection_metadata { .. }) |
-					Call::Uniques(pallet_uniques::Call::clear_metadata { .. }) |
-					Call::Uniques(pallet_uniques::Call::clear_attribute { .. }) |
-					Call::Uniques(pallet_uniques::Call::clear_collection_metadata { .. }) |
-					Call::Uniques(pallet_uniques::Call::set_collection_max_supply { .. }) |
-					Call::Utility { .. } | Call::Multisig { .. }
+				Call::Assets(pallet_assets::Call::create { .. })
+					| Call::Assets(pallet_assets::Call::destroy { .. })
+					| Call::Assets(pallet_assets::Call::transfer_ownership { .. })
+					| Call::Assets(pallet_assets::Call::set_team { .. })
+					| Call::Assets(pallet_assets::Call::set_metadata { .. })
+					| Call::Assets(pallet_assets::Call::clear_metadata { .. })
+					| Call::Uniques(pallet_uniques::Call::create { .. })
+					| Call::Uniques(pallet_uniques::Call::destroy { .. })
+					| Call::Uniques(pallet_uniques::Call::transfer_ownership { .. })
+					| Call::Uniques(pallet_uniques::Call::set_team { .. })
+					| Call::Uniques(pallet_uniques::Call::set_metadata { .. })
+					| Call::Uniques(pallet_uniques::Call::set_attribute { .. })
+					| Call::Uniques(pallet_uniques::Call::set_collection_metadata { .. })
+					| Call::Uniques(pallet_uniques::Call::clear_metadata { .. })
+					| Call::Uniques(pallet_uniques::Call::clear_attribute { .. })
+					| Call::Uniques(pallet_uniques::Call::clear_collection_metadata { .. })
+					| Call::Uniques(pallet_uniques::Call::set_collection_max_supply { .. })
+					| Call::Utility { .. }
+					| Call::Multisig { .. }
 			),
 			ProxyType::AssetManager => matches!(
 				c,
-				Call::Assets(pallet_assets::Call::mint { .. }) |
-					Call::Assets(pallet_assets::Call::burn { .. }) |
-					Call::Assets(pallet_assets::Call::freeze { .. }) |
-					Call::Assets(pallet_assets::Call::thaw { .. }) |
-					Call::Assets(pallet_assets::Call::freeze_asset { .. }) |
-					Call::Assets(pallet_assets::Call::thaw_asset { .. }) |
-					Call::Uniques(pallet_uniques::Call::mint { .. }) |
-					Call::Uniques(pallet_uniques::Call::burn { .. }) |
-					Call::Uniques(pallet_uniques::Call::freeze { .. }) |
-					Call::Uniques(pallet_uniques::Call::thaw { .. }) |
-					Call::Uniques(pallet_uniques::Call::freeze_collection { .. }) |
-					Call::Uniques(pallet_uniques::Call::thaw_collection { .. }) |
-					Call::Utility { .. } | Call::Multisig { .. }
+				Call::Assets(pallet_assets::Call::mint { .. })
+					| Call::Assets(pallet_assets::Call::burn { .. })
+					| Call::Assets(pallet_assets::Call::freeze { .. })
+					| Call::Assets(pallet_assets::Call::thaw { .. })
+					| Call::Assets(pallet_assets::Call::freeze_asset { .. })
+					| Call::Assets(pallet_assets::Call::thaw_asset { .. })
+					| Call::Uniques(pallet_uniques::Call::mint { .. })
+					| Call::Uniques(pallet_uniques::Call::burn { .. })
+					| Call::Uniques(pallet_uniques::Call::freeze { .. })
+					| Call::Uniques(pallet_uniques::Call::thaw { .. })
+					| Call::Uniques(pallet_uniques::Call::freeze_collection { .. })
+					| Call::Uniques(pallet_uniques::Call::thaw_collection { .. })
+					| Call::Utility { .. }
+					| Call::Multisig { .. }
 			),
 			ProxyType::Collator => matches!(
 				c,

--- a/parachains/runtimes/assets/westmint/src/lib.rs
+++ b/parachains/runtimes/assets/westmint/src/lib.rs
@@ -312,61 +312,57 @@ impl InstanceFilter<Call> for ProxyType {
 	fn filter(&self, c: &Call) -> bool {
 		match self {
 			ProxyType::Any => true,
-			ProxyType::NonTransfer => {
-				!matches!(c, Call::Balances { .. } | Call::Assets { .. } | Call::Uniques { .. })
-			},
+			ProxyType::NonTransfer =>
+				!matches!(c, Call::Balances { .. } | Call::Assets { .. } | Call::Uniques { .. }),
 			ProxyType::CancelProxy => matches!(
 				c,
-				Call::Proxy(pallet_proxy::Call::reject_announcement { .. })
-					| Call::Utility { .. }
-					| Call::Multisig { .. }
+				Call::Proxy(pallet_proxy::Call::reject_announcement { .. }) |
+					Call::Utility { .. } | Call::Multisig { .. }
 			),
 			ProxyType::Assets => {
 				matches!(
 					c,
-					Call::Assets { .. }
-						| Call::Utility { .. } | Call::Multisig { .. }
-						| Call::Uniques { .. }
+					Call::Assets { .. } |
+						Call::Utility { .. } | Call::Multisig { .. } |
+						Call::Uniques { .. }
 				)
 			},
 			ProxyType::AssetOwner => matches!(
 				c,
-				Call::Assets(pallet_assets::Call::create { .. })
-					| Call::Assets(pallet_assets::Call::destroy { .. })
-					| Call::Assets(pallet_assets::Call::transfer_ownership { .. })
-					| Call::Assets(pallet_assets::Call::set_team { .. })
-					| Call::Assets(pallet_assets::Call::set_metadata { .. })
-					| Call::Assets(pallet_assets::Call::clear_metadata { .. })
-					| Call::Uniques(pallet_uniques::Call::create { .. })
-					| Call::Uniques(pallet_uniques::Call::destroy { .. })
-					| Call::Uniques(pallet_uniques::Call::transfer_ownership { .. })
-					| Call::Uniques(pallet_uniques::Call::set_team { .. })
-					| Call::Uniques(pallet_uniques::Call::set_metadata { .. })
-					| Call::Uniques(pallet_uniques::Call::set_attribute { .. })
-					| Call::Uniques(pallet_uniques::Call::set_collection_metadata { .. })
-					| Call::Uniques(pallet_uniques::Call::clear_metadata { .. })
-					| Call::Uniques(pallet_uniques::Call::clear_attribute { .. })
-					| Call::Uniques(pallet_uniques::Call::clear_collection_metadata { .. })
-					| Call::Uniques(pallet_uniques::Call::set_collection_max_supply { .. })
-					| Call::Utility { .. }
-					| Call::Multisig { .. }
+				Call::Assets(pallet_assets::Call::create { .. }) |
+					Call::Assets(pallet_assets::Call::destroy { .. }) |
+					Call::Assets(pallet_assets::Call::transfer_ownership { .. }) |
+					Call::Assets(pallet_assets::Call::set_team { .. }) |
+					Call::Assets(pallet_assets::Call::set_metadata { .. }) |
+					Call::Assets(pallet_assets::Call::clear_metadata { .. }) |
+					Call::Uniques(pallet_uniques::Call::create { .. }) |
+					Call::Uniques(pallet_uniques::Call::destroy { .. }) |
+					Call::Uniques(pallet_uniques::Call::transfer_ownership { .. }) |
+					Call::Uniques(pallet_uniques::Call::set_team { .. }) |
+					Call::Uniques(pallet_uniques::Call::set_metadata { .. }) |
+					Call::Uniques(pallet_uniques::Call::set_attribute { .. }) |
+					Call::Uniques(pallet_uniques::Call::set_collection_metadata { .. }) |
+					Call::Uniques(pallet_uniques::Call::clear_metadata { .. }) |
+					Call::Uniques(pallet_uniques::Call::clear_attribute { .. }) |
+					Call::Uniques(pallet_uniques::Call::clear_collection_metadata { .. }) |
+					Call::Uniques(pallet_uniques::Call::set_collection_max_supply { .. }) |
+					Call::Utility { .. } | Call::Multisig { .. }
 			),
 			ProxyType::AssetManager => matches!(
 				c,
-				Call::Assets(pallet_assets::Call::mint { .. })
-					| Call::Assets(pallet_assets::Call::burn { .. })
-					| Call::Assets(pallet_assets::Call::freeze { .. })
-					| Call::Assets(pallet_assets::Call::thaw { .. })
-					| Call::Assets(pallet_assets::Call::freeze_asset { .. })
-					| Call::Assets(pallet_assets::Call::thaw_asset { .. })
-					| Call::Uniques(pallet_uniques::Call::mint { .. })
-					| Call::Uniques(pallet_uniques::Call::burn { .. })
-					| Call::Uniques(pallet_uniques::Call::freeze { .. })
-					| Call::Uniques(pallet_uniques::Call::thaw { .. })
-					| Call::Uniques(pallet_uniques::Call::freeze_collection { .. })
-					| Call::Uniques(pallet_uniques::Call::thaw_collection { .. })
-					| Call::Utility { .. }
-					| Call::Multisig { .. }
+				Call::Assets(pallet_assets::Call::mint { .. }) |
+					Call::Assets(pallet_assets::Call::burn { .. }) |
+					Call::Assets(pallet_assets::Call::freeze { .. }) |
+					Call::Assets(pallet_assets::Call::thaw { .. }) |
+					Call::Assets(pallet_assets::Call::freeze_asset { .. }) |
+					Call::Assets(pallet_assets::Call::thaw_asset { .. }) |
+					Call::Uniques(pallet_uniques::Call::mint { .. }) |
+					Call::Uniques(pallet_uniques::Call::burn { .. }) |
+					Call::Uniques(pallet_uniques::Call::freeze { .. }) |
+					Call::Uniques(pallet_uniques::Call::thaw { .. }) |
+					Call::Uniques(pallet_uniques::Call::freeze_collection { .. }) |
+					Call::Uniques(pallet_uniques::Call::thaw_collection { .. }) |
+					Call::Utility { .. } | Call::Multisig { .. }
 			),
 			ProxyType::Collator => matches!(
 				c,

--- a/parachains/runtimes/contracts/contracts-rococo/src/lib.rs
+++ b/parachains/runtimes/contracts/contracts-rococo/src/lib.rs
@@ -115,7 +115,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("contracts-rococo"),
 	impl_name: create_runtime_str!("contracts-rococo"),
 	authoring_version: 1,
-	spec_version: 9220,
+	spec_version: 9230,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/parachains/runtimes/starters/seedling/src/lib.rs
+++ b/parachains/runtimes/starters/seedling/src/lib.rs
@@ -61,7 +61,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("seedling"),
 	impl_name: create_runtime_str!("seedling"),
 	authoring_version: 1,
-	spec_version: 9220,
+	spec_version: 9230,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/parachains/runtimes/testing/rococo-parachain/src/lib.rs
+++ b/parachains/runtimes/testing/rococo-parachain/src/lib.rs
@@ -93,7 +93,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("test-parachain"),
 	impl_name: create_runtime_str!("test-parachain"),
 	authoring_version: 1,
-	spec_version: 9220,
+	spec_version: 9230,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/polkadot-parachain/Cargo.toml
+++ b/polkadot-parachain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polkadot-parachain"
-version = "0.9.220"
+version = "0.9.230"
 authors = ["Parity Technologies <admin@parity.io>"]
 build = "build.rs"
 edition = "2021"


### PR DESCRIPTION
As per planned runtime upgrade for runtime parachains we need to upgrade the version. 
For assets runtimes (statemint/e) it's known that we will need to bump `transaction_version` because of Uniques pallet changes.