### PR TITLE
standard way to get at the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cumulus ☁️
 
-[![master docs](https://img.shields.io/badge/rust%20doc-master-brightgreen)](https://paritytech.github.io/cumulus/)
+[![Doc](https://img.shields.io/badge/cumulus%20docs-master-brightgreen)](https://paritytech.github.io/cumulus/)
 
 This repository contains both the Cumulus SDK and also specific chains implemented
 on top of this SDK.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Cumulus ☁️
 
+[![master docs](https://img.shields.io/badge/rust%20doc-master-brightgreen)](https://paritytech.github.io/cumulus/)
+
 This repository contains both the Cumulus SDK and also specific chains implemented
 on top of this SDK.
 


### PR DESCRIPTION
small things. Will do the same to substrate and polkadot if this gets approved so there's a consistent button to press in a pretty standard location.