### PR TITLE
Removes duplication and unneeded sections of runtime release notes

### DIFF
--- a/scripts/ci/changelog/templates/changes.md.tera
+++ b/scripts/ci/changelog/templates/changes.md.tera
@@ -14,7 +14,6 @@
 
 {% include "changes_runtime.md.tera" %}
 
-{% include "runtimes.md.tera" -%}
 {% endif %}
 
 {% include "changes_misc.md.tera" %}

--- a/scripts/ci/changelog/templates/template.md.tera
+++ b/scripts/ci/changelog/templates/template.md.tera
@@ -20,15 +20,14 @@ This release contains the changes from `{{ env.REF1 }}` to `{{ env.REF2 }}`.
 {# we will force it to HIGH if at least one host function was detected. #}
 
 {% include "host_functions.md.tera" -%}
+
+{% if env.RELEASE_TYPE and env.RELEASE_TYPE == "client" -%}
 {% include "global_priority.md.tera" -%}
 {% include "compiler.md.tera" -%}
-{% include "migrations-db.md.tera" -%}
-
-{% if env.RELEASE_TYPE and env.RELEASE_TYPE == "client" %}
+{% include "migrations-db.md.tera" %}
 <!-- skipping runtime data for RELEASE_TYPE = {{ env.RELEASE_TYPE }} -->
 {% else %}
-{% include "migrations-runtime.md.tera" -%}
-
+{% include "migrations-runtime.md.tera" %}
 {% include "runtimes.md.tera" -%}
 {% endif %}
 


### PR DESCRIPTION
Better version of https://github.com/paritytech/cumulus/pull/1470

Tested to make sure no change to node release notes. All new lines are present and accounted for.

no need for compiler version as we use srtool (saying the compiler version was confusing and misdirection).
no need for priority as that only makes sense for nodes.
no need for the duplication of the runtime hashes.
