### PR TITLE
Disable beefy for inprocess relay chain node (#1382)

### DIFF
--- a/client/relay-chain-inprocess-interface/src/lib.rs
+++ b/client/relay-chain-inprocess-interface/src/lib.rs
@@ -345,7 +345,8 @@ fn build_polkadot_full_node(
 			config,
 			is_collator,
 			None,
-			true,
+			// Disable BEEFY. It should not be required by the internal relay chain node.
+			false,
 			None,
 			telemetry_worker_handle,
 			true,


### PR DESCRIPTION
* Disable beefy for inprocess relay chain node

* Update client/relay-chain-inprocess-interface/src/lib.rs

Co-authored-by: Bastian Köcher <bkchr@users.noreply.github.com>