### PR TITLE
Bump lockfile for `polkadot-v0.9.24-1`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -681,7 +681,7 @@ dependencies = [
 [[package]]
 name = "bp-header-chain"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "bp-runtime",
  "finality-grandpa",
@@ -698,7 +698,7 @@ dependencies = [
 [[package]]
 name = "bp-message-dispatch"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "bp-runtime",
  "frame-support",
@@ -710,7 +710,7 @@ dependencies = [
 [[package]]
 name = "bp-messages"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "bitvec",
  "bp-runtime",
@@ -727,7 +727,7 @@ dependencies = [
 [[package]]
 name = "bp-polkadot-core"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -745,7 +745,7 @@ dependencies = [
 [[package]]
 name = "bp-rococo"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "bp-messages",
  "bp-polkadot-core",
@@ -762,7 +762,7 @@ dependencies = [
 [[package]]
 name = "bp-runtime"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "frame-support",
  "hash-db",
@@ -780,7 +780,7 @@ dependencies = [
 [[package]]
 name = "bp-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "bp-header-chain",
  "ed25519-dalek",
@@ -795,7 +795,7 @@ dependencies = [
 [[package]]
 name = "bp-wococo"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "bp-messages",
  "bp-polkadot-core",
@@ -810,7 +810,7 @@ dependencies = [
 [[package]]
 name = "bridge-runtime-common"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "bp-message-dispatch",
  "bp-messages",
@@ -1208,7 +1208,7 @@ dependencies = [
  "parachains-common",
  "parity-scale-codec",
  "polkadot-core-primitives",
- "polkadot-parachain 0.9.24",
+ "polkadot-parachain 0.9.24-1",
  "polkadot-runtime-common",
  "scale-info",
  "serde",
@@ -1700,7 +1700,7 @@ dependencies = [
  "parking_lot 0.12.0",
  "polkadot-client",
  "polkadot-node-primitives",
- "polkadot-parachain 0.9.24",
+ "polkadot-parachain 0.9.24-1",
  "polkadot-primitives",
  "polkadot-service",
  "polkadot-test-client",
@@ -1834,7 +1834,7 @@ dependencies = [
  "log",
  "pallet-balances",
  "parity-scale-codec",
- "polkadot-parachain 0.9.24",
+ "polkadot-parachain 0.9.24-1",
  "sc-client-api",
  "scale-info",
  "serde",
@@ -1953,7 +1953,7 @@ dependencies = [
  "frame-support",
  "parity-scale-codec",
  "polkadot-core-primitives",
- "polkadot-parachain 0.9.24",
+ "polkadot-parachain 0.9.24-1",
  "polkadot-primitives",
  "sp-api",
  "sp-runtime",
@@ -2008,7 +2008,7 @@ dependencies = [
  "frame-support",
  "parity-scale-codec",
  "polkadot-core-primitives",
- "polkadot-parachain 0.9.24",
+ "polkadot-parachain 0.9.24-1",
  "polkadot-primitives",
  "sp-runtime",
  "sp-std",
@@ -2111,7 +2111,7 @@ dependencies = [
  "pallet-balances",
  "pallet-transaction-payment",
  "parity-scale-codec",
- "polkadot-parachain 0.9.24",
+ "polkadot-parachain 0.9.24-1",
  "polkadot-primitives",
  "sc-block-builder",
  "sc-consensus",
@@ -3905,8 +3905,8 @@ checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 
 [[package]]
 name = "kusama-runtime"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "beefy-primitives",
  "bitvec",
@@ -3998,8 +3998,8 @@ dependencies = [
 
 [[package]]
 name = "kusama-runtime-constants"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -5374,7 +5374,7 @@ checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 [[package]]
 name = "orchestra"
 version = "0.0.1"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "async-trait",
  "dyn-clonable",
@@ -5390,7 +5390,7 @@ dependencies = [
 [[package]]
 name = "orchestra-proc-macro"
 version = "0.0.1"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "expander 0.0.6",
  "petgraph",
@@ -5621,7 +5621,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-dispatch"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "bp-message-dispatch",
  "bp-runtime",
@@ -5638,7 +5638,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-grandpa"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "bp-header-chain",
  "bp-runtime",
@@ -5660,7 +5660,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-messages"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "bitvec",
  "bp-message-dispatch",
@@ -6480,8 +6480,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-xcm"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6498,8 +6498,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-xcm-benchmarks"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6551,7 +6551,7 @@ dependencies = [
  "parachain-template-runtime",
  "parity-scale-codec",
  "polkadot-cli",
- "polkadot-parachain 0.9.24",
+ "polkadot-parachain 0.9.24-1",
  "polkadot-primitives",
  "polkadot-service",
  "sc-basic-authorship",
@@ -6626,7 +6626,7 @@ dependencies = [
  "pallet-xcm",
  "parachain-info",
  "parity-scale-codec",
- "polkadot-parachain 0.9.24",
+ "polkadot-parachain 0.9.24-1",
  "polkadot-runtime-common",
  "scale-info",
  "serde",
@@ -7011,8 +7011,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-approval-distribution"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "futures 0.3.21",
  "polkadot-node-network-protocol",
@@ -7026,8 +7026,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "futures 0.3.21",
  "polkadot-node-network-protocol",
@@ -7040,8 +7040,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-availability-distribution"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "derive_more",
  "fatality",
@@ -7063,8 +7063,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-availability-recovery"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "fatality",
  "futures 0.3.21",
@@ -7084,8 +7084,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-cli"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "clap 3.1.18",
  "frame-benchmarking-cli",
@@ -7109,8 +7109,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-client"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "beefy-primitives",
  "frame-benchmarking",
@@ -7149,8 +7149,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-collator-protocol"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "always-assert",
  "fatality",
@@ -7170,8 +7170,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-core-primitives"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "parity-scale-codec",
  "parity-util-mem",
@@ -7183,8 +7183,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-dispute-distribution"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "derive_more",
  "fatality",
@@ -7206,8 +7206,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-erasure-coding"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -7220,8 +7220,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-gossip-support"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "futures 0.3.21",
  "futures-timer",
@@ -7240,8 +7240,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-network-bridge"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "always-assert",
  "async-trait",
@@ -7261,8 +7261,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-collation-generation"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "futures 0.3.21",
  "parity-scale-codec",
@@ -7279,8 +7279,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-approval-voting"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "bitvec",
  "derive_more",
@@ -7308,8 +7308,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-av-store"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "bitvec",
  "futures 0.3.21",
@@ -7328,8 +7328,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-backing"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "bitvec",
  "fatality",
@@ -7347,8 +7347,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "futures 0.3.21",
  "polkadot-node-subsystem",
@@ -7362,8 +7362,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-candidate-validation"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "async-trait",
  "futures 0.3.21",
@@ -7372,7 +7372,7 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-parachain 0.9.24",
+ "polkadot-parachain 0.9.24-1",
  "polkadot-primitives",
  "sp-maybe-compressed-blob",
  "tracing-gum",
@@ -7380,8 +7380,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-chain-api"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "futures 0.3.21",
  "polkadot-node-subsystem",
@@ -7395,8 +7395,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-chain-selection"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "futures 0.3.21",
  "futures-timer",
@@ -7412,8 +7412,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "fatality",
  "futures 0.3.21",
@@ -7431,8 +7431,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "async-trait",
  "futures 0.3.21",
@@ -7448,8 +7448,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-provisioner"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "bitvec",
  "fatality",
@@ -7466,8 +7466,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-pvf"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "always-assert",
  "assert_matches",
@@ -7479,7 +7479,7 @@ dependencies = [
  "pin-project 1.0.10",
  "polkadot-core-primitives",
  "polkadot-node-subsystem-util",
- "polkadot-parachain 0.9.24",
+ "polkadot-parachain 0.9.24-1",
  "rand 0.8.5",
  "sc-executor",
  "sc-executor-common",
@@ -7497,8 +7497,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-pvf-checker"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "futures 0.3.21",
  "polkadot-node-primitives",
@@ -7513,8 +7513,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-runtime-api"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "futures 0.3.21",
  "memory-lru",
@@ -7530,8 +7530,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-jaeger"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "async-std",
  "lazy_static",
@@ -7548,8 +7548,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-metrics"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "bs58",
  "futures 0.3.21",
@@ -7567,8 +7567,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-network-protocol"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -7588,13 +7588,13 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-primitives"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "bounded-vec",
  "futures 0.3.21",
  "parity-scale-codec",
- "polkadot-parachain 0.9.24",
+ "polkadot-parachain 0.9.24-1",
  "polkadot-primitives",
  "schnorrkel",
  "serde",
@@ -7610,8 +7610,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-subsystem"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "polkadot-node-jaeger",
  "polkadot-node-subsystem-types",
@@ -7620,8 +7620,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-subsystem-test-helpers"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "async-trait",
  "futures 0.3.21",
@@ -7638,8 +7638,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-subsystem-types"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "derive_more",
  "futures 0.3.21",
@@ -7657,8 +7657,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-subsystem-util"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -7690,8 +7690,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-overseer"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "futures 0.3.21",
  "futures-timer",
@@ -7712,8 +7712,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-parachain"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "derive_more",
  "frame-support",
@@ -7758,7 +7758,7 @@ dependencies = [
  "parachains-common",
  "parity-scale-codec",
  "polkadot-cli",
- "polkadot-parachain 0.9.24",
+ "polkadot-parachain 0.9.24-1",
  "polkadot-primitives",
  "polkadot-service",
  "rococo-parachain-runtime",
@@ -7806,8 +7806,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-performance-test"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "env_logger 0.9.0",
  "kusama-runtime",
@@ -7821,8 +7821,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-primitives"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "bitvec",
  "frame-system",
@@ -7830,7 +7830,7 @@ dependencies = [
  "parity-scale-codec",
  "parity-util-mem",
  "polkadot-core-primitives",
- "polkadot-parachain 0.9.24",
+ "polkadot-parachain 0.9.24-1",
  "scale-info",
  "serde",
  "sp-api",
@@ -7851,8 +7851,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-rpc"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "beefy-gadget",
  "beefy-gadget-rpc",
@@ -7883,8 +7883,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-runtime"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "beefy-primitives",
  "bitvec",
@@ -7969,8 +7969,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-runtime-common"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "beefy-primitives",
  "bitvec",
@@ -8016,8 +8016,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-runtime-constants"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -8028,8 +8028,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-runtime-metrics"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "bs58",
  "parity-scale-codec",
@@ -8040,8 +8040,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-runtime-parachains"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "bitflags",
  "bitvec",
@@ -8083,8 +8083,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-service"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "async-trait",
  "beefy-gadget",
@@ -8129,7 +8129,7 @@ dependencies = [
  "polkadot-node-subsystem-types",
  "polkadot-node-subsystem-util",
  "polkadot-overseer",
- "polkadot-parachain 0.9.24",
+ "polkadot-parachain 0.9.24-1",
  "polkadot-primitives",
  "polkadot-rpc",
  "polkadot-runtime",
@@ -8186,8 +8186,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-statement-distribution"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "arrayvec 0.5.2",
  "fatality",
@@ -8207,8 +8207,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-statement-table"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -8217,8 +8217,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-test-client"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-subsystem",
@@ -8242,8 +8242,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-test-runtime"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "beefy-primitives",
  "bitvec",
@@ -8271,7 +8271,7 @@ dependencies = [
  "pallet-vesting",
  "pallet-xcm",
  "parity-scale-codec",
- "polkadot-parachain 0.9.24",
+ "polkadot-parachain 0.9.24-1",
  "polkadot-primitives",
  "polkadot-runtime-common",
  "polkadot-runtime-parachains",
@@ -8304,8 +8304,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-test-service"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "frame-benchmarking",
  "frame-system",
@@ -8318,7 +8318,7 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-overseer",
- "polkadot-parachain 0.9.24",
+ "polkadot-parachain 0.9.24-1",
  "polkadot-primitives",
  "polkadot-rpc",
  "polkadot-runtime-common",
@@ -8450,7 +8450,7 @@ dependencies = [
 [[package]]
 name = "prioritized-metered-channel"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "coarsetime",
  "crossbeam-queue",
@@ -9049,7 +9049,7 @@ dependencies = [
  "parachain-info",
  "parachains-common",
  "parity-scale-codec",
- "polkadot-parachain 0.9.24",
+ "polkadot-parachain 0.9.24-1",
  "scale-info",
  "serde",
  "sp-api",
@@ -9072,8 +9072,8 @@ dependencies = [
 
 [[package]]
 name = "rococo-runtime"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "beefy-merkle-tree",
  "beefy-primitives",
@@ -9117,7 +9117,7 @@ dependencies = [
  "pallet-utility",
  "pallet-xcm",
  "parity-scale-codec",
- "polkadot-parachain 0.9.24",
+ "polkadot-parachain 0.9.24-1",
  "polkadot-primitives",
  "polkadot-runtime-common",
  "polkadot-runtime-parachains",
@@ -9149,8 +9149,8 @@ dependencies = [
 
 [[package]]
 name = "rococo-runtime-constants"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -10767,8 +10767,8 @@ checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
 
 [[package]]
 name = "slot-range-helper"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -11626,7 +11626,7 @@ dependencies = [
  "parachains-common",
  "parity-scale-codec",
  "polkadot-core-primitives",
- "polkadot-parachain 0.9.24",
+ "polkadot-parachain 0.9.24-1",
  "polkadot-runtime-common",
  "scale-info",
  "serde",
@@ -11691,7 +11691,7 @@ dependencies = [
  "parachains-common",
  "parity-scale-codec",
  "polkadot-core-primitives",
- "polkadot-parachain 0.9.24",
+ "polkadot-parachain 0.9.24-1",
  "polkadot-runtime-common",
  "polkadot-runtime-constants",
  "scale-info",
@@ -12041,8 +12041,8 @@ checksum = "13a4ec180a2de59b57434704ccfad967f789b12737738798fa08798cd5824c16"
 
 [[package]]
 name = "test-runtime-constants"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -12319,8 +12319,8 @@ dependencies = [
 
 [[package]]
 name = "tracing-gum"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "polkadot-node-jaeger",
  "polkadot-primitives",
@@ -12330,8 +12330,8 @@ dependencies = [
 
 [[package]]
 name = "tracing-gum-proc-macro"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "expander 0.0.6",
  "proc-macro-crate",
@@ -13040,8 +13040,8 @@ dependencies = [
 
 [[package]]
 name = "westend-runtime"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "beefy-primitives",
  "bitvec",
@@ -13095,7 +13095,7 @@ dependencies = [
  "pallet-xcm",
  "pallet-xcm-benchmarks",
  "parity-scale-codec",
- "polkadot-parachain 0.9.24",
+ "polkadot-parachain 0.9.24-1",
  "polkadot-primitives",
  "polkadot-runtime-common",
  "polkadot-runtime-parachains",
@@ -13129,8 +13129,8 @@ dependencies = [
 
 [[package]]
 name = "westend-runtime-constants"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -13181,7 +13181,7 @@ dependencies = [
  "parachains-common",
  "parity-scale-codec",
  "polkadot-core-primitives",
- "polkadot-parachain 0.9.24",
+ "polkadot-parachain 0.9.24-1",
  "polkadot-runtime-common",
  "scale-info",
  "serde",
@@ -13370,8 +13370,8 @@ dependencies = [
 
 [[package]]
 name = "xcm"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "derivative",
  "impl-trait-for-tuples",
@@ -13383,15 +13383,15 @@ dependencies = [
 
 [[package]]
 name = "xcm-builder"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "frame-support",
  "frame-system",
  "log",
  "pallet-transaction-payment",
  "parity-scale-codec",
- "polkadot-parachain 0.9.24",
+ "polkadot-parachain 0.9.24-1",
  "scale-info",
  "sp-arithmetic",
  "sp-io",
@@ -13403,8 +13403,8 @@ dependencies = [
 
 [[package]]
 name = "xcm-executor"
-version = "0.9.24"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+version = "0.9.24-1"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -13422,7 +13422,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#d812985e8882d3aa842ed4358cd356f533f88e61"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.24-1#67c19a335b52662319415669ab286dce06b75b60"
 dependencies = [
  "Inflector",
  "proc-macro2",


### PR DESCRIPTION
Looks like the `polkadot-v0.9.24-1` branch is protected so I can't push this directly to it.

This just updates the Polkadot references to the latest commit on the [`release-v0.9.24-1`](https://github.com/paritytech/polkadot/compare/release-v0.9.24...release-v0.9.24-1?expand=1) branch.