### PR TITLE
add wss bootnodes to statemine/t chainspec

### DIFF
--- a/parachains/chain-specs/statemine.json
+++ b/parachains/chain-specs/statemine.json
@@ -5,7 +5,15 @@
   "bootNodes": [
     "/ip4/34.77.217.152/tcp/30334/p2p/12D3KooWF63ZxKtZMYs5247WQA8fcTiGJb2osXykc31cmjwNLwem",
     "/ip4/34.77.119.77/tcp/30334/p2p/12D3KooWGowDwrXAh9cxkbPHPHuwMouFHrMcJhCVXcFS2B8vc5Ry",
-    "/ip4/35.188.228.71/tcp/30334/p2p/12D3KooWNqL6XroD35tDAs3DKG7do8dbKvdnACrR7Z3dcKesNcG4"
+    "/ip4/35.188.228.71/tcp/30334/p2p/12D3KooWNqL6XroD35tDAs3DKG7do8dbKvdnACrR7Z3dcKesNcG4",
+    "/dns/statemine-connect-ew1-0.parity-kusama-parachains.parity.io/tcp/30334/p2p/12D3KooWMzvdGcUXxacLdMQzRVrsP1mJrZHcrz8LtGbhLzve84Qx",
+    "/dns/statemine-connect-ew1-0.parity-kusama-parachains.parity.io/tcp/443/wss/p2p/12D3KooWMzvdGcUXxacLdMQzRVrsP1mJrZHcrz8LtGbhLzve84Qx",
+    "/dns/statemine-connect-ew1-1.parity-kusama-parachains.parity.io/tcp/30334/p2p/12D3KooWQmGf5z3DU1kKcZoLzMNgdbP31ybjuwxS1VGLKMUjq5ez",
+    "/dns/statemine-connect-ew1-1.parity-kusama-parachains.parity.io/tcp/443/wss/p2p/12D3KooWQmGf5z3DU1kKcZoLzMNgdbP31ybjuwxS1VGLKMUjq5ez",
+    "/dns/statemine-connect-ue4-0.parity-kusama-parachains.parity.io/tcp/30334/p2p/12D3KooWLm6iHcmA3YD4xn2zfbm4KLF5KSUqJJAnmt2UGr9o2PgB",
+    "/dns/statemine-connect-ue4-0.parity-kusama-parachains.parity.io/tcp/443/wss/p2p/12D3KooWLm6iHcmA3YD4xn2zfbm4KLF5KSUqJJAnmt2UGr9o2PgB",
+    "/dns/statemine-connect-ue4-1.parity-kusama-parachains.parity.io/tcp/30334/p2p/12D3KooWD8Bma5qPbq7N5qdED3Xy6GXHfvfk86TL8aVTQKxmWkHG",
+    "/dns/statemine-connect-ue4-1.parity-kusama-parachains.parity.io/tcp/443/wss/p2p/12D3KooWD8Bma5qPbq7N5qdED3Xy6GXHfvfk86TL8aVTQKxmWkHG"
   ],
   "telemetryEndpoints": null,
   "protocolId": null,

--- a/parachains/chain-specs/statemine.json
+++ b/parachains/chain-specs/statemine.json
@@ -22,7 +22,7 @@
     "tokenDecimals": 12,
     "tokenSymbol": "KSM"
   },
-  "relay_chain": "kusama",
+  "relay_chain": "ksmcc3",
   "para_id": 1000,
   "consensusEngine": null,
   "genesis": {

--- a/parachains/chain-specs/statemine.json
+++ b/parachains/chain-specs/statemine.json
@@ -22,7 +22,7 @@
     "tokenDecimals": 12,
     "tokenSymbol": "KSM"
   },
-  "relay_chain": "ksmcc3",
+  "relay_chain": "kusama",
   "para_id": 1000,
   "consensusEngine": null,
   "genesis": {

--- a/parachains/chain-specs/statemint.json
+++ b/parachains/chain-specs/statemint.json
@@ -6,7 +6,15 @@
     "/ip4/34.65.251.121/tcp/30334/p2p/12D3KooWG3GrM6XKMM4gp3cvemdwUvu96ziYoJmqmetLZBXE8bSa",
     "/ip4/34.65.35.228/tcp/30334/p2p/12D3KooWMRyTLrCEPcAQD6c4EnudL3vVzg9zji3whvsMYPUYevpq",
     "/ip4/34.83.247.146/tcp/30334/p2p/12D3KooWE4jFh5FpJDkWVZhnWtFnbSqRhdjvC7Dp9b8b3FTuubQC",
-    "/ip4/104.199.117.230/tcp/30334/p2p/12D3KooWG9R8pVXKumVo2rdkeVD4j5PVhRTqmYgLHY3a4yPYgLqM"
+    "/ip4/104.199.117.230/tcp/30334/p2p/12D3KooWG9R8pVXKumVo2rdkeVD4j5PVhRTqmYgLHY3a4yPYgLqM",
+    "/dns/statemint-connect-ew6-0.parity-polkadot-parachains.parity.io/tcp/30334/p2p/12D3KooWLHqbcQtoBygf7GJgVjVa3TaeLuf7VbicNdooaCmQM2JZ",
+    "/dns/statemint-connect-ew6-0.parity-polkadot-parachains.parity.io/tcp/443/wss/p2p/12D3KooWLHqbcQtoBygf7GJgVjVa3TaeLuf7VbicNdooaCmQM2JZ",
+    "/dns/statemint-connect-ew6-1.parity-polkadot-parachains.parity.io/tcp/30334/p2p/12D3KooWNDrKSayoZXGGE2dRSFW2g1iGPq3fTZE2U39ma9yZGKd3",
+    "/dns/statemint-connect-ew6-1.parity-polkadot-parachains.parity.io/tcp/443/wss/p2p/12D3KooWNDrKSayoZXGGE2dRSFW2g1iGPq3fTZE2U39ma9yZGKd3",
+    "/dns/statemint-connect-uw1-0.parity-polkadot-parachains.parity.io/tcp/30334/p2p/12D3KooWApa2JW4rbLtgzuK7fjLMupLS9HZheX9cdkQKyu6AnGrP",
+    "/dns/statemint-connect-uw1-0.parity-polkadot-parachains.parity.io/tcp/443/wss/p2p/12D3KooWApa2JW4rbLtgzuK7fjLMupLS9HZheX9cdkQKyu6AnGrP",
+    "/dns/statemint-connect-uw1-1.parity-polkadot-parachains.parity.io/tcp/30334/p2p/12D3KooWRsVeHqRs2iKmjLiguxp8myL4G2mDAWhtX2jHwyWujseV",
+    "/dns/statemint-connect-uw1-1.parity-polkadot-parachains.parity.io/tcp/443/wss/p2p/12D3KooWRsVeHqRs2iKmjLiguxp8myL4G2mDAWhtX2jHwyWujseV"
   ],
   "telemetryEndpoints": null,
   "protocolId": null,


### PR DESCRIPTION
A tutorial on Substrate Connect is being added to the Substrate Developer Hub: https://github.com/substrate-developer-hub/substrate-docs/pull/1122

It uses Statemint as example for Parachain, and a list of WebSocket-enabled bootnodes is necessary for Substrate Connect.