### PR TITLE
9270 Backport of Align versions for runtimes (#1517)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6800,7 +6800,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "penpal-runtime"
-version = "0.1.0"
+version = "0.9.27"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",

--- a/parachains/runtimes/testing/penpal/Cargo.toml
+++ b/parachains/runtimes/testing/penpal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "penpal-runtime"
-version = "0.1.0"
+version = "0.9.27"
 authors = ["Anonymous"]
 description = "A parachain for communication back and forth with XCM of assets and uniques."
 license = "Unlicense"

--- a/parachains/runtimes/testing/penpal/src/lib.rs
+++ b/parachains/runtimes/testing/penpal/src/lib.rs
@@ -186,7 +186,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("penpal-parachain"),
 	impl_name: create_runtime_str!("penpal-parachain"),
 	authoring_version: 1,
-	spec_version: 1,
+	spec_version: 9270,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
This has been released in 9270. ( https://github.com/paritytech/cumulus/commit/ba03538945fb6a41df56e5ccee2a550d747ad620 )