### PR TITLE
Backport core version fix

### DIFF
--- a/scripts/ci/changelog/templates/runtime.md.tera
+++ b/scripts/ci/changelog/templates/runtime.md.tera
@@ -19,7 +19,7 @@
 
 ```
 🏋️ Runtime Size:		{{ runtime.data.runtimes.compressed.subwasm.size | filesizeformat }} ({{ runtime.data.runtimes.compressed.subwasm.size }} bytes)
-🔥 Core Version:		{{ runtime.data.runtimes.compressed.subwasm.core_version }}
+🔥 Core Version:		{{ runtime.data.runtimes.compressed.subwasm.core_version.specName }}-{{ runtime.data.runtimes.compressed.subwasm.core_version.specVersion }} ({{ runtime.data.runtimes.compressed.subwasm.core_version.implName }}-{{ runtime.data.runtimes.compressed.subwasm.core_version.implVersion }}.tx{{ runtime.data.runtimes.compressed.subwasm.core_version.transactionVersion }}.au{{ runtime.data.runtimes.compressed.subwasm.core_version.authoringVersion }})
 🗜 Compressed:			{{ compressed }}: {{ comp_ratio | round(method="ceil", precision=2) }}%
 🎁 Metadata version:		V{{ runtime.data.runtimes.compressed.subwasm.metadata_version }}
 🗳️ Blake2-256 hash:		{{ runtime.data.runtimes.compressed.subwasm.blake2_256 }}


### PR DESCRIPTION
This backport is only relevant for the **runtimes** release branch and fixes the issue resulting in improperly showing `[object]` as version in the release notes.