### PR TITLE
Adding TxVersion Check to signed params

### DIFF
--- a/parachains/runtimes/testing/rococo-parachain/src/lib.rs
+++ b/parachains/runtimes/testing/rococo-parachain/src/lib.rs
@@ -570,6 +570,7 @@ pub type BlockId = generic::BlockId<Block>;
 pub type SignedExtra = (
 	frame_system::CheckNonZeroSender<Runtime>,
 	frame_system::CheckSpecVersion<Runtime>,
+	frame_system::CheckTxVersion<Runtime>,
 	frame_system::CheckGenesis<Runtime>,
 	frame_system::CheckEra<Runtime>,
 	frame_system::CheckNonce<Runtime>,


### PR DESCRIPTION
Is there any underlaying reason to not have the TxVersion check as part of the signature payload in this particular test runtime? If not, then I would love to have it in, for consistency sake with most of runtime implementations.