### PR TITLE
[ci] Disable auto-fmt and revert cancel-pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -112,23 +112,6 @@ variables:
   tags:
     - kubernetes-parity-build
 
-#### stage:                        .pre
-
-# checks code format and fails if formatting is required
-# the code will be formatted automatically and the pipeline will be restarted
-cargo-fmt:
-  stage:                           .pre
-  <<:                              *pr-refs
-  <<:                              *kubernetes-env
-  before_script:
-    - echo PROJECT_NAME=$CI_PROJECT_NAME > fmt.env
-    - echo PR_BRANCH_NAME=$(curl -s https://api.github.com/repos/paritytech/${CI_PROJECT_NAME}/pulls/${CI_COMMIT_REF_NAME} | jq -r ".head.ref") >> fmt.env
-  script:
-    - cargo +nightly fmt --check
-  artifacts:
-     reports:
-       dotenv: fmt.env
-
 #### stage:                        test
 
 test-linux-stable:
@@ -686,19 +669,5 @@ cancel-pipeline:
     PR_NUM:                        "${PR_NUM}"
   trigger:
     project:                       "parity/infrastructure/ci_cd/pipeline-stopper"
-    # remove branch, when pipeline-stopper for substrate and polakdot is updated to the same branch
-    branch:                        "as-improve"
 
-# this job will automatically format code and rerun pipeline if cargo-fmt job fails
-auto-fmt:
-  stage:                           .post
-  rules:
-    - if: $CI_COMMIT_REF_NAME =~ /^[0-9]+$/                         # PRs
-      when: on_failure
-  needs:
-    - job: cargo-fmt
-  variables:
-    PROJECT_NAME:                  "${CI_PROJECT_NAME}"
-    PR_BRANCH_NAME:                "${PR_BRANCH_NAME}"
-  trigger:
-    project:                       "parity/infrastructure/ci_cd/auto-fmt"
+

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -127,6 +127,7 @@ test-linux-stable:
     # but still want to have debug assertions.
     RUSTFLAGS: "-Cdebug-assertions=y -Dwarnings"
   script:
+    - exit 1
     - time cargo nextest run --all --release --locked --run-ignored all
 
 test-doc:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -127,7 +127,6 @@ test-linux-stable:
     # but still want to have debug assertions.
     RUSTFLAGS: "-Cdebug-assertions=y -Dwarnings"
   script:
-    - exit 1
     - time cargo nextest run --all --release --locked --run-ignored all
 
 test-doc:


### PR DESCRIPTION
The PR removes auto-fmt (reason: https://github.com/paritytech/ci_cd/issues/462#issuecomment-1252009270) and reverts cancel-pipeline job to an old version in order to change it (more info: https://github.com/paritytech/ci_cd/issues/548#issuecomment-1233436898)