### PR TITLE
gitignore dot-underscore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ polkadot_argument_parsing
 *.iml
 .env
 bin
+**/._*


### PR DESCRIPTION
Git ignore dot-underscore.

Same pattern used as within [substrate](https://github.com/paritytech/substrate/blob/6401300a2ff7ce013385f2c61fc9a3798bd4272d/.gitignore#L10) and polkadot repos.
