### PR TITLE
Fix failing weights jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -359,7 +359,8 @@ benchmarks-assets:
     - ./scripts/benchmarks-ci.sh assets statemine ./artifacts
     - ./scripts/benchmarks-ci.sh assets statemint ./artifacts
     - ./scripts/benchmarks-ci.sh assets westmint ./artifacts
-    - export BRANCHNAME="weights-statemint-${CI_COMMIT_BRANCH}"
+    - export CURRENT_TIME=$(date '+%s')
+    - export BRANCHNAME="weights-statemint-${CI_COMMIT_BRANCH}-${CURRENT_TIME}"
     - *git-commit-push
     # create PR to release-parachains-v* branch
     - curl -u ${GITHUB_USER}:${GITHUB_TOKEN}
@@ -394,7 +395,8 @@ benchmarks-collectives:
   script:
     - ./scripts/benchmarks-ci.sh collectives collectives-polkadot ./artifacts
     - git status
-    - export BRANCHNAME="weights-collectives-${CI_COMMIT_BRANCH}"
+    - export CURRENT_TIME=$(date '+%s')
+    - export BRANCHNAME="weights-collectives-${CI_COMMIT_BRANCH}-${CURRENT_TIME}"
     - *git-commit-push
     # create PR
     - curl -u ${GITHUB_USER}:${GITHUB_TOKEN}


### PR DESCRIPTION
This small fix adds current time in millis to the name of the branch with weights to make it uniq and avoid issue when the re-ran job fails because the branch with the same name already exist