### PR TITLE
chore: bump zombienet version

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,7 +29,7 @@ variables:
   CI_IMAGE:                        "paritytech/ci-linux:production"
   DOCKER_OS:                       "debian:stretch"
   ARCH:                            "x86_64"
-  ZOMBIENET_IMAGE:                 "docker.io/paritytech/zombienet:v1.2.53"
+  ZOMBIENET_IMAGE:                 "docker.io/paritytech/zombienet:v1.2.56"
 
 .collect-artifacts:                &collect-artifacts
   artifacts:


### PR DESCRIPTION
Bump zombienet, this new version set the baseline resources for pods in CI.

cc @bkchr.