### PR TITLE
rename now shared node creation function

### DIFF
--- a/polkadot-parachain/src/command.rs
+++ b/polkadot-parachain/src/command.rs
@@ -548,21 +548,21 @@ pub fn run() -> Result<()> {
 				info!("Is collating: {}", if config.role.is_authority() { "yes" } else { "no" });
 
 				match config.chain_spec.runtime() {
-					Runtime::Statemint => crate::service::start_statemint_node::<
+					Runtime::Statemint => crate::service::start_generic_aura_node::<
 						statemint_runtime::RuntimeApi,
 						StatemintAuraId,
 					>(config, polkadot_config, collator_options, id, hwbench)
 					.await
 					.map(|r| r.0)
 					.map_err(Into::into),
-					Runtime::Statemine => crate::service::start_statemint_node::<
+					Runtime::Statemine => crate::service::start_generic_aura_node::<
 						statemine_runtime::RuntimeApi,
 						AuraId,
 					>(config, polkadot_config, collator_options, id, hwbench)
 					.await
 					.map(|r| r.0)
 					.map_err(Into::into),
-					Runtime::Westmint => crate::service::start_statemint_node::<
+					Runtime::Westmint => crate::service::start_generic_aura_node::<
 						westmint_runtime::RuntimeApi,
 						AuraId,
 					>(config, polkadot_config, collator_options, id, hwbench)

--- a/polkadot-parachain/src/service.rs
+++ b/polkadot-parachain/src/service.rs
@@ -1165,8 +1165,9 @@ where
 	))
 }
 
-/// Start a statemint/statemine/westmint parachain node.
-pub async fn start_statemint_node<RuntimeApi, AuraId: AppKey>(
+/// Start an aura powered parachain node.
+/// (collective-polkadot and statemine/t use this)
+pub async fn start_generic_aura_node<RuntimeApi, AuraId: AppKey>(
 	parachain_config: Configuration,
 	polkadot_config: Configuration,
 	collator_options: CollatorOptions,


### PR DESCRIPTION
We're going to reuse the same node construction for as many common good parachains as we can (unless there's a particular reason not to). 