### PR TITLE
[ci] Add timeout to benchmark job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -274,6 +274,7 @@ benchmarks:
     - *rust-info-script
   <<:                              *collect-artifacts
   <<:                              *benchmarks-refs
+  timeout:                         1d
   script:
     - ./scripts/benchmarks-ci.sh assets statemine
     - ./scripts/benchmarks-ci.sh assets statemint


### PR DESCRIPTION
Currently timeout for all jobs is 1 day which is too much especially when a job hangs for some reasons. PR sets timeout 1 day only from benchmark job. For other jobs default timeout will be 2 hours (it's going to be set in repo settings)

https://github.com/paritytech/ci_cd/issues/543