### PR TITLE
Derive MaxEncodedLen on cumulus_pallet_xcm::Origin

### DIFF
--- a/pallets/xcm/src/lib.rs
+++ b/pallets/xcm/src/lib.rs
@@ -77,7 +77,7 @@ pub mod pallet {
 	}
 
 	/// Origin for the parachains module.
-	#[derive(PartialEq, Eq, Clone, Encode, Decode, TypeInfo, RuntimeDebug)]
+	#[derive(PartialEq, Eq, Clone, Encode, Decode, TypeInfo, RuntimeDebug, MaxEncodedLen)]
 	#[pallet::origin]
 	pub enum Origin {
 		/// It comes from the (parent) relay chain.


### PR DESCRIPTION
Is a companion for paritytech/substrate#11631, but can be merged on its own.