### PR TITLE
cherrypick deposit asset xcm fix to runtime rel branch

### DIFF
--- a/parachains/runtimes/assets/statemine/src/weights/xcm/mod.rs
+++ b/parachains/runtimes/assets/statemine/src/weights/xcm/mod.rs
@@ -117,7 +117,10 @@ impl<Call> XcmWeightInfo<Call> for StatemineXcmWeight<Call> {
 		_max_assets: &u32,
 		_dest: &MultiLocation,
 	) -> XCMWeight {
-		assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::deposit_asset())
+		// Hardcoded till the XCM pallet is fixed
+		let hardcoded_weight = Weight::from_ref_time(1_000_000_000 as u64).ref_time();
+		let weight = assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::deposit_asset());
+		cmp::min(hardcoded_weight, weight)
 	}
 	fn deposit_reserve_asset(
 		assets: &MultiAssetFilter,

--- a/parachains/runtimes/assets/statemint/src/weights/xcm/mod.rs
+++ b/parachains/runtimes/assets/statemint/src/weights/xcm/mod.rs
@@ -117,7 +117,10 @@ impl<Call> XcmWeightInfo<Call> for StatemintXcmWeight<Call> {
 		_max_assets: &u32,
 		_dest: &MultiLocation,
 	) -> XCMWeight {
-		assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::deposit_asset())
+		// Hardcoded till the XCM pallet is fixed
+		let hardcoded_weight = Weight::from_ref_time(1_000_000_000 as u64).ref_time();
+		let weight = assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::deposit_asset());
+		cmp::min(hardcoded_weight, weight)
 	}
 	fn deposit_reserve_asset(
 		assets: &MultiAssetFilter,

--- a/parachains/runtimes/assets/westmint/src/weights/xcm/mod.rs
+++ b/parachains/runtimes/assets/westmint/src/weights/xcm/mod.rs
@@ -117,7 +117,10 @@ impl<Call> XcmWeightInfo<Call> for WestmintXcmWeight<Call> {
 		_max_assets: &u32,
 		_dest: &MultiLocation,
 	) -> XCMWeight {
-		assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::deposit_asset())
+		// Hardcoded till the XCM pallet is fixed
+		let hardcoded_weight = Weight::from_ref_time(1_000_000_000 as u64).ref_time();
+		let weight = assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::deposit_asset());
+		cmp::min(hardcoded_weight, weight)
 	}
 	fn deposit_reserve_asset(
 		assets: &MultiAssetFilter,


### PR DESCRIPTION
cherry-pick of https://github.com/paritytech/cumulus/pull/1651 from master to the runtime release branch.
* [Fix] Deposit weight hardcoded to pre-bench value 