### PR TITLE
Release note fixes

### DIFF
--- a/.github/workflows/release-02_create-draft.yml
+++ b/.github/workflows/release-02_create-draft.yml
@@ -177,6 +177,7 @@ jobs:
         with:
           name: srtool-json
           path: |
+            scripts/ci/changelog/context.json
             **/*-srtool-digest.json
 
       - name: Archive context artifact

--- a/scripts/ci/changelog/templates/runtime.md.tera
+++ b/scripts/ci/changelog/templates/runtime.md.tera
@@ -19,7 +19,7 @@
 
 ```
 🏋️ Runtime Size:		{{ runtime.data.runtimes.compressed.subwasm.size | filesizeformat }} ({{ runtime.data.runtimes.compressed.subwasm.size }} bytes)
-🔥 Core Version:		{{ runtime.data.runtimes.compressed.subwasm.core_version }}
+🔥 Core Version:		{{ runtime.data.runtimes.compressed.subwasm.core_version.specName }}-{{ runtime.data.runtimes.compressed.subwasm.core_version.specVersion }} ({{ runtime.data.runtimes.compressed.subwasm.core_version.implName }}-{{ runtime.data.runtimes.compressed.subwasm.core_version.implVersion }}.tx{{ runtime.data.runtimes.compressed.subwasm.core_version.transactionVersion }}.au{{ runtime.data.runtimes.compressed.subwasm.core_version.authoringVersion }})
 🗜 Compressed:			{{ compressed }}: {{ comp_ratio | round(method="ceil", precision=2) }}%
 🎁 Metadata version:		V{{ runtime.data.runtimes.compressed.subwasm.metadata_version }}
 🗳️ Blake2-256 hash:		{{ runtime.data.runtimes.compressed.subwasm.blake2_256 }}


### PR DESCRIPTION
This is side-porting a couple of changes from polkadot to the cumulus repo. 

srtool's version has changed and current release notes generate a version of `[object]`. This fixes that.

Also for release note testing purposes it's helpful to be able to get at the context.json file that has been produced by a build. (Again this is already produced in the polkadot artifacts so this brings cumulus into line with that)