### PR TITLE
updated integration tests

### DIFF
--- a/parachains/integration-tests/statemine/config.toml
+++ b/parachains/integration-tests/statemine/config.toml
@@ -5,7 +5,7 @@ chain = "kusama-local"
 
 	[[relaychain.nodes]]
 	name = "alice"
-	ws_port = 9900
+	ws_port = 8800
 	validator = true
 
 	[[relaychain.nodes]]
@@ -27,7 +27,7 @@ cumulus_based = true
 
 	[[parachains.collators]]
 	name = "collator1"
-	ws_port = 9910
+	ws_port = 8810
 	command = "./bin/polkadot-parachain"
 
 	[[parachains.collators]]
@@ -41,7 +41,7 @@ cumulus_based = true
 
 	[[parachains.collators]]
 	name = "collator3"
-	ws_port = 9920
+	ws_port = 8820
 	command = "./bin/polkadot-parachain"
 
 	[[parachains.collators]]

--- a/parachains/integration-tests/statemine/xcm/0_init.yml
+++ b/parachains/integration-tests/statemine/xcm/0_init.yml
@@ -2,12 +2,12 @@
 settings:
   chains:
     relay_chain: &relay_chain
-      wsPort: 9900
+      wsPort: 8800
     assets_parachain: &assets_parachain
-      wsPort: 9910
+      wsPort: 8810
       paraId: &ap_id 1000
     penpal_parachain: &penpal_parachain
-      wsPort: 9920
+      wsPort: 8820
       paraId: &pp_id 2000
   variables:
     common:

--- a/parachains/integration-tests/statemine/xcm/1_dmp.yml
+++ b/parachains/integration-tests/statemine/xcm/1_dmp.yml
@@ -2,9 +2,9 @@
 settings:
   chains:
     relay_chain: &relay_chain
-      wsPort: 9900
+      wsPort: 8800
     assets_parachain: &assets_parachain
-      wsPort: 9910
+      wsPort: 8810
       paraId: &ap_id 1000
   variables:
     relay_chain:
@@ -77,7 +77,7 @@ tests:
                       attribute:
                         type: XcmV2TraitsOutcome
                         isComplete: true
-                        value: 4,000,000,000
+                        # value: 4,000,000,000
               - queries:
                   balance_rc_sender_after:
                     chain: *relay_chain
@@ -148,7 +148,7 @@ tests:
                       attribute:
                         type: XcmV2TraitsOutcome
                         isComplete: true
-                        value: 2,000,000,000
+                        # value: 2,000,000,000
               - queries:
                   forced_created_asset:
                     chain: *assets_parachain
@@ -215,8 +215,8 @@ tests:
                       chain: *assets_parachain
                       attribute:
                         type: XcmV2TraitsOutcome
-                        isIncomplete: true
-                        value: ['1,000,000,000' , UntrustedReserveLocation]
+                        isError: true
+                        value: "WeightNotComputable"
               - queries:
                   balance_rc_sender_after:
                     chain: *relay_chain

--- a/parachains/integration-tests/statemine/xcm/2_ump.yml
+++ b/parachains/integration-tests/statemine/xcm/2_ump.yml
@@ -2,9 +2,9 @@
 settings:
   chains:
     relay_chain: &relay_chain
-      wsPort: 9900
+      wsPort: 8800
     assets_parachain: &assets_parachain
-      wsPort: 9910
+      wsPort: 8810
       paraId: &ap_id 1000
   variables:
     common:
@@ -62,7 +62,7 @@ tests:
                       attribute:
                         type: XcmV2TraitsOutcome
                         isComplete: true
-                        value: 4,000,000,000
+                        # value: 4,000,000,000
 
           - name: Get the balances of the Assets Parachain's sender & Relay Chain's receiver
             actions:
@@ -77,6 +77,7 @@ tests:
                     pallet: system
                     call: account
                     args: [ *rc_wallet ]
+
         its:
           - name: Should teleport native assets back from Assets Parachain to the Relay Chain
             actions:
@@ -97,7 +98,7 @@ tests:
                       attribute:
                         type: XcmV2TraitsOutcome
                         isComplete: true
-                        value: 2,000,000,000
+                        # value: 2,000,000,000
                     - name: ump.ExecutedUpward
                       chain: *relay_chain
                       attribute:
@@ -145,7 +146,7 @@ tests:
 
       - name: polkadotXcm.send | Native - Transact(system.remark)
         its:
-          - name: Assets Parachain SHOULD NOT be able to dipatch 'send' call
+          - name: Assets Parachain SHOULD NOT be able to dispatch 'send' call
             actions:
               - extrinsics:
                 - chain: *assets_parachain

