### PR TITLE
Fix release notes templates according to label changes in #1533

### DIFF
--- a/scripts/ci/changelog/templates/change.md.tera
+++ b/scripts/ci/changelog/templates/change.md.tera
@@ -1,7 +1,7 @@
 {# This macro shows ONE change #}
 {%- macro change(c, cml="[C]", dot="[P]", sub="[S]") -%}
 
-{%- if c.meta.C and c.meta.C.value >= 7 -%}
+{%- if c.meta.C and c.meta.C.value >= 5 -%}
 {%- set prio = " ‼️ HIGH" -%}
 {%- elif c.meta.C and c.meta.C.value >= 3 -%}
 {%- set prio = " ❗️ Medium" -%}

--- a/scripts/ci/changelog/templates/changes_misc.md.tera
+++ b/scripts/ci/changelog/templates/changes_misc.md.tera
@@ -7,7 +7,7 @@
         {%- if pr.meta.B.value == 0 -%}
         {#- We skip silent ones -#}
         {%- else -%}
-            {%- if pr.meta.B and pr.meta.B.value != 5 and pr.meta.B.value != 7 or pr.meta.C or not pr.meta.B %}
+            {%- if pr.meta.B and pr.meta.B.value != 5 or pr.meta.C or not pr.meta.B %}
 {%- set_global misc_count = misc_count + 1 -%}
             {%- endif -%}
         {% endif -%}
@@ -27,7 +27,7 @@ There are other misc. changes. You can expand the list below to view them all.
         {%- if pr.meta.B.value == 0 %}
         {#- We skip silent ones -#}
         {%- else -%}
-            {%- if pr.meta.B and pr.meta.B.value != 5 and pr.meta.B.value != 7 or pr.meta.C or not pr.meta.B %}
+            {%- if pr.meta.B and pr.meta.B.value != 5 or pr.meta.C or not pr.meta.B %}
 - {{ m_c::change(c=pr) }}
             {%- endif -%}
         {% endif -%}

--- a/scripts/ci/changelog/templates/changes_runtime.md.tera
+++ b/scripts/ci/changelog/templates/changes_runtime.md.tera
@@ -5,12 +5,12 @@
 {#- The changes are sorted by merge date -#}
 {% for pr in changes | sort(attribute="merged_at") -%}
 
-{%- if pr.meta.B -%}
+{%- if pr.meta.B and pr.meta.X -%}
 {%- if pr.meta.B.value == 0 -%}
 {#- We skip silent ones -#}
 {%- else -%}
 
-{%- if pr.meta.B.value == 7 and not pr.title is containing("ompanion") %}
+{%- if pr.meta.B.value == 1 and pr.meta.X.value == 1 and not pr.title is containing("ompanion") %}
 - {{ m_c::change(c=pr) }}
 {%- endif -%}
 {%- endif -%}

--- a/scripts/ci/changelog/templates/high_priority.md.tera
+++ b/scripts/ci/changelog/templates/high_priority.md.tera
@@ -19,7 +19,7 @@
 {%- endif -%}
 {%- endfor -%}
 
-{%- if p >= 7 or host_fn_count > 0 -%}
+{%- if p >= 5 or host_fn_count > 0 -%}
     {%- set prio = "‼️ HIGH" -%}
     {%- set text = "This is a **high priority** release and you must upgrade as as soon as possible." -%}
 {%- elif p >= 3 -%}
@@ -45,7 +45,7 @@ The changes motivating this priority level are:
     {%- if pr.meta.C -%}
         {%- if pr.meta.C.value == p %}
 - {{ m_c::change(c=pr) }}
-{%- if pr.meta.B and pr.meta.B.value == 7 %}
+{%- if pr.meta.B and pr.meta.X and pr.meta.B.value == 1 and pr.meta.X.value == 1 %}
 (RUNTIME)
 {% endif %}
 


### PR DESCRIPTION
WIP: #1533 is required to be merged before we can merge this PR

## Before merging

Before merging, the following needs to be checked:
- [x] The repo is clean from duplicates (checkable using `glabel get paritytech/cumulus | awk '{print $2}' | cut -d '-' -f1 | sort | uniq -c| sort`)
- [x] `B7` no longer exists


cc @the-right-joyce 