### PR TITLE
rename build_import_queue to not be statemint specific

### DIFF
--- a/polkadot-parachain/src/command.rs
+++ b/polkadot-parachain/src/command.rs
@@ -263,21 +263,21 @@ macro_rules! construct_benchmark_partials {
 			Runtime::Statemine => {
 				let $partials = new_partial::<statemine_runtime::RuntimeApi, _>(
 					&$config,
-					crate::service::statemint_build_import_queue::<_, AuraId>,
+					crate::service::aura_build_import_queue::<_, AuraId>,
 				)?;
 				$code
 			},
 			Runtime::Westmint => {
 				let $partials = new_partial::<westmint_runtime::RuntimeApi, _>(
 					&$config,
-					crate::service::statemint_build_import_queue::<_, AuraId>,
+					crate::service::aura_build_import_queue::<_, AuraId>,
 				)?;
 				$code
 			},
 			Runtime::Statemint => {
 				let $partials = new_partial::<statemint_runtime::RuntimeApi, _>(
 					&$config,
-					crate::service::statemint_build_import_queue::<_, StatemintAuraId>,
+					crate::service::aura_build_import_queue::<_, StatemintAuraId>,
 				)?;
 				$code
 			},
@@ -294,7 +294,7 @@ macro_rules! construct_async_run {
 				runner.async_run(|$config| {
 					let $components = new_partial::<westmint_runtime::RuntimeApi, _>(
 						&$config,
-						crate::service::statemint_build_import_queue::<_, AuraId>,
+						crate::service::aura_build_import_queue::<_, AuraId>,
 					)?;
 					let task_manager = $components.task_manager;
 					{ $( $code )* }.map(|v| (v, task_manager))
@@ -304,7 +304,7 @@ macro_rules! construct_async_run {
 				runner.async_run(|$config| {
 					let $components = new_partial::<statemine_runtime::RuntimeApi, _>(
 						&$config,
-						crate::service::statemint_build_import_queue::<_, AuraId>,
+						crate::service::aura_build_import_queue::<_, AuraId>,
 					)?;
 					let task_manager = $components.task_manager;
 					{ $( $code )* }.map(|v| (v, task_manager))
@@ -314,7 +314,7 @@ macro_rules! construct_async_run {
 				runner.async_run(|$config| {
 					let $components = new_partial::<statemint_runtime::RuntimeApi, _>(
 						&$config,
-						crate::service::statemint_build_import_queue::<_, StatemintAuraId>,
+						crate::service::aura_build_import_queue::<_, StatemintAuraId>,
 					)?;
 					let task_manager = $components.task_manager;
 					{ $( $code )* }.map(|v| (v, task_manager))

--- a/polkadot-parachain/src/service.rs
+++ b/polkadot-parachain/src/service.rs
@@ -1085,8 +1085,8 @@ where
 	}
 }
 
-/// Build the import queue for the statemint/statemine/westmine runtime.
-pub fn statemint_build_import_queue<RuntimeApi, AuraId: AppKey>(
+/// Build the import queue for the statemint and other similar aura based runtimes.
+pub fn aura_build_import_queue<RuntimeApi, AuraId: AppKey>(
 	client: Arc<TFullClient<Block, RuntimeApi, WasmExecutor<HostFunctions>>>,
 	config: &Configuration,
 	telemetry_handle: Option<TelemetryHandle>,
@@ -1203,7 +1203,7 @@ where
 		collator_options,
 		id,
 		|_| Ok(RpcModule::new(())),
-		statemint_build_import_queue::<_, AuraId>,
+		aura_build_import_queue::<_, AuraId>,
 		|client,
 		 prometheus_registry,
 		 telemetry,

--- a/polkadot-parachain/src/service.rs
+++ b/polkadot-parachain/src/service.rs
@@ -1085,7 +1085,7 @@ where
 	}
 }
 
-/// Build the import queue for the statemint and other similar aura based runtimes.
+/// Build the import queue for Statemint and other Aura-based runtimes.
 pub fn aura_build_import_queue<RuntimeApi, AuraId: AppKey>(
 	client: Arc<TFullClient<Block, RuntimeApi, WasmExecutor<HostFunctions>>>,
 	config: &Configuration,


### PR DESCRIPTION
We intend to reuse this across chains (E.g. collectives-polkadot CGP).