### PR TITLE
Fix Docker CI

### DIFF
--- a/.github/workflows/release-10_docker-manual.yml
+++ b/.github/workflows/release-10_docker-manual.yml
@@ -9,7 +9,7 @@ on:
     inputs:
       tag:
         description: release tag to build image for
-        default: polkadot-v0.9.17
+        default: v0.9.230
         required: true
       prerelease:
         description: is prerelease
@@ -31,6 +31,7 @@ jobs:
         run: |
           echo "Repo: ${{ github.event.repository.full_name }}"
 
+          mkdir -p tmp; cd tmp
           for f in $BINARY $BINARY.asc $BINARY.sha256; do
             URL="https://github.com/${{ github.event.repository.full_name }}/releases/download/${{ github.event.inputs.tag }}/$f"
             echo " - Fetching $f from $URL"
@@ -41,7 +42,7 @@ jobs:
 
       - name: Check files
         run: |
-          ls -al *collator*
+          ls -al *$BINARY*
           shasum -a 256 -c $BINARY.sha256
           sha_result=$?
 

--- a/.github/workflows/release-10_docker.yml
+++ b/.github/workflows/release-10_docker.yml
@@ -32,6 +32,7 @@ jobs:
           echo "Prerelease: ${{ github.event.release.prerelease }}"
           echo "Assets: ${{ github.event.release.assets }}"
 
+          mkdir -p tmp; cd tmp
           for f in $BINARY $BINARY.asc $BINARY.sha256; do
             URL="https://github.com/${{ github.event.repository.full_name }}/releases/download/${{ github.event.release.tag_name }}/$f"
             echo " - Fetching $f from $URL"
@@ -42,7 +43,7 @@ jobs:
 
       - name: Check files
         run: |
-          ls -al *collator*
+          ls -al *$BINARY*
           shasum -a 256 -c $BINARY.sha256
           sha_result=$?
 


### PR DESCRIPTION
With the recent refactoring, we now have a folder named like the binary we release and that causes troubles when fetching the artifacts from Github into the checked out repo.

To address this, tihs PR downloads the artifacts into a `tmp` folder.