### PR TITLE
[Fix] Weight calculations for Wild -> affects teleports

### DIFF
--- a/parachains/common/src/xcm_config.rs
+++ b/parachains/common/src/xcm_config.rs
@@ -127,9 +127,9 @@ pub fn weigh_multi_assets_generic(
 	weight: Weight,
 	max_assets: u32,
 ) -> XCMWeight {
-	let weight = match filter {
-		MultiAssetFilter::Definite(assets) => weight.saturating_mul(assets.len() as u64),
-		MultiAssetFilter::Wild(_) => weight.saturating_mul(max_assets as u64),
+	let multiplier = match filter {
+		MultiAssetFilter::Definite(assets) => assets.len() as u64,
+		MultiAssetFilter::Wild(_) => max_assets as u64,
 	};
-	weight.ref_time()
+	weight.saturating_mul(multiplier).ref_time()
 }

--- a/parachains/common/src/xcm_config.rs
+++ b/parachains/common/src/xcm_config.rs
@@ -119,3 +119,17 @@ impl<Location: Get<MultiLocation>> FilterAssetLocation for ConcreteNativeAssetFr
 		matches!(asset.id, Concrete(ref id) if id == origin && origin == &Location::get())
 	}
 }
+
+/// A generic function to use for MultiAssetFilter implementations, currently used to differentiate
+/// between reserve operations and the rest of them.
+pub fn weigh_multi_assets_generic(
+	filter: &MultiAssetFilter,
+	weight: Weight,
+	max_assets: u32,
+) -> XCMWeight {
+	let weight = match filter {
+		MultiAssetFilter::Definite(assets) => weight.saturating_mul(assets.len() as u64),
+		MultiAssetFilter::Wild(_) => weight.saturating_mul(max_assets as u64),
+	};
+	weight.ref_time()
+}

