### PR TITLE
fix release report generation script

### DIFF
--- a/scripts/ci/changelog/bin/changelog
+++ b/scripts/ci/changelog/bin/changelog
@@ -124,8 +124,8 @@ else
             { name: "statemine", data: $srtool_statemine[0] },
             { name: "statemint", data: $srtool_statemint[0] },
             { name: "rococo", data: $srtool_rococo_parachain[0] },
-            { name: "contracts", data: $srtool_contracts_rococo[0] }
-            { name: "polkadot-collectives", data: $srtool_polkadot_collectives[0] },
+            { name: "contracts", data: $srtool_contracts_rococo[0] },
+            { name: "polkadot-collectives", data: $srtool_polkadot_collectives[0] }
       ] }\' > context.json',
         cumulus_data,
         substrate_data,


### PR DESCRIPTION
Error from "Generate release notes" - https://github.com/paritytech/cumulus/runs/8194727157?check_suite_focus=true

```
[2022-09-05T18:50:05.653663 #1757] DEBUG -- : Building changelog with runtimes
jq: error: syntax error, unexpected '{' (Unix shell quoting issues?) at <top-level>, line 12:
            { name: "polkadot-collectives", data: $srtool_polkadot_collectives[0] },            
jq: error: syntax error, unexpected ']' (Unix shell quoting issues?) at <top-level>, line 13:
      ] }      
jq: 2 compile errors
thread 'main' panicked at 'JSON parsing: Error("EOF while parsing a value", line: 1, column: 0)', src/wrapped_context.rs:40:53
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Aborted (core dumped)
-rw-r--r-- 1 runner docker 0 Sep  5 18:50 context.json
```