### PR TITLE
fix a wrong path to Extrinsic Ordering ci script

### DIFF
--- a/.github/workflows/release-20_extrinsic-ordering-check-from-bin.yml
+++ b/.github/workflows/release-20_extrinsic-ordering-check-from-bin.yml
@@ -65,7 +65,7 @@ jobs:
           $CMD >> output.txt
           sed -z -i 's/\n\n/\n/g' output.txt
           cat output.txt | egrep -n -i ''
-          SUMMARY=$(./scripts/ci/extrinsic-ordering-filter.sh output.txt)
+          SUMMARY=$(./scripts/ci/github/extrinsic-ordering-filter.sh output.txt)
           echo -e $SUMMARY
           echo -e $SUMMARY >> output.txt
 


### PR DESCRIPTION
the script - https://github.com/paritytech/cumulus/blob/master/scripts/ci/github/extrinsic-ordering-filter.sh