--- a/parachains/integration-tests/statemine/xcm/3_hrmp-open-channels.yml
+++ b/parachains/integration-tests/statemine/xcm/3_hrmp-open-channels.yml
@@ -2,12 +2,12 @@
 settings:
   chains:
     relay_chain: &relay_chain
-      wsPort: 9900
+      wsPort: 8800
     assets_parachain: &assets_parachain
-      wsPort: 9910
+      wsPort: 8810
       paraId: &ap_id 1000
     penpal_parachain: &penpal_parachain
-      wsPort: 9920
+      wsPort: 8820
       paraId: &pp_id 2000
   variables:
     common:
@@ -226,7 +226,7 @@ tests:
 
       - name: hrmp.hrmpAcceptOpenChannel (Assets Parachain → Penpal Parachain)
         its:
-          - name: Assets Parachain sends a response to the Relay Chain accepting the Penpal Parachain's request for openning a HRMP channel
+          - name: Assets Parachain sends a response to the Relay Chain accepting the Penpal Parachain's request for opening a HRMP channel
             actions:
               - extrinsics:
                 - chain: *relay_chain
@@ -259,7 +259,7 @@ tests:
                       attribute:
                         type: XcmV2TraitsOutcome
                         isComplete: true
-                        value: 2,000,000,000
+                        # value: 2,000,000,000
                     - name: polkadotXcm.Sent
                       chain: *assets_parachain
                     - name: ump.ExecutedUpward
@@ -291,7 +291,7 @@ tests:
 
       - name: hrmp.hrmpInitOpenChannel (Assets Parachain → Penpal Parachain)
         its:
-          - name: Assets Parchain sends a request to the Relay Chain to open a channel with a Penpal Parachain
+          - name: Assets Parachain sends a request to the Relay Chain to open a channel with a Penpal Parachain
             actions:
               - extrinsics:
                 - chain: *relay_chain
@@ -324,7 +324,7 @@ tests:
                       attribute:
                         type: XcmV2TraitsOutcome
                         isComplete: true
-                        value: 2,000,000,000
+                        # value: 2,000,000,000
                     - name: polkadotXcm.Sent
                       chain: *assets_parachain
                     - name: ump.ExecutedUpward
@@ -355,7 +355,7 @@ tests:
 
       - name: hrmp.hrmpAcceptOpenChannel (Penpal Parachain → Assets Parachain)
         its:
-          - name: Penpal Parachain sends a response to the Relay Chain accepting the Assets Parachain's request for openning a HRMP channel
+          - name: Penpal Parachain sends a response to the Relay Chain accepting the Assets Parachain's request for opening a HRMP channel
             actions:
               - extrinsics:
                 - chain: *penpal_parachain

--- a/parachains/integration-tests/statemine/xcm/4_hrmp.yml
+++ b/parachains/integration-tests/statemine/xcm/4_hrmp.yml
@@ -2,12 +2,12 @@
 settings:
   chains:
     relay_chain: &relay_chain
-      wsPort: 9900
+      wsPort: 8800
     assets_parachain: &assets_parachain
-      wsPort: 9910
+      wsPort: 8810
       paraId: &ap_id 1000
     penpal_parachain: &penpal_parachain
-      wsPort: 9920
+      wsPort: 8820
       paraId: &pp_id 2000
   variables:
     common:
@@ -87,7 +87,7 @@ tests:
                       attribute:
                         type: XcmV2TraitsOutcome
                         isComplete: true
-                        value: 2,000,000,000
+                        # value: 2,000,000,000
               - queries:
                   forced_created_asset:
                     chain: *assets_parachain
@@ -112,7 +112,6 @@ tests:
                   ]
                   events:
                     - name: assets.Issued
-
         its:
           - name: Assets Parachain should be able to reserve transfer an Asset to Penpal Parachain
             actions:
@@ -168,7 +167,7 @@ tests:
                       attribute:
                         type: XcmV2TraitsOutcome
                         isComplete: true
-                        value: 1,000,000,000
+                        # value: 1,000,000,000
                     - name: assets.Transferred
                       attribute:
                         type: AccountId32
@@ -176,7 +175,7 @@ tests:
                     - name: assets.Transferred
                       attribute:
                         type: u128
-                        value: *amount_to_send
+                        value: 500,000,000,000
 
       - name: polkadotXcm.limitedReserveTransferAssets (KSM) | Assets Parachain -> Penpal Parachain
         its:
@@ -215,7 +214,7 @@ tests:
                       attribute:
                         type: XcmV2TraitsOutcome
                         isComplete: true
