### PR TITLE
[ci] improve cancel-pipeline job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -384,5 +384,5 @@ cancel-pipeline:
     FAILED_JOB_NAME:               "${FAILED_JOB_NAME}"
     PR_NUM:                        "${PR_NUM}"
   trigger:
-    project:                   "parity/infrastructure/ci_cd/pipeline-stopper"
-    branch:                       "as-improve"
+    project:                       "parity/infrastructure/ci_cd/pipeline-stopper"
+    branch:                        "as-improve"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -385,4 +385,5 @@ cancel-pipeline:
     PR_NUM:                        "${PR_NUM}"
   trigger:
     project:                       "parity/infrastructure/ci_cd/pipeline-stopper"
+    # remove branch, when pipeline-stopper for substrate and polakdot is updated to the same branch
     branch:                        "as-improve"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -382,4 +382,6 @@ cancel-pipeline:
     FAILED_JOB_URL:                "${FAILED_JOB_URL}"
     FAILED_JOB_NAME:               "${FAILED_JOB_NAME}"
     PR_NUM:                        "${PR_NUM}"
-  trigger:                         "parity/infrastructure/ci_cd/pipeline-stopper"
+  trigger:
+    - project:                     "parity/infrastructure/ci_cd/pipeline-stopper"
+      ref:                         "as-improve"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -110,6 +110,7 @@ test-linux-stable:
     # but still want to have debug assertions.
     RUSTFLAGS: "-Cdebug-assertions=y -Dwarnings"
   script:
+    - exit 1
     - time cargo nextest run --all --release --locked --run-ignored all
 
 test-doc:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -383,5 +383,6 @@ cancel-pipeline:
     FAILED_JOB_NAME:               "${FAILED_JOB_NAME}"
     PR_NUM:                        "${PR_NUM}"
   trigger:
-    - project:                     "parity/infrastructure/ci_cd/pipeline-stopper"
-      ref:                         "as-improve"
+    include:
+      - project:                   "parity/infrastructure/ci_cd/pipeline-stopper"
+        ref:                       "as-improve"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -44,6 +44,19 @@ variables:
   - cargo +nightly --version
   - bash --version
 
+# collecting vars for pipeline stopper
+# they will be used if the job fails
+.pipeline-stopper-vars:            &pipeline-stopper-vars
+    - echo "FAILED_JOB_URL=${CI_JOB_URL}" > pipeline-stopper.env
+    - echo "FAILED_JOB_NAME=${CI_JOB_NAME}" >> pipeline-stopper.env
+    - echo "FAILED_JOB_NAME=${CI_JOB_NAME}" >> pipeline-stopper.env
+    - echo "PR_NUM=${CI_COMMIT_REF_NAME}" >> pipeline-stopper.env
+
+.pipeline-stopper-artifacts:       &pipeline-stopper-artifacts
+  artifacts:
+     reports:
+       dotenv: pipeline-stopper.env
+
 .common-refs:                      &common-refs
   # these jobs run always*
   rules:
@@ -86,8 +99,12 @@ variables:
 
 test-linux-stable:
   stage:                           test
+  before_script:
+    - *rust-info-script
+    - *pipeline-stopper-vars
   <<:                              *docker-env
   <<:                              *common-refs
+  <<:                              *pipeline-stopper-artifacts
   variables:
     # Enable debug assertions since we are running optimized builds for testing
     # but still want to have debug assertions.
@@ -355,11 +372,14 @@ cancel-pipeline:
   stage:                           .post
   needs:
     - job:                         test-linux-stable
-      artifacts:                   false
   rules:
     - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
       when: on_failure
   variables:
     PROJECT_ID:                    "${CI_PROJECT_ID}"
+    PROJECT_NAME:                  "${CI_PROJECT_NAME}"
     PIPELINE_ID:                   "${CI_PIPELINE_ID}"
+    FAILED_JOB_URL:                "${FAILED_JOB_URL}"
+    FAILED_JOB_NAME:               "${FAILED_JOB_NAME}"
+    PR_NUM:                        "${PR_NUM}"
   trigger:                         "parity/infrastructure/ci_cd/pipeline-stopper"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -384,7 +384,5 @@ cancel-pipeline:
     FAILED_JOB_NAME:               "${FAILED_JOB_NAME}"
     PR_NUM:                        "${PR_NUM}"
   trigger:
-    include:
-      - project:                   "parity/infrastructure/ci_cd/pipeline-stopper"
-        ref:                       "as-improve"
-        file:                      ".gitlab-ci.yml"
+    project:                   "parity/infrastructure/ci_cd/pipeline-stopper"
+    branch:                       "as-improve"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -99,12 +99,12 @@ variables:
 
 test-linux-stable:
   stage:                           test
-  before_script:
-    - *rust-info-script
-    - *pipeline-stopper-vars
   <<:                              *docker-env
   <<:                              *common-refs
   <<:                              *pipeline-stopper-artifacts
+  before_script:
+    - *rust-info-script
+    - *pipeline-stopper-vars
   variables:
     # Enable debug assertions since we are running optimized builds for testing
     # but still want to have debug assertions.

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -386,3 +386,4 @@ cancel-pipeline:
     include:
       - project:                   "parity/infrastructure/ci_cd/pipeline-stopper"
         ref:                       "as-improve"
+        file:                      ".gitlab-ci.yml"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -110,7 +110,6 @@ test-linux-stable:
     # but still want to have debug assertions.
     RUSTFLAGS: "-Cdebug-assertions=y -Dwarnings"
   script:
-    - exit 1
     - time cargo nextest run --all --release --locked --run-ignored all
 
 test-doc:


### PR DESCRIPTION
The PR improves `test-linux-stable` job. Now it posts a message that the pipeline was cancelled and logs to the failed job.
I will remove `branch:                        "as-improve"` when adapt this job in polkadot and substrate.

cc https://github.com/paritytech/ci_cd/issues/548 