### PR TITLE
bump zombienet version, support new weights

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,7 +29,7 @@ variables:
   CI_IMAGE:                        "paritytech/ci-linux:production"
   DOCKER_OS:                       "debian:stretch"
   ARCH:                            "x86_64"
-  ZOMBIENET_IMAGE:                 "docker.io/paritytech/zombienet:v1.2.56"
+  ZOMBIENET_IMAGE:                 "docker.io/paritytech/zombienet:v1.2.59"
 
 .collect-artifacts:                &collect-artifacts
   artifacts:


### PR DESCRIPTION
Add support for weights changes (https://github.com/paritytech/substrate/pull/12138), used in upgrade test
e.g [zombienet-0004-runtime_upgrade](https://gitlab.parity.io/parity/mirrors/cumulus/-/jobs/1803178).