-                        value: 1,000,000,000
+                        # value: 1,000,000,000
                     - name: balances.Endowed
                       attribute:
                         type: AccountId32
@@ -223,7 +222,7 @@ tests:
                     - name: balances.Endowed
                       attribute:
                         type: u128
-                        value: *amount
+                        value: 1,000,000,000,000
 
       - name: polkadotXcm.send( system.remarkWithEvent() ) | Penpal Parachain -> Assets Parachain
         before:

--- a/parachains/integration-tests/statemint/xcm/1_dmp.yml
+++ b/parachains/integration-tests/statemint/xcm/1_dmp.yml
@@ -77,7 +77,7 @@ tests:
                       attribute:
                         type: XcmV2TraitsOutcome
                         isComplete: true
-                        value: 4,000,000,000
+                        # value: 4,000,000,000
               - queries:
                   balance_rc_sender_after:
                     chain: *relay_chain
@@ -148,7 +148,7 @@ tests:
                       attribute:
                         type: XcmV2TraitsOutcome
                         isComplete: true
-                        value: 2,000,000,000
+                        # value: 2,000,000,000
               - queries:
                   forced_created_asset:
                     chain: *assets_parachain
@@ -215,8 +215,8 @@ tests:
                       chain: *assets_parachain
                       attribute:
                         type: XcmV2TraitsOutcome
-                        isIncomplete: true
-                        value: ['1,000,000,000' , UntrustedReserveLocation]
+                        isError: true
+                        value: "WeightNotComputable"
               - queries:
                   balance_rc_sender_after:
                     chain: *relay_chain

--- a/parachains/integration-tests/statemint/xcm/2_ump.yml
+++ b/parachains/integration-tests/statemint/xcm/2_ump.yml
@@ -62,7 +62,7 @@ tests:
                       attribute:
                         type: XcmV2TraitsOutcome
                         isComplete: true
-                        value: 4,000,000,000
+                        # value: 4,000,000,000
 
           - name: Get the balances of the Assets Parachain's sender & Relay Chain's receiver
             actions:
@@ -79,7 +79,7 @@ tests:
                     args: [ *rc_wallet ]
 
         its:
-          - name: Should be able to teleport native assets back from Assets Parachain to the Relay Chain
+          - name: Should teleport native assets back from Assets Parachain to the Relay Chain
             actions:
               - extrinsics:
                 - chain: *assets_parachain
@@ -98,7 +98,7 @@ tests:
                       attribute:
                         type: XcmV2TraitsOutcome
                         isComplete: true
-                        value: 2,000,000,000
+                        # value: 2,000,000,000 to 40 billion
                     - name: ump.ExecutedUpward
                       chain: *relay_chain
                       attribute:
@@ -146,7 +146,7 @@ tests:
 
       - name: polkadotXcm.send | Native - Transact(system.remark)
         its:
-          - name: Assets Parachain SHOULD NOT be able to dipatch 'send' call
+          - name: Assets Parachain SHOULD NOT be able to dispatch 'send' call
             actions:
               - extrinsics:
                 - chain: *assets_parachain

--- a/parachains/integration-tests/statemint/xcm/3_hrmp-open-channels.yml
+++ b/parachains/integration-tests/statemint/xcm/3_hrmp-open-channels.yml
@@ -224,7 +224,7 @@ tests:
 
       - name: hrmp.hrmpAcceptOpenChannel (Assets Parachain → Penpal Parachain)
         its:
-          - name: Assets Parachain sends a response to the Relay Chain accepting the Penpal Parachain's request for openning a HRMP channel
+          - name: Assets Parachain sends a response to the Relay Chain accepting the Penpal Parachain's request for opening a HRMP channel
             actions:
               - extrinsics:
                 - chain: *relay_chain
@@ -257,7 +257,7 @@ tests:
                       attribute:
                         type: XcmV2TraitsOutcome
                         isComplete: true
-                        value: 2,000,000,000
+                        # value: 2,000,000,000
                     - name: polkadotXcm.Sent
                       chain: *assets_parachain
                     - name: ump.ExecutedUpward
@@ -289,7 +289,7 @@ tests:
 
       - name: hrmp.hrmpInitOpenChannel (Assets Parachain → Penpal Parachain)
         its:
-          - name: Assets Parchain sends a request to the Relay Chain to open a channel with a Penpal Parachain
+          - name: Assets Parachain sends a request to the Relay Chain to open a channel with a Penpal Parachain
             actions:
               - extrinsics:
                 - chain: *relay_chain
