### PR TITLE
Introduce RPC Worker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1951,6 +1951,7 @@ dependencies = [
  "sc-client-api",
  "sc-rpc-api",
  "sc-service",
+ "sc-utils",
  "sp-api",
  "sp-core",
  "sp-runtime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1950,12 +1950,12 @@ dependencies = [
  "polkadot-service",
  "sc-client-api",
  "sc-rpc-api",
- "sc-utils",
  "sp-api",
  "sp-core",
  "sp-runtime",
  "sp-state-machine",
  "sp-storage",
+ "tokio",
  "tracing",
  "url",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1950,7 +1950,6 @@ dependencies = [
  "polkadot-service",
  "sc-client-api",
  "sc-rpc-api",
- "sc-service",
  "sc-utils",
  "sp-api",
  "sp-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2091,6 +2091,7 @@ dependencies = [
  "polkadot-service",
  "sc-client-api",
  "sc-rpc-api",
+ "sc-service",
  "sp-api",
  "sp-core",
  "sp-runtime",

--- a/client/relay-chain-interface/src/lib.rs
+++ b/client/relay-chain-interface/src/lib.rs
@@ -54,7 +54,7 @@ pub enum RelayChainError {
 	RPCCallError(String, JsonRPSeeError),
 	#[error("RPC Error: '{0}'")]
 	JsonRPCError(#[from] JsonRPSeeError),
-	#[error("Unable to reach worker: {0}")]
+	#[error("Unable to reach RPCStreamWorker: {0}")]
 	WorkerCommunicationError(String),
 	#[error("Scale codec deserialization error: {0}")]
 	DeserializationError(CodecError),

--- a/client/relay-chain-interface/src/lib.rs
+++ b/client/relay-chain-interface/src/lib.rs
@@ -29,7 +29,7 @@ use sc_client_api::StorageProof;
 use futures::Stream;
 
 use async_trait::async_trait;
-use jsonrpsee_core::Error as JsonRPSeeError;
+use jsonrpsee_core::Error as JsonRpcError;
 use parity_scale_codec::Error as CodecError;
 use sp_api::ApiError;
 use sp_state_machine::StorageValue;
@@ -51,10 +51,10 @@ pub enum RelayChainError {
 	#[error("State machine error occured: {0}")]
 	StateMachineError(Box<dyn sp_state_machine::Error>),
 	#[error("Unable to call RPC method '{0}' due to error: {1}")]
-	RPCCallError(String, JsonRPSeeError),
+	RpcCallError(String, JsonRpcError),
 	#[error("RPC Error: '{0}'")]
-	JsonRPCError(#[from] JsonRPSeeError),
-	#[error("Unable to reach RPCStreamWorker: {0}")]
+	JsonRpcError(#[from] JsonRpcError),
+	#[error("Unable to reach RpcStreamWorker: {0}")]
 	WorkerCommunicationError(String),
 	#[error("Scale codec deserialization error: {0}")]
 	DeserializationError(CodecError),

--- a/client/relay-chain-interface/src/lib.rs
+++ b/client/relay-chain-interface/src/lib.rs
@@ -54,6 +54,8 @@ pub enum RelayChainError {
 	RPCCallError(String, JsonRPSeeError),
 	#[error("RPC Error: '{0}'")]
 	JsonRPCError(#[from] JsonRPSeeError),
+	#[error("Unable to reach worker: {0}")]
+	WorkerCommunicationError(String),
 	#[error("Scale codec deserialization error: {0}")]
 	DeserializationError(CodecError),
 	#[error("Scale codec deserialization error: {0}")]

--- a/client/relay-chain-rpc-interface/Cargo.toml
+++ b/client/relay-chain-rpc-interface/Cargo.toml
@@ -16,6 +16,7 @@ sp-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sp-state-machine = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-service = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sp-storage = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sc-rpc-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
 

--- a/client/relay-chain-rpc-interface/Cargo.toml
+++ b/client/relay-chain-rpc-interface/Cargo.toml
@@ -16,7 +16,6 @@ sp-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sp-state-machine = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sc-service = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sc-utils = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sp-storage = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sc-rpc-api = { git = "https://github.com/paritytech/substrate", branch = "master" }

--- a/client/relay-chain-rpc-interface/Cargo.toml
+++ b/client/relay-chain-rpc-interface/Cargo.toml
@@ -16,9 +16,9 @@ sp-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sp-state-machine = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
-sc-utils = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sp-storage = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sc-rpc-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
+tokio = { version = "1.19.2", features = ["sync"] }
 
 futures = "0.3.21"
 futures-timer = "3.0.2"

--- a/client/relay-chain-rpc-interface/Cargo.toml
+++ b/client/relay-chain-rpc-interface/Cargo.toml
@@ -17,6 +17,7 @@ sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master
 sp-state-machine = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sc-service = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-utils = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sp-storage = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sc-rpc-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
 

--- a/client/relay-chain-rpc-interface/src/lib.rs
+++ b/client/relay-chain-rpc-interface/src/lib.rs
@@ -35,7 +35,7 @@ use std::pin::Pin;
 pub use url::Url;
 
 mod rpc_client;
-pub use rpc_client::{create_worker_client, RelayChainRPCClient};
+pub use rpc_client::{create_worker_client, RPCStreamWorker, RelayChainRPCClient};
 
 const TIMEOUT_IN_SECONDS: u64 = 6;
 

--- a/client/relay-chain-rpc-interface/src/lib.rs
+++ b/client/relay-chain-rpc-interface/src/lib.rs
@@ -35,25 +35,25 @@ use std::pin::Pin;
 pub use url::Url;
 
 mod rpc_client;
-pub use rpc_client::{create_worker_client, RPCStreamWorker, RelayChainRPCClient};
+pub use rpc_client::{create_worker_client, RelayChainRpcClient, RpcStreamWorker};
 
 const TIMEOUT_IN_SECONDS: u64 = 6;
 
-/// RelayChainRPCInterface is used to interact with a full node that is running locally
+/// RelayChainRpcInterface is used to interact with a full node that is running locally
 /// in the same process.
 #[derive(Clone)]
-pub struct RelayChainRPCInterface {
-	rpc_client: RelayChainRPCClient,
+pub struct RelayChainRpcInterface {
+	rpc_client: RelayChainRpcClient,
 }
 
-impl RelayChainRPCInterface {
-	pub fn new(rpc_client: RelayChainRPCClient) -> Self {
+impl RelayChainRpcInterface {
+	pub fn new(rpc_client: RelayChainRpcClient) -> Self {
 		Self { rpc_client }
 	}
 }
 
 #[async_trait]
-impl RelayChainInterface for RelayChainRPCInterface {
+impl RelayChainInterface for RelayChainRpcInterface {
 	async fn retrieve_dmq_contents(
 		&self,
 		para_id: ParaId,

--- a/client/relay-chain-rpc-interface/src/lib.rs
+++ b/client/relay-chain-rpc-interface/src/lib.rs
@@ -46,238 +46,11 @@ use sp_storage::StorageKey;
 use std::{pin::Pin, sync::Arc};
 
 pub use url::Url;
+mod rpc_client;
+pub use rpc_client::RelayChainRPCClient;
 
 const LOG_TARGET: &str = "relay-chain-rpc-interface";
 const TIMEOUT_IN_SECONDS: u64 = 6;
-
-/// Client that maps RPC methods and deserializes results
-#[derive(Clone)]
-struct RelayChainRPCClient {
-	/// Websocket client to make calls
-	ws_client: Arc<JsonRPCClient>,
-
-	/// Retry strategy that should be used for requests and subscriptions
-	retry_strategy: ExponentialBackoff,
-}
-
-impl RelayChainRPCClient {
-	pub async fn new(url: Url) -> RelayChainResult<Self> {
-		tracing::info!(target: LOG_TARGET, url = %url.to_string(), "Initializing RPC Client");
-		let ws_client = WsClientBuilder::default().build(url.as_str()).await?;
-
-		Ok(RelayChainRPCClient {
-			ws_client: Arc::new(ws_client),
-			retry_strategy: ExponentialBackoff::default(),
-		})
-	}
-
-	/// Call a call to `state_call` rpc method.
-	async fn call_remote_runtime_function<R: Decode>(
-		&self,
-		method_name: &str,
-		hash: PHash,
-		payload: Option<impl Encode>,
-	) -> RelayChainResult<R> {
-		let payload_bytes =
-			payload.map_or(sp_core::Bytes(Vec::new()), |v| sp_core::Bytes(v.encode()));
-		let params = rpc_params! {
-			method_name,
-			payload_bytes,
-			hash
-		};
-		let res = self
-			.request_tracing::<sp_core::Bytes, _>("state_call", params, |err| {
-				tracing::trace!(
-					target: LOG_TARGET,
-					%method_name,
-					%hash,
-					error = %err,
-					"Error during call to 'state_call'.",
-				);
-			})
-			.await?;
-		Decode::decode(&mut &*res.0).map_err(Into::into)
-	}
-
-	/// Subscribe to a notification stream via RPC
-	async fn subscribe<'a, R>(
-		&self,
-		sub_name: &'a str,
-		unsub_name: &'a str,
-		params: Option<ParamsSer<'a>>,
-	) -> RelayChainResult<Subscription<R>>
-	where
-		R: DeserializeOwned,
-	{
-		self.ws_client
-			.subscribe::<R>(sub_name, params, unsub_name)
-			.await
-			.map_err(|err| RelayChainError::RPCCallError(sub_name.to_string(), err))
-	}
-
-	/// Perform RPC request
-	async fn request<'a, R>(
-		&self,
-		method: &'a str,
-		params: Option<ParamsSer<'a>>,
-	) -> Result<R, RelayChainError>
-	where
-		R: DeserializeOwned + std::fmt::Debug,
-	{
-		self.request_tracing(
-			method,
-			params,
-			|e| tracing::trace!(target:LOG_TARGET, error = %e, %method, "Unable to complete RPC request"),
-		)
-		.await
-	}
-
-	/// Perform RPC request
-	async fn request_tracing<'a, R, OR>(
-		&self,
-		method: &'a str,
-		params: Option<ParamsSer<'a>>,
-		trace_error: OR,
-	) -> Result<R, RelayChainError>
-	where
-		R: DeserializeOwned + std::fmt::Debug,
-		OR: Fn(&jsonrpsee::core::Error),
-	{
-		retry_notify(
-			self.retry_strategy.clone(),
-			|| async {
-				self.ws_client.request(method, params.clone()).await.map_err(|err| match err {
-					JsonRpseeError::Transport(_) =>
-						backoff::Error::Transient { err, retry_after: None },
-					_ => backoff::Error::Permanent(err),
-				})
-			},
-			|error, dur| tracing::trace!(target: LOG_TARGET, %error, ?dur, "Encountered transport error, retrying."),
-		)
-		.await
-		.map_err(|err| {
-			trace_error(&err);
-			RelayChainError::RPCCallError(method.to_string(), err)})
-	}
-
-	async fn system_health(&self) -> Result<Health, RelayChainError> {
-		self.request("system_health", None).await
-	}
-
-	async fn state_get_read_proof(
-		&self,
-		storage_keys: Vec<StorageKey>,
-		at: Option<PHash>,
-	) -> Result<ReadProof<PHash>, RelayChainError> {
-		let params = rpc_params!(storage_keys, at);
-		self.request("state_getReadProof", params).await
-	}
-
-	async fn state_get_storage(
-		&self,
-		storage_key: StorageKey,
-		at: Option<PHash>,
-	) -> Result<Option<StorageData>, RelayChainError> {
-		let params = rpc_params!(storage_key, at);
-		self.request("state_getStorage", params).await
-	}
-
-	async fn chain_get_head(&self) -> Result<PHash, RelayChainError> {
-		self.request("chain_getHead", None).await
-	}
-
-	async fn chain_get_header(
-		&self,
-		hash: Option<PHash>,
-	) -> Result<Option<PHeader>, RelayChainError> {
-		let params = rpc_params!(hash);
-		self.request("chain_getHeader", params).await
-	}
-
-	async fn parachain_host_candidate_pending_availability(
-		&self,
-		at: PHash,
-		para_id: ParaId,
-	) -> Result<Option<CommittedCandidateReceipt>, RelayChainError> {
-		self.call_remote_runtime_function(
-			"ParachainHost_candidate_pending_availability",
-			at,
-			Some(para_id),
-		)
-		.await
-	}
-
-	async fn parachain_host_session_index_for_child(
-		&self,
-		at: PHash,
-	) -> Result<SessionIndex, RelayChainError> {
-		self.call_remote_runtime_function("ParachainHost_session_index_for_child", at, None::<()>)
-			.await
-	}
-
-	async fn parachain_host_validators(
-		&self,
-		at: PHash,
-	) -> Result<Vec<ValidatorId>, RelayChainError> {
-		self.call_remote_runtime_function("ParachainHost_validators", at, None::<()>)
-			.await
-	}
-
-	async fn parachain_host_persisted_validation_data(
-		&self,
-		at: PHash,
-		para_id: ParaId,
-		occupied_core_assumption: OccupiedCoreAssumption,
-	) -> Result<Option<PersistedValidationData>, RelayChainError> {
-		self.call_remote_runtime_function(
-			"ParachainHost_persisted_validation_data",
-			at,
-			Some((para_id, occupied_core_assumption)),
-		)
-		.await
-	}
-
-	async fn parachain_host_inbound_hrmp_channels_contents(
-		&self,
-		para_id: ParaId,
-		at: PHash,
-	) -> Result<BTreeMap<ParaId, Vec<InboundHrmpMessage>>, RelayChainError> {
-		self.call_remote_runtime_function(
-			"ParachainHost_inbound_hrmp_channels_contents",
-			at,
-			Some(para_id),
-		)
-		.await
-	}
-
-	async fn parachain_host_dmq_contents(
-		&self,
-		para_id: ParaId,
-		at: PHash,
-	) -> Result<Vec<InboundDownwardMessage>, RelayChainError> {
-		self.call_remote_runtime_function("ParachainHost_dmq_contents", at, Some(para_id))
-			.await
-	}
-
-	async fn subscribe_all_heads(&self) -> Result<Subscription<PHeader>, RelayChainError> {
-		self.subscribe::<PHeader>("chain_subscribeAllHeads", "chain_unsubscribeAllHeads", None)
-			.await
-	}
-
-	async fn subscribe_new_best_heads(&self) -> Result<Subscription<PHeader>, RelayChainError> {
-		self.subscribe::<PHeader>("chain_subscribeNewHeads", "chain_unsubscribeNewHeads", None)
-			.await
-	}
-
-	async fn subscribe_finalized_heads(&self) -> Result<Subscription<PHeader>, RelayChainError> {
-		self.subscribe::<PHeader>(
-			"chain_subscribeFinalizedHeads",
-			"chain_unsubscribeFinalizedHeads",
-			None,
-		)
-		.await
-	}
-}
 
 /// RelayChainRPCInterface is used to interact with a full node that is running locally
 /// in the same process.
@@ -344,17 +117,7 @@ impl RelayChainInterface for RelayChainRPCInterface {
 	async fn import_notification_stream(
 		&self,
 	) -> RelayChainResult<Pin<Box<dyn Stream<Item = PHeader> + Send>>> {
-		let imported_headers_stream =
-			self.rpc_client.subscribe_all_heads().await?.filter_map(|item| async move {
-				item.map_err(|err| {
-					tracing::error!(
-						target: LOG_TARGET,
-						"Encountered error in import notification stream: {}",
-						err
-					)
-				})
-				.ok()
-			});
+		let imported_headers_stream = self.rpc_client.get_imported_heads_stream().await?;
 
 		Ok(imported_headers_stream.boxed())
 	}
@@ -362,20 +125,7 @@ impl RelayChainInterface for RelayChainRPCInterface {
 	async fn finality_notification_stream(
 		&self,
 	) -> RelayChainResult<Pin<Box<dyn Stream<Item = PHeader> + Send>>> {
-		let imported_headers_stream = self
-			.rpc_client
-			.subscribe_finalized_heads()
-			.await?
-			.filter_map(|item| async move {
-				item.map_err(|err| {
-					tracing::error!(
-						target: LOG_TARGET,
-						"Encountered error in finality notification stream: {}",
-						err
-					)
-				})
-				.ok()
-			});
+		let imported_headers_stream = self.rpc_client.get_finalized_heads_stream().await?;
 
 		Ok(imported_headers_stream.boxed())
 	}
@@ -430,7 +180,7 @@ impl RelayChainInterface for RelayChainRPCInterface {
 	/// 3. Wait for the block to be imported via subscription.
 	/// 4. If timeout is reached, we return an error.
 	async fn wait_for_block(&self, wait_for_hash: PHash) -> RelayChainResult<()> {
-		let mut head_stream = self.rpc_client.subscribe_all_heads().await?;
+		let mut head_stream = self.rpc_client.get_imported_heads_stream().await?;
 
 		if self.rpc_client.chain_get_header(Some(wait_for_hash)).await?.is_some() {
 			return Ok(())
@@ -442,7 +192,7 @@ impl RelayChainInterface for RelayChainRPCInterface {
 			futures::select! {
 				_ = timeout => return Err(RelayChainError::WaitTimeout(wait_for_hash)),
 				evt = head_stream.next().fuse() => match evt {
-					Some(Ok(evt)) if evt.hash() == wait_for_hash => return Ok(()),
+					Some(evt) if evt.hash() == wait_for_hash => return Ok(()),
 					// Not the event we waited on.
 					Some(_) => continue,
 					None => return Err(RelayChainError::ImportListenerClosed(wait_for_hash)),
@@ -454,18 +204,7 @@ impl RelayChainInterface for RelayChainRPCInterface {
 	async fn new_best_notification_stream(
 		&self,
 	) -> RelayChainResult<Pin<Box<dyn Stream<Item = PHeader> + Send>>> {
-		let imported_headers_stream =
-			self.rpc_client.subscribe_new_best_heads().await?.filter_map(|item| async move {
-				item.map_err(|err| {
-					tracing::error!(
-						target: LOG_TARGET,
-						"Error in best block notification stream: {}",
-						err
-					)
-				})
-				.ok()
-			});
-
+		let imported_headers_stream = self.rpc_client.get_best_heads_stream().await?;
 		Ok(imported_headers_stream.boxed())
 	}
 }

--- a/client/relay-chain-rpc-interface/src/lib.rs
+++ b/client/relay-chain-rpc-interface/src/lib.rs
@@ -33,6 +33,7 @@ use sp_storage::StorageKey;
 use std::pin::Pin;
 
 pub use url::Url;
+
 mod rpc_client;
 pub use rpc_client::{create_worker_client, RelayChainRPCClient};
 

--- a/client/relay-chain-rpc-interface/src/lib.rs
+++ b/client/relay-chain-rpc-interface/src/lib.rs
@@ -25,18 +25,8 @@ use cumulus_primitives_core::{
 };
 use cumulus_relay_chain_interface::{RelayChainError, RelayChainInterface, RelayChainResult};
 use futures::{FutureExt, Stream, StreamExt};
-use jsonrpsee::{
-	core::{
-		client::{Client as JsonRPCClient, ClientT, Subscription, SubscriptionClientT},
-		Error as JsonRpseeError,
-	},
-	rpc_params,
-	types::ParamsSer,
-	ws_client::WsClientBuilder,
-};
 use polkadot_service::Handle;
 use sc_client_api::StorageProof;
-use sc_service::SpawnTaskHandle;
 use sp_core::sp_std::collections::btree_map::BTreeMap;
 use sp_state_machine::StorageValue;
 use sp_storage::StorageKey;
@@ -44,9 +34,8 @@ use std::pin::Pin;
 
 pub use url::Url;
 mod rpc_client;
-pub use rpc_client::RelayChainRPCClient;
+pub use rpc_client::{create_worker_client, RelayChainRPCClient};
 
-const LOG_TARGET: &str = "relay-chain-rpc-interface";
 const TIMEOUT_IN_SECONDS: u64 = 6;
 
 /// RelayChainRPCInterface is used to interact with a full node that is running locally
@@ -57,10 +46,8 @@ pub struct RelayChainRPCInterface {
 }
 
 impl RelayChainRPCInterface {
-	pub async fn new(url: Url, spawn_handle: SpawnTaskHandle) -> RelayChainResult<Self> {
-		let (worker, client) = rpc_client::create_worker_client(url).await?;
-		spawn_handle.spawn("relay-chain-rpc-worker", None, worker.run());
-		Ok(Self { rpc_client: client })
+	pub fn new(rpc_client: RelayChainRPCClient) -> Self {
+		Self { rpc_client }
 	}
 }
 

--- a/client/relay-chain-rpc-interface/src/lib.rs
+++ b/client/relay-chain-rpc-interface/src/lib.rs
@@ -35,7 +35,7 @@ use std::pin::Pin;
 pub use url::Url;
 
 mod rpc_client;
-pub use rpc_client::{create_worker_client, RelayChainRpcClient, RpcStreamWorker};
+pub use rpc_client::{create_client_and_start_worker, RelayChainRpcClient, RpcStreamWorker};
 
 const TIMEOUT_IN_SECONDS: u64 = 6;
 

--- a/client/relay-chain-rpc-interface/src/lib.rs
+++ b/client/relay-chain-rpc-interface/src/lib.rs
@@ -35,7 +35,7 @@ use std::pin::Pin;
 pub use url::Url;
 
 mod rpc_client;
-pub use rpc_client::{create_client_and_start_worker, RelayChainRpcClient, RpcStreamWorker};
+pub use rpc_client::{create_client_and_start_worker, RelayChainRpcClient};
 
 const TIMEOUT_IN_SECONDS: u64 = 6;
 

--- a/client/relay-chain-rpc-interface/src/rpc_client.rs
+++ b/client/relay-chain-rpc-interface/src/rpc_client.rs
@@ -108,7 +108,7 @@ impl RPCWorker {
 		(worker, tx)
 	}
 
-	pub async fn run(&mut self) -> ! {
+	pub async fn run(mut self) {
 		loop {
 			futures::select! {
 				evt = self.client_receiver.next().fuse() => match evt {
@@ -120,7 +120,7 @@ impl RPCWorker {
 				import_evt = self.import_sub.next().fuse() => {
 					match import_evt {
 						Some(Ok(header)) => self.import_listener.iter().for_each(|e| {
-							tracing::debug!(target:LOG_TARGET, ?header, "Sending header to import listener.");
+							tracing::info!(target:LOG_TARGET, ?header, "Sending header to import listener.");
 							e.unbounded_send(header.clone());
 						}),
 						None => todo!(),
@@ -130,7 +130,7 @@ impl RPCWorker {
 				header_evt = self.best_sub.next().fuse() => {
 					match header_evt {
 						Some(Ok(header)) => self.head_listener.iter().for_each(|e| {
-							tracing::debug!(target:LOG_TARGET, ?header, "Sending header to best head listener.");
+							tracing::info!(target:LOG_TARGET, ?header, "Sending header to best head listener.");
 							e.unbounded_send(header.clone());
 						}),
 						None => todo!(),
@@ -140,7 +140,7 @@ impl RPCWorker {
 				finalized_evt = self.finalized_sub.next().fuse() => {
 					match finalized_evt {
 						Some(Ok(header)) => self.finalized_listener.iter().for_each(|e| {
-							tracing::debug!(target:LOG_TARGET, ?header, "Sending header to finalized head listener.");
+							tracing::info!(target:LOG_TARGET, ?header, "Sending header to finalized head listener2.");
 							e.unbounded_send(header.clone());
 						}),
 						None => todo!(),

--- a/client/relay-chain-rpc-interface/src/rpc_client.rs
+++ b/client/relay-chain-rpc-interface/src/rpc_client.rs
@@ -49,6 +49,8 @@ pub use url::Url;
 
 const LOG_TARGET: &str = "relay-chain-rpc-client";
 
+const NOTIFICATION_CHANNEL_SIZE_LIMIT: usize = 20;
+
 /// Client that maps RPC methods and deserializes results
 #[derive(Clone)]
 pub struct RelayChainRPCClient {
@@ -407,7 +409,7 @@ impl RelayChainRPCClient {
 	}
 
 	pub async fn get_imported_heads_stream(&self) -> Result<Receiver<PHeader>, RelayChainError> {
-		let (tx, rx) = futures::channel::mpsc::channel::<PHeader>(128);
+		let (tx, rx) = futures::channel::mpsc::channel::<PHeader>(NOTIFICATION_CHANNEL_SIZE_LIMIT);
 		self.send_register_message_to_worker(NotificationRegisterMessage::RegisterImportListener(
 			tx,
 		))?;
@@ -415,7 +417,7 @@ impl RelayChainRPCClient {
 	}
 
 	pub async fn get_best_heads_stream(&self) -> Result<Receiver<PHeader>, RelayChainError> {
-		let (tx, rx) = futures::channel::mpsc::channel::<PHeader>(128);
+		let (tx, rx) = futures::channel::mpsc::channel::<PHeader>(NOTIFICATION_CHANNEL_SIZE_LIMIT);
 		self.send_register_message_to_worker(
 			NotificationRegisterMessage::RegisterBestHeadListener(tx),
 		)?;
@@ -423,7 +425,7 @@ impl RelayChainRPCClient {
 	}
 
 	pub async fn get_finalized_heads_stream(&self) -> Result<Receiver<PHeader>, RelayChainError> {
-		let (tx, rx) = futures::channel::mpsc::channel::<PHeader>(128);
+		let (tx, rx) = futures::channel::mpsc::channel::<PHeader>(NOTIFICATION_CHANNEL_SIZE_LIMIT);
 		self.send_register_message_to_worker(
 			NotificationRegisterMessage::RegisterFinalizationListener(tx),
 		)?;

--- a/client/relay-chain-rpc-interface/src/rpc_client.rs
+++ b/client/relay-chain-rpc-interface/src/rpc_client.rs
@@ -73,7 +73,7 @@ pub enum NotificationRegisterMessage {
 }
 
 /// Worker that should be used in combination with [`RelayChainRpcClient`]. Must be polled to distribute header notifications to listeners.
-pub struct RpcStreamWorker {
+struct RpcStreamWorker {
 	// Communication channel with the RPC client
 	client_receiver: TracingUnboundedReceiver<NotificationRegisterMessage>,
 

--- a/client/relay-chain-rpc-interface/src/rpc_client.rs
+++ b/client/relay-chain-rpc-interface/src/rpc_client.rs
@@ -72,7 +72,7 @@ pub enum NotificationRegisterMessage {
 	RegisterFinalizationListener(Sender<PHeader>),
 }
 
-/// Worker that should be used in combination with [`RelayChainRPCClient`]. Must be polled to distribute header notifications to listeners.
+/// Worker that should be used in combination with [`RelayChainRpcClient`]. Must be polled to distribute header notifications to listeners.
 pub struct RpcStreamWorker {
 	// Communication channel with the RPC client
 	client_receiver: TracingUnboundedReceiver<NotificationRegisterMessage>,

--- a/client/relay-chain-rpc-interface/src/rpc_client.rs
+++ b/client/relay-chain-rpc-interface/src/rpc_client.rs
@@ -1,0 +1,428 @@
+// Copyright 2022 Parity Technologies (UK) Ltd.
+// This file is part of Cumulus.
+
+// Cumulus is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Cumulus is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
+
+use async_trait::async_trait;
+use backoff::{future::retry_notify, ExponentialBackoff};
+use core::time::Duration;
+use cumulus_primitives_core::{
+	relay_chain::{
+		v2::{CommittedCandidateReceipt, OccupiedCoreAssumption, SessionIndex, ValidatorId},
+		Hash as PHash, Header as PHeader, InboundHrmpMessage,
+	},
+	InboundDownwardMessage, ParaId, PersistedValidationData,
+};
+use cumulus_relay_chain_interface::{RelayChainError, RelayChainInterface, RelayChainResult};
+use futures::{
+	channel::mpsc::{UnboundedReceiver, UnboundedSender},
+	FutureExt, Stream, StreamExt,
+};
+use jsonrpsee::{
+	core::{
+		client::{Client as JsonRPCClient, ClientT, Subscription, SubscriptionClientT},
+		Error as JsonRpseeError,
+	},
+	rpc_params,
+	types::ParamsSer,
+	ws_client::WsClientBuilder,
+};
+use parity_scale_codec::{Decode, Encode};
+use polkadot_service::Handle;
+use sc_client_api::{StorageData, StorageProof};
+use sc_rpc_api::{state::ReadProof, system::Health};
+use sp_core::sp_std::collections::btree_map::BTreeMap;
+use sp_runtime::DeserializeOwned;
+use sp_state_machine::StorageValue;
+use sp_storage::StorageKey;
+use std::{pin::Pin, sync::Arc};
+
+pub use url::Url;
+
+const LOG_TARGET: &str = "relay-chain-rpc-interface";
+const TIMEOUT_IN_SECONDS: u64 = 6;
+
+/// Client that maps RPC methods and deserializes results
+#[derive(Clone)]
+pub struct RelayChainRPCClient {
+	/// Websocket client to make calls
+	ws_client: Arc<JsonRPCClient>,
+
+	/// Retry strategy that should be used for requests and subscriptions
+	retry_strategy: ExponentialBackoff,
+
+	to_worker_channel: Option<UnboundedSender<RPCMessages>>,
+}
+
+#[derive(Clone, Debug)]
+pub enum RPCMessages {
+	NewHeadListener(UnboundedSender<PHeader>),
+	NewImportListener(UnboundedSender<PHeader>),
+	NewFinalizedListener(UnboundedSender<PHeader>),
+}
+
+pub struct RPCWorker {
+	client_receiver: UnboundedReceiver<RPCMessages>,
+	import_listener: Vec<UnboundedSender<PHeader>>,
+	finalized_listener: Vec<UnboundedSender<PHeader>>,
+	head_listener: Vec<UnboundedSender<PHeader>>,
+	import_sub: Subscription<PHeader>,
+	finalized_sub: Subscription<PHeader>,
+	best_sub: Subscription<PHeader>,
+}
+
+pub async fn create_worker_client(url: Url) -> RelayChainResult<(RPCWorker, RelayChainRPCClient)> {
+	let (mut client, import, head, finalized) = RelayChainRPCClient::new_with_streams(url).await?;
+	let (worker, sender) = RPCWorker::new(import, head, finalized);
+	client.set_worker_channel(sender);
+	Ok((worker, client))
+}
+
+impl RPCWorker {
+	pub fn new(
+		import_sub: Subscription<PHeader>,
+		best_sub: Subscription<PHeader>,
+		finalized_sub: Subscription<PHeader>,
+	) -> (RPCWorker, UnboundedSender<RPCMessages>) {
+		let (tx, rx) = futures::channel::mpsc::unbounded();
+		let worker = RPCWorker {
+			client_receiver: rx,
+			import_listener: Vec::new(),
+			finalized_listener: Vec::new(),
+			head_listener: Vec::new(),
+			import_sub,
+			best_sub,
+			finalized_sub,
+		};
+		(worker, tx)
+	}
+
+	pub async fn run(&mut self) -> ! {
+		loop {
+			futures::select! {
+				evt = self.client_receiver.next().fuse() => match evt {
+					Some(RPCMessages::NewHeadListener(tx)) => { self.head_listener.push(tx) },
+					Some(RPCMessages::NewImportListener(tx)) => { self.import_listener.push(tx) },
+					Some(RPCMessages::NewFinalizedListener(tx)) => {self.finalized_listener.push(tx)  },
+					None => {}
+				},
+				import_evt = self.import_sub.next().fuse() => {
+					match import_evt {
+						Some(Ok(header)) => self.import_listener.iter().for_each(|e| {
+							tracing::debug!(target:LOG_TARGET, ?header, "Sending header to import listener.");
+							e.unbounded_send(header.clone());
+						}),
+						None => todo!(),
+						_ => todo!(),
+					};
+				},
+				header_evt = self.best_sub.next().fuse() => {
+					match header_evt {
+						Some(Ok(header)) => self.head_listener.iter().for_each(|e| {
+							tracing::debug!(target:LOG_TARGET, ?header, "Sending header to best head listener.");
+							e.unbounded_send(header.clone());
+						}),
+						None => todo!(),
+						_ => todo!(),
+					};
+				},
+				finalized_evt = self.finalized_sub.next().fuse() => {
+					match finalized_evt {
+						Some(Ok(header)) => self.finalized_listener.iter().for_each(|e| {
+							tracing::debug!(target:LOG_TARGET, ?header, "Sending header to finalized head listener.");
+							e.unbounded_send(header.clone());
+						}),
+						None => todo!(),
+						_ => todo!(),
+					};
+				},
+			}
+		}
+	}
+}
+
+impl RelayChainRPCClient {
+	fn set_worker_channel(&mut self, sender: UnboundedSender<RPCMessages>) {
+		self.to_worker_channel = Some(sender);
+	}
+
+	pub async fn new_with_streams(
+		url: Url,
+	) -> RelayChainResult<(Self, Subscription<PHeader>, Subscription<PHeader>, Subscription<PHeader>)>
+	{
+		tracing::info!(target: LOG_TARGET, url = %url.to_string(), "Initializing RPC Client");
+		let ws_client = WsClientBuilder::default().build(url.as_str()).await?;
+
+		let client = RelayChainRPCClient {
+			to_worker_channel: None,
+			ws_client: Arc::new(ws_client),
+			retry_strategy: ExponentialBackoff::default(),
+		};
+		let head_stream = client.subscribe_new_best_heads().await?;
+		let finalized_stream = client.subscribe_finalized_heads().await?;
+		let imported_stream = client.subscribe_imported_heads().await?;
+		Ok((client, imported_stream, head_stream, finalized_stream))
+	}
+
+	pub async fn new(url: Url) -> RelayChainResult<Self> {
+		tracing::info!(target: LOG_TARGET, url = %url.to_string(), "Initializing RPC Client");
+		let ws_client = WsClientBuilder::default().build(url.as_str()).await?;
+
+		Ok(RelayChainRPCClient {
+			to_worker_channel: None,
+			ws_client: Arc::new(ws_client),
+			retry_strategy: ExponentialBackoff::default(),
+		})
+	}
+
+	/// Call a call to `state_call` rpc method.
+	pub async fn call_remote_runtime_function<R: Decode>(
+		&self,
+		method_name: &str,
+		hash: PHash,
+		payload: Option<impl Encode>,
+	) -> RelayChainResult<R> {
+		let payload_bytes =
+			payload.map_or(sp_core::Bytes(Vec::new()), |v| sp_core::Bytes(v.encode()));
+		let params = rpc_params! {
+			method_name,
+			payload_bytes,
+			hash
+		};
+		let res = self
+			.request_tracing::<sp_core::Bytes, _>("state_call", params, |err| {
+				tracing::trace!(
+					target: LOG_TARGET,
+					%method_name,
+					%hash,
+					error = %err,
+					"Error during call to 'state_call'.",
+				);
+			})
+			.await?;
+		Decode::decode(&mut &*res.0).map_err(Into::into)
+	}
+
+	/// Subscribe to a notification stream via RPC
+	pub async fn subscribe<'a, R>(
+		&self,
+		sub_name: &'a str,
+		unsub_name: &'a str,
+		params: Option<ParamsSer<'a>>,
+	) -> RelayChainResult<Subscription<R>>
+	where
+		R: DeserializeOwned,
+	{
+		self.ws_client
+			.subscribe::<R>(sub_name, params, unsub_name)
+			.await
+			.map_err(|err| RelayChainError::RPCCallError(sub_name.to_string(), err))
+	}
+
+	/// Perform RPC request
+	async fn request<'a, R>(
+		&self,
+		method: &'a str,
+		params: Option<ParamsSer<'a>>,
+	) -> Result<R, RelayChainError>
+	where
+		R: DeserializeOwned + std::fmt::Debug,
+	{
+		self.request_tracing(
+			method,
+			params,
+			|e| tracing::trace!(target:LOG_TARGET, error = %e, %method, "Unable to complete RPC request"),
+		)
+		.await
+	}
+
+	/// Perform RPC request
+	async fn request_tracing<'a, R, OR>(
+		&self,
+		method: &'a str,
+		params: Option<ParamsSer<'a>>,
+		trace_error: OR,
+	) -> Result<R, RelayChainError>
+	where
+		R: DeserializeOwned + std::fmt::Debug,
+		OR: Fn(&jsonrpsee::core::Error),
+	{
+		retry_notify(
+			self.retry_strategy.clone(),
+			|| async {
+				self.ws_client.request(method, params.clone()).await.map_err(|err| match err {
+					JsonRpseeError::Transport(_) =>
+						backoff::Error::Transient { err, retry_after: None },
+					_ => backoff::Error::Permanent(err),
+				})
+			},
+			|error, dur| tracing::trace!(target: LOG_TARGET, %error, ?dur, "Encountered transport error, retrying."),
+		)
+		.await
+		.map_err(|err| {
+			trace_error(&err);
+			RelayChainError::RPCCallError(method.to_string(), err)})
+	}
+
+	pub async fn system_health(&self) -> Result<Health, RelayChainError> {
+		self.request("system_health", None).await
+	}
+
+	pub async fn state_get_read_proof(
+		&self,
+		storage_keys: Vec<StorageKey>,
+		at: Option<PHash>,
+	) -> Result<ReadProof<PHash>, RelayChainError> {
+		let params = rpc_params!(storage_keys, at);
+		self.request("state_getReadProof", params).await
+	}
+
+	pub async fn state_get_storage(
+		&self,
+		storage_key: StorageKey,
+		at: Option<PHash>,
+	) -> Result<Option<StorageData>, RelayChainError> {
+		let params = rpc_params!(storage_key, at);
+		self.request("state_getStorage", params).await
+	}
+
+	pub async fn chain_get_head(&self) -> Result<PHash, RelayChainError> {
+		self.request("chain_getHead", None).await
+	}
+
+	pub async fn chain_get_header(
+		&self,
+		hash: Option<PHash>,
+	) -> Result<Option<PHeader>, RelayChainError> {
+		let params = rpc_params!(hash);
+		self.request("chain_getHeader", params).await
+	}
+
+	pub async fn parachain_host_candidate_pending_availability(
+		&self,
+		at: PHash,
+		para_id: ParaId,
+	) -> Result<Option<CommittedCandidateReceipt>, RelayChainError> {
+		self.call_remote_runtime_function(
+			"ParachainHost_candidate_pending_availability",
+			at,
+			Some(para_id),
+		)
+		.await
+	}
+
+	pub async fn parachain_host_session_index_for_child(
+		&self,
+		at: PHash,
+	) -> Result<SessionIndex, RelayChainError> {
+		self.call_remote_runtime_function("ParachainHost_session_index_for_child", at, None::<()>)
+			.await
+	}
+
+	pub async fn parachain_host_validators(
+		&self,
+		at: PHash,
+	) -> Result<Vec<ValidatorId>, RelayChainError> {
+		self.call_remote_runtime_function("ParachainHost_validators", at, None::<()>)
+			.await
+	}
+
+	pub async fn parachain_host_persisted_validation_data(
+		&self,
+		at: PHash,
+		para_id: ParaId,
+		occupied_core_assumption: OccupiedCoreAssumption,
+	) -> Result<Option<PersistedValidationData>, RelayChainError> {
+		self.call_remote_runtime_function(
+			"ParachainHost_persisted_validation_data",
+			at,
+			Some((para_id, occupied_core_assumption)),
+		)
+		.await
+	}
+
+	pub async fn parachain_host_inbound_hrmp_channels_contents(
+		&self,
+		para_id: ParaId,
+		at: PHash,
+	) -> Result<BTreeMap<ParaId, Vec<InboundHrmpMessage>>, RelayChainError> {
+		self.call_remote_runtime_function(
+			"ParachainHost_inbound_hrmp_channels_contents",
+			at,
+			Some(para_id),
+		)
+		.await
+	}
+
+	pub async fn parachain_host_dmq_contents(
+		&self,
+		para_id: ParaId,
+		at: PHash,
+	) -> Result<Vec<InboundDownwardMessage>, RelayChainError> {
+		self.call_remote_runtime_function("ParachainHost_dmq_contents", at, Some(para_id))
+			.await
+	}
+
+	pub async fn get_imported_heads_stream(
+		&self,
+	) -> Result<UnboundedReceiver<PHeader>, RelayChainError> {
+		let (tx, rx) = futures::channel::mpsc::unbounded::<PHeader>();
+		if let Some(channel) = &self.to_worker_channel {
+			tracing::debug!(target: LOG_TARGET, "Registering 'NewImportListener'");
+			channel.unbounded_send(RPCMessages::NewImportListener(tx));
+		}
+		Ok(rx)
+	}
+
+	pub async fn get_best_heads_stream(
+		&self,
+	) -> Result<UnboundedReceiver<PHeader>, RelayChainError> {
+		let (tx, rx) = futures::channel::mpsc::unbounded::<PHeader>();
+		if let Some(channel) = &self.to_worker_channel {
+			tracing::debug!(target: LOG_TARGET, "Registering 'NewHeadListener'");
+			channel.unbounded_send(RPCMessages::NewHeadListener(tx));
+		}
+		Ok(rx)
+	}
+
+	pub async fn get_finalized_heads_stream(
+		&self,
+	) -> Result<UnboundedReceiver<PHeader>, RelayChainError> {
+		let (tx, rx) = futures::channel::mpsc::unbounded::<PHeader>();
+		if let Some(channel) = &self.to_worker_channel {
+			tracing::debug!(target: LOG_TARGET, "Registering 'NewFinalizedListener'");
+			channel.unbounded_send(RPCMessages::NewFinalizedListener(tx));
+		}
+		Ok(rx)
+	}
+
+	async fn subscribe_imported_heads(&self) -> Result<Subscription<PHeader>, RelayChainError> {
+		self.subscribe::<PHeader>("chain_subscribeAllHeads", "chain_unsubscribeAllHeads", None)
+			.await
+	}
+
+	async fn subscribe_finalized_heads(&self) -> Result<Subscription<PHeader>, RelayChainError> {
+		self.subscribe::<PHeader>(
+			"chain_subscribeFinalizedHeads",
+			"chain_unsubscribeFinalizedHeads",
+			None,
+		)
+		.await
+	}
+
+	async fn subscribe_new_best_heads(&self) -> Result<Subscription<PHeader>, RelayChainError> {
+		self.subscribe::<PHeader>("chain_subscribeNewHeads", "chain_unsubscribeNewHeads", None)
+			.await
+	}
+}

--- a/client/relay-chain-rpc-interface/src/rpc_client.rs
+++ b/client/relay-chain-rpc-interface/src/rpc_client.rs
@@ -63,6 +63,7 @@ pub struct RelayChainRPCClient {
 	to_worker_channel: Option<TracingUnboundedSender<NotificationRegisterMessage>>,
 }
 
+/// Worker messages to register new notification listeners
 #[derive(Clone, Debug)]
 pub enum NotificationRegisterMessage {
 	RegisterBestHeadListener(Sender<PHeader>),

--- a/parachain-template/node/src/service.rs
+++ b/parachain-template/node/src/service.rs
@@ -176,8 +176,12 @@ async fn build_relay_chain_interface(
 	hwbench: Option<sc_sysinfo::HwBench>,
 ) -> RelayChainResult<(Arc<(dyn RelayChainInterface + 'static)>, Option<CollatorPair>)> {
 	match collator_options.relay_chain_rpc_url {
-		Some(relay_chain_url) =>
-			Ok((Arc::new(RelayChainRPCInterface::new(relay_chain_url).await?) as Arc<_>, None)),
+		Some(relay_chain_url) => Ok((
+			Arc::new(
+				RelayChainRPCInterface::new(relay_chain_url, task_manager.spawn_handle()).await?,
+			) as Arc<_>,
+			None,
+		)),
 		None => build_inprocess_relay_chain(
 			polkadot_config,
 			parachain_config,

--- a/parachain-template/node/src/service.rs
+++ b/parachain-template/node/src/service.rs
@@ -22,7 +22,7 @@ use cumulus_client_service::{
 use cumulus_primitives_core::ParaId;
 use cumulus_relay_chain_inprocess_interface::build_inprocess_relay_chain;
 use cumulus_relay_chain_interface::{RelayChainError, RelayChainInterface, RelayChainResult};
-use cumulus_relay_chain_rpc_interface::RelayChainRPCInterface;
+use cumulus_relay_chain_rpc_interface::{create_worker_client, RelayChainRPCInterface};
 
 // Substrate Imports
 use sc_client_api::ExecutorProvider;
@@ -176,12 +176,15 @@ async fn build_relay_chain_interface(
 	hwbench: Option<sc_sysinfo::HwBench>,
 ) -> RelayChainResult<(Arc<(dyn RelayChainInterface + 'static)>, Option<CollatorPair>)> {
 	match collator_options.relay_chain_rpc_url {
-		Some(relay_chain_url) => Ok((
-			Arc::new(
-				RelayChainRPCInterface::new(relay_chain_url, task_manager.spawn_handle()).await?,
-			) as Arc<_>,
-			None,
-		)),
+		Some(relay_chain_url) => {
+			let (worker, client) = create_worker_client(relay_chain_url).await?;
+			task_manager.spawn_essential_handle().spawn(
+				"relay-chain-rpc-worker",
+				None,
+				worker.run(),
+			);
+			Ok((Arc::new(RelayChainRPCInterface::new(client)) as Arc<_>, None))
+		},
 		None => build_inprocess_relay_chain(
 			polkadot_config,
 			parachain_config,

--- a/parachain-template/node/src/service.rs
+++ b/parachain-template/node/src/service.rs
@@ -22,7 +22,7 @@ use cumulus_client_service::{
 use cumulus_primitives_core::ParaId;
 use cumulus_relay_chain_inprocess_interface::build_inprocess_relay_chain;
 use cumulus_relay_chain_interface::{RelayChainError, RelayChainInterface, RelayChainResult};
-use cumulus_relay_chain_rpc_interface::{create_worker_client, RelayChainRPCInterface};
+use cumulus_relay_chain_rpc_interface::{create_worker_client, RelayChainRpcInterface};
 
 // Substrate Imports
 use sc_client_api::ExecutorProvider;
@@ -183,7 +183,7 @@ async fn build_relay_chain_interface(
 				None,
 				worker.run(),
 			);
-			Ok((Arc::new(RelayChainRPCInterface::new(client)) as Arc<_>, None))
+			Ok((Arc::new(RelayChainRpcInterface::new(client)) as Arc<_>, None))
 		},
 		None => build_inprocess_relay_chain(
 			polkadot_config,

--- a/parachain-template/node/src/service.rs
+++ b/parachain-template/node/src/service.rs
@@ -22,7 +22,7 @@ use cumulus_client_service::{
 use cumulus_primitives_core::ParaId;
 use cumulus_relay_chain_inprocess_interface::build_inprocess_relay_chain;
 use cumulus_relay_chain_interface::{RelayChainError, RelayChainInterface, RelayChainResult};
-use cumulus_relay_chain_rpc_interface::{create_worker_client, RelayChainRpcInterface};
+use cumulus_relay_chain_rpc_interface::{create_client_and_start_worker, RelayChainRpcInterface};
 
 // Substrate Imports
 use sc_client_api::ExecutorProvider;
@@ -177,12 +177,7 @@ async fn build_relay_chain_interface(
 ) -> RelayChainResult<(Arc<(dyn RelayChainInterface + 'static)>, Option<CollatorPair>)> {
 	match collator_options.relay_chain_rpc_url {
 		Some(relay_chain_url) => {
-			let (worker, client) = create_worker_client(relay_chain_url).await?;
-			task_manager.spawn_essential_handle().spawn(
-				"relay-chain-rpc-worker",
-				None,
-				worker.run(),
-			);
+			let client = create_client_and_start_worker(relay_chain_url, task_manager).await?;
 			Ok((Arc::new(RelayChainRpcInterface::new(client)) as Arc<_>, None))
 		},
 		None => build_inprocess_relay_chain(

--- a/polkadot-parachain/src/service.rs
+++ b/polkadot-parachain/src/service.rs
@@ -30,7 +30,7 @@ use cumulus_primitives_core::{
 };
 use cumulus_relay_chain_inprocess_interface::build_inprocess_relay_chain;
 use cumulus_relay_chain_interface::{RelayChainError, RelayChainInterface, RelayChainResult};
-use cumulus_relay_chain_rpc_interface::RelayChainRPCInterface;
+use cumulus_relay_chain_rpc_interface::{create_worker_client, RelayChainRPCInterface};
 use polkadot_service::CollatorPair;
 use sp_core::Pair;
 
@@ -296,12 +296,15 @@ async fn build_relay_chain_interface(
 	hwbench: Option<sc_sysinfo::HwBench>,
 ) -> RelayChainResult<(Arc<(dyn RelayChainInterface + 'static)>, Option<CollatorPair>)> {
 	match collator_options.relay_chain_rpc_url {
-		Some(relay_chain_url) => Ok((
-			Arc::new(
-				RelayChainRPCInterface::new(relay_chain_url, task_manager.spawn_handle()).await?,
-			) as Arc<_>,
-			None,
-		)),
+		Some(relay_chain_url) => {
+			let (worker, client) = create_worker_client(relay_chain_url).await?;
+			task_manager.spawn_essential_handle().spawn(
+				"relay-chain-rpc-worker",
+				None,
+				worker.run(),
+			);
+			Ok((Arc::new(RelayChainRPCInterface::new(client)) as Arc<_>, None))
+		},
 		None => build_inprocess_relay_chain(
 			polkadot_config,
 			parachain_config,

--- a/polkadot-parachain/src/service.rs
+++ b/polkadot-parachain/src/service.rs
@@ -30,7 +30,7 @@ use cumulus_primitives_core::{
 };
 use cumulus_relay_chain_inprocess_interface::build_inprocess_relay_chain;
 use cumulus_relay_chain_interface::{RelayChainError, RelayChainInterface, RelayChainResult};
-use cumulus_relay_chain_rpc_interface::{create_worker_client, RelayChainRPCInterface};
+use cumulus_relay_chain_rpc_interface::{create_worker_client, RelayChainRpcInterface};
 use polkadot_service::CollatorPair;
 use sp_core::Pair;
 
@@ -303,7 +303,7 @@ async fn build_relay_chain_interface(
 				None,
 				worker.run(),
 			);
-			Ok((Arc::new(RelayChainRPCInterface::new(client)) as Arc<_>, None))
+			Ok((Arc::new(RelayChainRpcInterface::new(client)) as Arc<_>, None))
 		},
 		None => build_inprocess_relay_chain(
 			polkadot_config,

--- a/polkadot-parachain/src/service.rs
+++ b/polkadot-parachain/src/service.rs
@@ -296,8 +296,12 @@ async fn build_relay_chain_interface(
 	hwbench: Option<sc_sysinfo::HwBench>,
 ) -> RelayChainResult<(Arc<(dyn RelayChainInterface + 'static)>, Option<CollatorPair>)> {
 	match collator_options.relay_chain_rpc_url {
-		Some(relay_chain_url) =>
-			Ok((Arc::new(RelayChainRPCInterface::new(relay_chain_url).await?) as Arc<_>, None)),
+		Some(relay_chain_url) => Ok((
+			Arc::new(
+				RelayChainRPCInterface::new(relay_chain_url, task_manager.spawn_handle()).await?,
+			) as Arc<_>,
+			None,
+		)),
 		None => build_inprocess_relay_chain(
 			polkadot_config,
 			parachain_config,

--- a/test/service/src/lib.rs
+++ b/test/service/src/lib.rs
@@ -37,7 +37,7 @@ use cumulus_client_service::{
 use cumulus_primitives_core::ParaId;
 use cumulus_relay_chain_inprocess_interface::RelayChainInProcessInterface;
 use cumulus_relay_chain_interface::{RelayChainError, RelayChainInterface, RelayChainResult};
-use cumulus_relay_chain_rpc_interface::{create_worker_client, RelayChainRpcInterface};
+use cumulus_relay_chain_rpc_interface::{create_client_and_start_worker, RelayChainRpcInterface};
 use cumulus_test_runtime::{Hash, Header, NodeBlock as Block, RuntimeApi};
 use parking_lot::Mutex;
 
@@ -182,10 +182,7 @@ async fn build_relay_chain_interface(
 	task_manager: &mut TaskManager,
 ) -> RelayChainResult<Arc<dyn RelayChainInterface + 'static>> {
 	if let Some(relay_chain_url) = collator_options.relay_chain_rpc_url {
-		let (worker, client) = create_worker_client(relay_chain_url).await?;
-		task_manager
-			.spawn_essential_handle()
-			.spawn("relay-chain-rpc-worker", None, worker.run());
+		let client = create_client_and_start_worker(relay_chain_url, task_manager).await?;
 		return Ok(Arc::new(RelayChainRpcInterface::new(client)) as Arc<_>)
 	}
 

--- a/test/service/src/lib.rs
+++ b/test/service/src/lib.rs
@@ -182,7 +182,9 @@ async fn build_relay_chain_interface(
 	task_manager: &mut TaskManager,
 ) -> RelayChainResult<Arc<dyn RelayChainInterface + 'static>> {
 	if let Some(relay_chain_url) = collator_options.relay_chain_rpc_url {
-		return Ok(Arc::new(RelayChainRPCInterface::new(relay_chain_url).await?) as Arc<_>)
+		return Ok(Arc::new(
+			RelayChainRPCInterface::new(relay_chain_url, task_manager.spawn_handle()).await?,
+		) as Arc<_>)
 	}
 
 	let relay_chain_full_node = polkadot_test_service::new_full(

--- a/test/service/src/lib.rs
+++ b/test/service/src/lib.rs
@@ -37,7 +37,7 @@ use cumulus_client_service::{
 use cumulus_primitives_core::ParaId;
 use cumulus_relay_chain_inprocess_interface::RelayChainInProcessInterface;
 use cumulus_relay_chain_interface::{RelayChainError, RelayChainInterface, RelayChainResult};
-use cumulus_relay_chain_rpc_interface::{create_worker_client, RelayChainRPCInterface};
+use cumulus_relay_chain_rpc_interface::{create_worker_client, RelayChainRpcInterface};
 use cumulus_test_runtime::{Hash, Header, NodeBlock as Block, RuntimeApi};
 use parking_lot::Mutex;
 
@@ -186,7 +186,7 @@ async fn build_relay_chain_interface(
 		task_manager
 			.spawn_essential_handle()
 			.spawn("relay-chain-rpc-worker", None, worker.run());
-		return Ok(Arc::new(RelayChainRPCInterface::new(client)) as Arc<_>)
+		return Ok(Arc::new(RelayChainRpcInterface::new(client)) as Arc<_>)
 	}
 
 	let relay_chain_full_node = polkadot_test_service::new_full(


### PR DESCRIPTION
This PR is the next step towards https://github.com/paritytech/cumulus/issues/989.

Currently the collator opens a new RPC subscription every time we request a notification stream from the `RelayChainRPCInterface`. 

After this PR is merged, we will have only three open notification subscriptionsvia RPC:
- finalized block headers
- imported block headers
- new best block headers

A worker is introduced that will poll these three subscriptions regularly and distribute the contained headers to all listening streams. Requesting a stream from the `RelayChainRPCInterface` will return a new channel and inform the worker.
Since the streams are only used in the collator, and we have complete control, we use bounded channels with a limit of 20 items.