### PR TITLE
Fix patch handling for `relay-validation-worker-provider` build script

### DIFF
--- a/test/relay-validation-worker-provider/build.rs
+++ b/test/relay-validation-worker-provider/build.rs
@@ -120,6 +120,9 @@ fn add_patches(project_toml: &mut Table) {
 	)
 	.expect("Workspace root `Cargo.toml` is a valid toml file; qed");
 
+	let mut workspace_path = workspace_toml_path;
+	workspace_path.pop();
+
 	while let Some(mut patch) =
 		workspace_toml.remove("patch").and_then(|p| p.try_into::<Table>().ok())
 	{
@@ -134,7 +137,7 @@ fn add_patches(project_toml: &mut Table) {
 				p.iter_mut().filter(|(k, _)| k == &"path").for_each(|(_, v)| {
 					if let Some(path) = v.as_str().map(PathBuf::from) {
 						if path.is_relative() {
-							*v = workspace_toml_path.join(path).display().to_string().into();
+							*v = workspace_path.join(path).display().to_string().into();
 						}
 					}
 				})


### PR DESCRIPTION
I was seeing build errors on a patched repo.

Problem is that we append relative paths to a filepath. From what I see we want to use the workspace directory, not the 'Cargo.toml' path.