@@ -322,7 +322,7 @@ tests:
                       attribute:
                         type: XcmV2TraitsOutcome
                         isComplete: true
-                        value: 2,000,000,000
+                        # value: 2,000,000,000
                     - name: polkadotXcm.Sent
                       chain: *assets_parachain
                     - name: ump.ExecutedUpward
@@ -353,7 +353,7 @@ tests:
 
       - name: hrmp.hrmpAcceptOpenChannel (Penpal Parachain → Assets Parachain)
         its:
-          - name: Penpal Parachain sends a response to the Relay Chain accepting the Assets Parachain's request for openning a HRMP channel
+          - name: Penpal Parachain sends a response to the Relay Chain accepting the Assets Parachain's request for opening a HRMP channel
             actions:
               - extrinsics:
                 - chain: *penpal_parachain

--- a/parachains/integration-tests/statemint/xcm/4_hrmp.yml
+++ b/parachains/integration-tests/statemint/xcm/4_hrmp.yml
@@ -87,7 +87,7 @@ tests:
                       attribute:
                         type: XcmV2TraitsOutcome
                         isComplete: true
-                        value: 2,000,000,000
+                        # value: 2,000,000,000
               - queries:
                   forced_created_asset:
                     chain: *assets_parachain
@@ -167,7 +167,7 @@ tests:
                       attribute:
                         type: XcmV2TraitsOutcome
                         isComplete: true
-                        value: 1,000,000,000
+                        # value: 1,000,000,000  "655,068,000"
                     - name: assets.Transferred
                       attribute:
                         type: AccountId32
@@ -175,11 +175,11 @@ tests:
                     - name: assets.Transferred
                       attribute:
                         type: u128
-                        value: *amount_to_send
+                        value: 500,000,000,000
 
-      - name: polkadotXcm.limitedReserveTransferAssets (KSM) | Assets Parachain -> Penpal Parachain
+      - name: polkadotXcm.limitedReserveTransferAssets (DOT) | Assets Parachain -> Penpal Parachain
         its:
-          - name: Assets Parachain should be able to reserve transfer KSM to Penpal Parachain
+          - name: Assets Parachain should be able to reserve transfer DOT to Penpal Parachain
             actions:
               - extrinsics:
                 - chain: *assets_parachain
@@ -214,7 +214,7 @@ tests:
                       attribute:
                         type: XcmV2TraitsOutcome
                         isComplete: true
-                        value: 1,000,000,000
+                        # value: 1,000,000,000   "655,068,000"
                     - name: balances.Endowed
                       attribute:
                         type: AccountId32
@@ -222,4 +222,4 @@ tests:
                     - name: balances.Endowed
                       attribute:
                         type: u128
-                        value: *amount
+                        value: 1,000,000,000,000

--- a/parachains/runtimes/assets/statemine/src/weights/xcm/mod.rs
+++ b/parachains/runtimes/assets/statemine/src/weights/xcm/mod.rs
@@ -57,7 +57,7 @@ impl<Call> XcmWeightInfo<Call> for StatemineXcmWeight<Call> {
 	}
 	// Currently there is no trusted reserve
 	fn reserve_asset_deposited(_assets: &MultiAssets) -> XCMWeight {
-		unimplemented!()
+		u64::MAX
 	}
 	fn receive_teleported_asset(assets: &MultiAssets) -> XCMWeight {
 		assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::receive_teleported_asset())

--- a/parachains/runtimes/assets/statemint/src/weights/xcm/mod.rs
+++ b/parachains/runtimes/assets/statemint/src/weights/xcm/mod.rs
@@ -57,7 +57,7 @@ impl<Call> XcmWeightInfo<Call> for StatemintXcmWeight<Call> {
 	}
 	// Currently there is no trusted reserve
 	fn reserve_asset_deposited(_assets: &MultiAssets) -> XCMWeight {
-		unimplemented!()
+		u64::MAX
 	}
 	fn receive_teleported_asset(assets: &MultiAssets) -> XCMWeight {
 		assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::receive_teleported_asset())


### PR DESCRIPTION
Integration test changes:

- xcm weights are no longer all fixed (can we assert they're in a range? https://github.com/paritytech/parachains-integration-tests/issues/35 )
- default port changes so that polkadot is not on the same ports as kusama. (at some point we're going to be running both at once doing integration tests between them and if they're on the same ports we can't do that so let's get into good conventions early on.)
- typo fixes.
- change from `*amount` to `1,000,000,000,000` as it was expecting the commas when it checked the assertion now. (Can / should we make it less picky @NachoPal ? )

(I can break these up into smaller PRs on request)