--- a/parachains/runtimes/assets/statemine/src/weights/xcm/mod.rs
+++ b/parachains/runtimes/assets/statemine/src/weights/xcm/mod.rs
@@ -135,7 +135,7 @@ impl<Call> XcmWeightInfo<Call> for StatemineXcmWeight<Call> {
 		_max_assets: &u32,
 		_dest: &MultiLocation,
 	) -> XCMWeight {
-		assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::deposit_asset())
+		assets.weigh_multi_assets_teleport(XcmFungibleWeight::<Runtime>::deposit_asset())
 	}
 	fn deposit_reserve_asset(
 		assets: &MultiAssetFilter,

--- a/parachains/runtimes/assets/statemine/src/weights/xcm/mod.rs
+++ b/parachains/runtimes/assets/statemine/src/weights/xcm/mod.rs
@@ -31,13 +31,12 @@ trait WeighMultiAssets {
 	fn weigh_multi_assets(&self, weight: Weight) -> XCMWeight;
 }
 
-const MAX_ASSETS: u32 = 100;
+const MAX_ASSETS: u32 = 1;
 
 impl WeighMultiAssets for MultiAssetFilter {
 	fn weigh_multi_assets(&self, weight: Weight) -> XCMWeight {
 		let weight = match self {
-			Self::Definite(assets) =>
-				weight.saturating_mul(assets.inner().into_iter().count() as u64),
+			Self::Definite(assets) => weight.saturating_mul(assets.len() as u64),
 			Self::Wild(_) => weight.saturating_mul(MAX_ASSETS as u64),
 		};
 		weight.ref_time()
@@ -46,7 +45,7 @@ impl WeighMultiAssets for MultiAssetFilter {
 
 impl WeighMultiAssets for MultiAssets {
 	fn weigh_multi_assets(&self, weight: Weight) -> XCMWeight {
-		weight.saturating_mul(self.inner().into_iter().count() as u64).ref_time()
+		weight.saturating_mul(self.len() as u64).ref_time()
 	}
 }
 

--- a/parachains/runtimes/assets/statemine/src/weights/xcm/mod.rs
+++ b/parachains/runtimes/assets/statemine/src/weights/xcm/mod.rs
@@ -21,22 +21,11 @@ use crate::Runtime;
 use frame_support::weights::Weight;
 use pallet_xcm_benchmarks_fungible::WeightInfo as XcmFungibleWeight;
 use pallet_xcm_benchmarks_generic::WeightInfo as XcmGeneric;
+use parachains_common::xcm_config::weigh_multi_assets_generic;
 use xcm::{
 	latest::{prelude::*, Weight as XCMWeight},
 	DoubleEncoded,
 };
-
-fn weigh_multi_assets_generic(
-	filter: &MultiAssetFilter,
-	weight: Weight,
-	max_assets: u32,
-) -> XCMWeight {
-	let weight = match filter {
-		MultiAssetFilter::Definite(assets) => weight.saturating_mul(assets.len() as u64),
-		MultiAssetFilter::Wild(_) => weight.saturating_mul(max_assets as u64),
-	};
-	weight.ref_time()
-}
 
 trait WeighMultiAssets {
 	fn weigh_multi_assets(&self, weight: Weight) -> XCMWeight;

--- a/parachains/runtimes/assets/statemine/src/weights/xcm/mod.rs
+++ b/parachains/runtimes/assets/statemine/src/weights/xcm/mod.rs
@@ -21,7 +21,6 @@ use crate::Runtime;
 use frame_support::weights::Weight;
 use pallet_xcm_benchmarks_fungible::WeightInfo as XcmFungibleWeight;
 use pallet_xcm_benchmarks_generic::WeightInfo as XcmGeneric;
-use sp_std::prelude::*;
 use xcm::{
 	latest::{prelude::*, Weight as XCMWeight},
 	DoubleEncoded,

--- a/parachains/runtimes/assets/statemine/src/weights/xcm/mod.rs
+++ b/parachains/runtimes/assets/statemine/src/weights/xcm/mod.rs
@@ -43,12 +43,12 @@ trait WeighMultiAssets {
 	fn weigh_multi_assets(&self, weight: Weight) -> XCMWeight;
 }
 
-trait WeighMultiAssetsTeleport {
-	fn weigh_multi_assets_teleport(&self, weight: Weight) -> XCMWeight;
+trait WeighMultiAssetsReserve {
+	fn weigh_multi_assets_reserve(&self, weight: Weight) -> XCMWeight;
 }
 
-const MAX_ASSETS: u32 = 100;
-const TELEPORT_MAX_ASSETS: u32 = 1;
+const RESERVE_MAX_ASSETS: u32 = 100;
+const MAX_ASSETS: u32 = 1;
 
 impl WeighMultiAssets for MultiAssetFilter {
 	fn weigh_multi_assets(&self, weight: Weight) -> XCMWeight {
@@ -56,9 +56,9 @@ impl WeighMultiAssets for MultiAssetFilter {
 	}
 }
 
-impl WeighMultiAssetsTeleport for MultiAssetFilter {
-	fn weigh_multi_assets_teleport(&self, weight: Weight) -> XCMWeight {
-		weigh_multi_assets_generic(self, weight, TELEPORT_MAX_ASSETS)
+impl WeighMultiAssetsReserve for MultiAssetFilter {
+	fn weigh_multi_assets_reserve(&self, weight: Weight) -> XCMWeight {
+		weigh_multi_assets_generic(self, weight, RESERVE_MAX_ASSETS)
 	}
 }
 
@@ -135,7 +135,7 @@ impl<Call> XcmWeightInfo<Call> for StatemineXcmWeight<Call> {
 		_max_assets: &u32,
 		_dest: &MultiLocation,
 	) -> XCMWeight {
-		assets.weigh_multi_assets_teleport(XcmFungibleWeight::<Runtime>::deposit_asset())
+		assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::deposit_asset())
 	}
 	fn deposit_reserve_asset(
 		assets: &MultiAssetFilter,
@@ -143,7 +143,7 @@ impl<Call> XcmWeightInfo<Call> for StatemineXcmWeight<Call> {
 		_dest: &MultiLocation,
 		_xcm: &Xcm<()>,
 	) -> XCMWeight {
-		assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::deposit_reserve_asset())
+		assets.weigh_multi_assets_reserve(XcmFungibleWeight::<Runtime>::deposit_reserve_asset())
 	}
 	fn exchange_asset(_give: &MultiAssetFilter, _receive: &MultiAssets) -> XCMWeight {
 		Weight::MAX.ref_time()
@@ -153,14 +153,14 @@ impl<Call> XcmWeightInfo<Call> for StatemineXcmWeight<Call> {
 		_reserve: &MultiLocation,
 		_xcm: &Xcm<()>,
 	) -> XCMWeight {
-		assets.weigh_multi_assets(XcmGeneric::<Runtime>::initiate_reserve_withdraw())
+		assets.weigh_multi_assets_reserve(XcmGeneric::<Runtime>::initiate_reserve_withdraw())
 	}
 	fn initiate_teleport(
 		assets: &MultiAssetFilter,
 		_dest: &MultiLocation,
 		_xcm: &Xcm<()>,
 	) -> XCMWeight {
-		assets.weigh_multi_assets_teleport(XcmFungibleWeight::<Runtime>::initiate_teleport())
+		assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::initiate_teleport())
 	}
 	fn query_holding(
 		_query_id: &u64,

--- a/parachains/runtimes/assets/statemine/src/weights/xcm/mod.rs
+++ b/parachains/runtimes/assets/statemine/src/weights/xcm/mod.rs
@@ -36,6 +36,7 @@ trait WeighMultiAssetsReserve {
 }
 
 const RESERVE_MAX_ASSETS: u32 = 100;
+/// For teleports and deposits
 const MAX_ASSETS: u32 = 1;
 
 impl WeighMultiAssets for MultiAssetFilter {

--- a/parachains/runtimes/assets/statemint/src/weights/xcm/mod.rs
+++ b/parachains/runtimes/assets/statemint/src/weights/xcm/mod.rs
@@ -135,7 +135,7 @@ impl<Call> XcmWeightInfo<Call> for StatemintXcmWeight<Call> {
 		_max_assets: &u32,
 		_dest: &MultiLocation,
 	) -> XCMWeight {
-		assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::deposit_asset())
+		assets.weigh_multi_assets_teleport(XcmFungibleWeight::<Runtime>::deposit_asset())
 	}
 	fn deposit_reserve_asset(
 		assets: &MultiAssetFilter,

--- a/parachains/runtimes/assets/statemint/src/weights/xcm/mod.rs
+++ b/parachains/runtimes/assets/statemint/src/weights/xcm/mod.rs
@@ -31,13 +31,12 @@ trait WeighMultiAssets {
 	fn weigh_multi_assets(&self, weight: Weight) -> XCMWeight;
 }
 
-const MAX_ASSETS: u32 = 100;
+const MAX_ASSETS: u32 = 1;
 
 impl WeighMultiAssets for MultiAssetFilter {
 	fn weigh_multi_assets(&self, weight: Weight) -> XCMWeight {
 		let weight = match self {
-			Self::Definite(assets) =>
-				weight.saturating_mul(assets.inner().into_iter().count() as u64),
+			Self::Definite(assets) => weight.saturating_mul(assets.len() as u64),
 			Self::Wild(_) => weight.saturating_mul(MAX_ASSETS as u64),
 		};
 		weight.ref_time()
@@ -46,7 +45,7 @@ impl WeighMultiAssets for MultiAssetFilter {
 
 impl WeighMultiAssets for MultiAssets {
 	fn weigh_multi_assets(&self, weight: Weight) -> XCMWeight {
-		weight.saturating_mul(self.inner().into_iter().count() as u64).ref_time()
+		weight.saturating_mul(self.len() as u64).ref_time()
 	}
 }
 

--- a/parachains/runtimes/assets/statemint/src/weights/xcm/mod.rs
+++ b/parachains/runtimes/assets/statemint/src/weights/xcm/mod.rs
@@ -21,22 +21,11 @@ use crate::Runtime;
 use frame_support::weights::Weight;
 use pallet_xcm_benchmarks_fungible::WeightInfo as XcmFungibleWeight;
 use pallet_xcm_benchmarks_generic::WeightInfo as XcmGeneric;
+use parachains_common::xcm_config::weigh_multi_assets_generic;
 use xcm::{
 	latest::{prelude::*, Weight as XCMWeight},
 	DoubleEncoded,
 };
-
-fn weigh_multi_assets_generic(
-	filter: &MultiAssetFilter,
-	weight: Weight,
-	max_assets: u32,
-) -> XCMWeight {
-	let weight = match filter {
-		MultiAssetFilter::Definite(assets) => weight.saturating_mul(assets.len() as u64),
-		MultiAssetFilter::Wild(_) => weight.saturating_mul(max_assets as u64),
-	};
-	weight.ref_time()
-}
 
 trait WeighMultiAssets {
 	fn weigh_multi_assets(&self, weight: Weight) -> XCMWeight;

--- a/parachains/runtimes/assets/statemint/src/weights/xcm/mod.rs
+++ b/parachains/runtimes/assets/statemint/src/weights/xcm/mod.rs
@@ -43,12 +43,12 @@ trait WeighMultiAssets {
 	fn weigh_multi_assets(&self, weight: Weight) -> XCMWeight;
 }
 
-trait WeighMultiAssetsTeleport {
-	fn weigh_multi_assets_teleport(&self, weight: Weight) -> XCMWeight;
+trait WeighMultiAssetsReserve {
+	fn weigh_multi_assets_reserve(&self, weight: Weight) -> XCMWeight;
 }
 
-const MAX_ASSETS: u32 = 100;
-const TELEPORT_MAX_ASSETS: u32 = 1;
+const RESERVE_MAX_ASSETS: u32 = 100;
+const MAX_ASSETS: u32 = 1;
 
 impl WeighMultiAssets for MultiAssetFilter {
 	fn weigh_multi_assets(&self, weight: Weight) -> XCMWeight {
@@ -56,9 +56,9 @@ impl WeighMultiAssets for MultiAssetFilter {
 	}
 }
 
-impl WeighMultiAssetsTeleport for MultiAssetFilter {
-	fn weigh_multi_assets_teleport(&self, weight: Weight) -> XCMWeight {
-		weigh_multi_assets_generic(self, weight, TELEPORT_MAX_ASSETS)
+impl WeighMultiAssetsReserve for MultiAssetFilter {
+	fn weigh_multi_assets_reserve(&self, weight: Weight) -> XCMWeight {
+		weigh_multi_assets_generic(self, weight, RESERVE_MAX_ASSETS)
 	}
 }
 
@@ -135,7 +135,7 @@ impl<Call> XcmWeightInfo<Call> for StatemintXcmWeight<Call> {
 		_max_assets: &u32,
 		_dest: &MultiLocation,
 	) -> XCMWeight {
-		assets.weigh_multi_assets_teleport(XcmFungibleWeight::<Runtime>::deposit_asset())
+		assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::deposit_asset())
 	}
 	fn deposit_reserve_asset(
 		assets: &MultiAssetFilter,
@@ -143,7 +143,7 @@ impl<Call> XcmWeightInfo<Call> for StatemintXcmWeight<Call> {
 		_dest: &MultiLocation,
 		_xcm: &Xcm<()>,
 	) -> XCMWeight {
-		assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::deposit_reserve_asset())
+		assets.weigh_multi_assets_reserve(XcmFungibleWeight::<Runtime>::deposit_reserve_asset())
 	}
 	fn exchange_asset(_give: &MultiAssetFilter, _receive: &MultiAssets) -> XCMWeight {
 		Weight::MAX.ref_time()
@@ -153,14 +153,14 @@ impl<Call> XcmWeightInfo<Call> for StatemintXcmWeight<Call> {
 		_reserve: &MultiLocation,
 		_xcm: &Xcm<()>,
 	) -> XCMWeight {
-		assets.weigh_multi_assets(XcmGeneric::<Runtime>::initiate_reserve_withdraw())
+		assets.weigh_multi_assets_reserve(XcmGeneric::<Runtime>::initiate_reserve_withdraw())
 	}
 	fn initiate_teleport(
 		assets: &MultiAssetFilter,
 		_dest: &MultiLocation,
 		_xcm: &Xcm<()>,
 	) -> XCMWeight {
-		assets.weigh_multi_assets_teleport(XcmFungibleWeight::<Runtime>::initiate_teleport())
+		assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::initiate_teleport())
 	}
 	fn query_holding(
 		_query_id: &u64,

--- a/parachains/runtimes/assets/statemint/src/weights/xcm/mod.rs
+++ b/parachains/runtimes/assets/statemint/src/weights/xcm/mod.rs
@@ -21,7 +21,6 @@ use crate::Runtime;
 use frame_support::weights::Weight;
 use pallet_xcm_benchmarks_fungible::WeightInfo as XcmFungibleWeight;
 use pallet_xcm_benchmarks_generic::WeightInfo as XcmGeneric;
-use sp_std::prelude::*;
 use xcm::{
 	latest::{prelude::*, Weight as XCMWeight},
 	DoubleEncoded,

--- a/parachains/runtimes/assets/statemint/src/weights/xcm/mod.rs
+++ b/parachains/runtimes/assets/statemint/src/weights/xcm/mod.rs
@@ -36,6 +36,7 @@ trait WeighMultiAssetsReserve {
 }
 
 const RESERVE_MAX_ASSETS: u32 = 100;
+/// For teleports and deposits
 const MAX_ASSETS: u32 = 1;
 
 impl WeighMultiAssets for MultiAssetFilter {

--- a/parachains/runtimes/assets/statemint/src/weights/xcm/mod.rs
+++ b/parachains/runtimes/assets/statemint/src/weights/xcm/mod.rs
@@ -27,19 +27,38 @@ use xcm::{
 	DoubleEncoded,
 };
 
+fn weigh_multi_assets_generic(
+	filter: &MultiAssetFilter,
+	weight: Weight,
+	max_assets: u32,
+) -> XCMWeight {
+	let weight = match filter {
+		MultiAssetFilter::Definite(assets) => weight.saturating_mul(assets.len() as u64),
+		MultiAssetFilter::Wild(_) => weight.saturating_mul(max_assets as u64),
+	};
+	weight.ref_time()
+}
+
 trait WeighMultiAssets {
 	fn weigh_multi_assets(&self, weight: Weight) -> XCMWeight;
 }
 
-const MAX_ASSETS: u32 = 1;
+trait WeighMultiAssetsTeleport {
+	fn weigh_multi_assets_teleport(&self, weight: Weight) -> XCMWeight;
+}
+
+const MAX_ASSETS: u32 = 100;
+const TELEPORT_MAX_ASSETS: u32 = 1;
 
 impl WeighMultiAssets for MultiAssetFilter {
 	fn weigh_multi_assets(&self, weight: Weight) -> XCMWeight {
-		let weight = match self {
-			Self::Definite(assets) => weight.saturating_mul(assets.len() as u64),
-			Self::Wild(_) => weight.saturating_mul(MAX_ASSETS as u64),
-		};
-		weight.ref_time()
+		weigh_multi_assets_generic(self, weight, MAX_ASSETS)
+	}
+}
+
+impl WeighMultiAssetsTeleport for MultiAssetFilter {
+	fn weigh_multi_assets_teleport(&self, weight: Weight) -> XCMWeight {
+		weigh_multi_assets_generic(self, weight, TELEPORT_MAX_ASSETS)
 	}
 }
 
@@ -141,7 +160,7 @@ impl<Call> XcmWeightInfo<Call> for StatemintXcmWeight<Call> {
 		_dest: &MultiLocation,
 		_xcm: &Xcm<()>,
 	) -> XCMWeight {
-		assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::initiate_teleport())
+		assets.weigh_multi_assets_teleport(XcmFungibleWeight::<Runtime>::initiate_teleport())
 	}
 	fn query_holding(
 		_query_id: &u64,

--- a/parachains/runtimes/assets/westmint/src/weights/xcm/mod.rs
+++ b/parachains/runtimes/assets/westmint/src/weights/xcm/mod.rs
@@ -31,13 +31,12 @@ trait WeighMultiAssets {
 	fn weigh_multi_assets(&self, weight: Weight) -> XCMWeight;
 }
 
-const MAX_ASSETS: u32 = 100;
+const MAX_ASSETS: u32 = 1;
 
 impl WeighMultiAssets for MultiAssetFilter {
 	fn weigh_multi_assets(&self, weight: Weight) -> XCMWeight {
 		let weight = match self {
-			Self::Definite(assets) =>
-				weight.saturating_mul(assets.inner().into_iter().count() as u64),
+			Self::Definite(assets) => weight.saturating_mul(assets.len() as u64),
 			Self::Wild(_) => weight.saturating_mul(MAX_ASSETS as u64),
 		};
 		weight.ref_time()
@@ -46,7 +45,7 @@ impl WeighMultiAssets for MultiAssetFilter {
 
 impl WeighMultiAssets for MultiAssets {
 	fn weigh_multi_assets(&self, weight: Weight) -> XCMWeight {
-		weight.saturating_mul(self.inner().into_iter().count() as u64).ref_time()
+		weight.saturating_mul(self.len() as u64).ref_time()
 	}
 }
 

--- a/parachains/runtimes/assets/westmint/src/weights/xcm/mod.rs
+++ b/parachains/runtimes/assets/westmint/src/weights/xcm/mod.rs
@@ -43,12 +43,12 @@ trait WeighMultiAssets {
 	fn weigh_multi_assets(&self, weight: Weight) -> XCMWeight;
 }
 
-trait WeighMultiAssetsTeleport {
-	fn weigh_multi_assets_teleport(&self, weight: Weight) -> XCMWeight;
+trait WeighMultiAssetsReserve {
+	fn weigh_multi_assets_reserve(&self, weight: Weight) -> XCMWeight;
 }
 
-const MAX_ASSETS: u32 = 100;
-const TELEPORT_MAX_ASSETS: u32 = 1;
+const RESERVE_MAX_ASSETS: u32 = 100;
+const MAX_ASSETS: u32 = 1;
 
 impl WeighMultiAssets for MultiAssetFilter {
 	fn weigh_multi_assets(&self, weight: Weight) -> XCMWeight {
@@ -56,9 +56,9 @@ impl WeighMultiAssets for MultiAssetFilter {
 	}
 }
 
-impl WeighMultiAssetsTeleport for MultiAssetFilter {
-	fn weigh_multi_assets_teleport(&self, weight: Weight) -> XCMWeight {
-		weigh_multi_assets_generic(self, weight, TELEPORT_MAX_ASSETS)
+impl WeighMultiAssetsReserve for MultiAssetFilter {
+	fn weigh_multi_assets_reserve(&self, weight: Weight) -> XCMWeight {
+		weigh_multi_assets_generic(self, weight, RESERVE_MAX_ASSETS)
 	}
 }
 
@@ -135,7 +135,7 @@ impl<Call> XcmWeightInfo<Call> for WestmintXcmWeight<Call> {
 		_max_assets: &u32,
 		_dest: &MultiLocation,
 	) -> XCMWeight {
-		assets.weigh_multi_assets_teleport(XcmFungibleWeight::<Runtime>::deposit_asset())
+		assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::deposit_asset())
 	}
 	fn deposit_reserve_asset(
 		assets: &MultiAssetFilter,
@@ -143,7 +143,7 @@ impl<Call> XcmWeightInfo<Call> for WestmintXcmWeight<Call> {
 		_dest: &MultiLocation,
 		_xcm: &Xcm<()>,
 	) -> XCMWeight {
-		assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::deposit_reserve_asset())
+		assets.weigh_multi_assets_reserve(XcmFungibleWeight::<Runtime>::deposit_reserve_asset())
 	}
 	fn exchange_asset(_give: &MultiAssetFilter, _receive: &MultiAssets) -> XCMWeight {
 		Weight::MAX.ref_time()
@@ -153,14 +153,14 @@ impl<Call> XcmWeightInfo<Call> for WestmintXcmWeight<Call> {
 		_reserve: &MultiLocation,
 		_xcm: &Xcm<()>,
 	) -> XCMWeight {
-		assets.weigh_multi_assets(XcmGeneric::<Runtime>::initiate_reserve_withdraw())
+		assets.weigh_multi_assets_reserve(XcmGeneric::<Runtime>::initiate_reserve_withdraw())
 	}
 	fn initiate_teleport(
 		assets: &MultiAssetFilter,
 		_dest: &MultiLocation,
 		_xcm: &Xcm<()>,
 	) -> XCMWeight {
-		assets.weigh_multi_assets_teleport(XcmFungibleWeight::<Runtime>::initiate_teleport())
+		assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::initiate_teleport())
 	}
 	fn query_holding(
 		_query_id: &u64,

--- a/parachains/runtimes/assets/westmint/src/weights/xcm/mod.rs
+++ b/parachains/runtimes/assets/westmint/src/weights/xcm/mod.rs
@@ -21,22 +21,11 @@ use crate::Runtime;
 use frame_support::weights::Weight;
 use pallet_xcm_benchmarks_fungible::WeightInfo as XcmFungibleWeight;
 use pallet_xcm_benchmarks_generic::WeightInfo as XcmGeneric;
+use parachains_common::xcm_config::weigh_multi_assets_generic;
 use xcm::{
 	latest::{prelude::*, Weight as XCMWeight},
 	DoubleEncoded,
 };
-
-fn weigh_multi_assets_generic(
-	filter: &MultiAssetFilter,
-	weight: Weight,
-	max_assets: u32,
-) -> XCMWeight {
-	let weight = match filter {
-		MultiAssetFilter::Definite(assets) => weight.saturating_mul(assets.len() as u64),
-		MultiAssetFilter::Wild(_) => weight.saturating_mul(max_assets as u64),
-	};
-	weight.ref_time()
-}
 
 trait WeighMultiAssets {
 	fn weigh_multi_assets(&self, weight: Weight) -> XCMWeight;

--- a/parachains/runtimes/assets/westmint/src/weights/xcm/mod.rs
+++ b/parachains/runtimes/assets/westmint/src/weights/xcm/mod.rs
@@ -21,7 +21,6 @@ use crate::Runtime;
 use frame_support::weights::Weight;
 use pallet_xcm_benchmarks_fungible::WeightInfo as XcmFungibleWeight;
 use pallet_xcm_benchmarks_generic::WeightInfo as XcmGeneric;
-use sp_std::prelude::*;
 use xcm::{
 	latest::{prelude::*, Weight as XCMWeight},
 	DoubleEncoded,

--- a/parachains/runtimes/assets/westmint/src/weights/xcm/mod.rs
+++ b/parachains/runtimes/assets/westmint/src/weights/xcm/mod.rs
@@ -27,19 +27,38 @@ use xcm::{
 	DoubleEncoded,
 };
 
+fn weigh_multi_assets_generic(
+	filter: &MultiAssetFilter,
+	weight: Weight,
+	max_assets: u32,
+) -> XCMWeight {
+	let weight = match filter {
+		MultiAssetFilter::Definite(assets) => weight.saturating_mul(assets.len() as u64),
+		MultiAssetFilter::Wild(_) => weight.saturating_mul(max_assets as u64),
+	};
+	weight.ref_time()
+}
+
 trait WeighMultiAssets {
 	fn weigh_multi_assets(&self, weight: Weight) -> XCMWeight;
 }
 
-const MAX_ASSETS: u32 = 1;
+trait WeighMultiAssetsTeleport {
+	fn weigh_multi_assets_teleport(&self, weight: Weight) -> XCMWeight;
+}
+
+const MAX_ASSETS: u32 = 100;
+const TELEPORT_MAX_ASSETS: u32 = 1;
 
 impl WeighMultiAssets for MultiAssetFilter {
 	fn weigh_multi_assets(&self, weight: Weight) -> XCMWeight {
-		let weight = match self {
-			Self::Definite(assets) => weight.saturating_mul(assets.len() as u64),
-			Self::Wild(_) => weight.saturating_mul(MAX_ASSETS as u64),
-		};
-		weight.ref_time()
+		weigh_multi_assets_generic(self, weight, MAX_ASSETS)
+	}
+}
+
+impl WeighMultiAssetsTeleport for MultiAssetFilter {
+	fn weigh_multi_assets_teleport(&self, weight: Weight) -> XCMWeight {
+		weigh_multi_assets_generic(self, weight, TELEPORT_MAX_ASSETS)
 	}
 }
 
@@ -141,7 +160,7 @@ impl<Call> XcmWeightInfo<Call> for WestmintXcmWeight<Call> {
 		_dest: &MultiLocation,
 		_xcm: &Xcm<()>,
 	) -> XCMWeight {
-		assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::initiate_teleport())
+		assets.weigh_multi_assets_teleport(XcmFungibleWeight::<Runtime>::initiate_teleport())
 	}
 	fn query_holding(
 		_query_id: &u64,

--- a/parachains/runtimes/assets/westmint/src/weights/xcm/mod.rs
+++ b/parachains/runtimes/assets/westmint/src/weights/xcm/mod.rs
@@ -135,7 +135,7 @@ impl<Call> XcmWeightInfo<Call> for WestmintXcmWeight<Call> {
 		_max_assets: &u32,
 		_dest: &MultiLocation,
 	) -> XCMWeight {
-		assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::deposit_asset())
+		assets.weigh_multi_assets_teleport(XcmFungibleWeight::<Runtime>::deposit_asset())
 	}
 	fn deposit_reserve_asset(
 		assets: &MultiAssetFilter,

--- a/parachains/runtimes/assets/westmint/src/weights/xcm/mod.rs
+++ b/parachains/runtimes/assets/westmint/src/weights/xcm/mod.rs
@@ -36,6 +36,7 @@ trait WeighMultiAssetsReserve {
 }
 
 const RESERVE_MAX_ASSETS: u32 = 100;
+/// For teleports and deposits
 const MAX_ASSETS: u32 = 1;
 
 impl WeighMultiAssets for MultiAssetFilter {


### PR DESCRIPTION
Fixes issues with high teleport costs due to high multiplier for `Wild` assets, which is always the case with teleports. 

This is blocking the current release. 