### PR TITLE
fix weights PR generation

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -411,22 +411,7 @@ benchmarks-assets:
     - *git-commit-push
     # create PR to release-parachains-v* branch
     - curl -u ${GITHUB_USER}:${GITHUB_TOKEN}
-      -d '{"title":"[benchmarks] Update weights for statemine/t","body":"This PR is generated automatically by CI.","head":"'${BRANCHNAME}'","base":"'${CI_COMMIT_BRANCH}'"}'
-      -X POST https://api.github.com/repos/paritytech/${CI_PROJECT_NAME}/pulls
-    # create PR to master
-    - curl -u ${GITHUB_USER}:${GITHUB_TOKEN}
-      -d '{"title":"[benchmarks] Update weights for statemine/t","body":"This PR is generated automatically by CI.","head":"'${BRANCHNAME}'","base":"master"}'
-      -X POST https://api.github.com/repos/paritytech/${CI_PROJECT_NAME}/pulls
-    # create PR to a branch with version number (e.g. v0.9.270) and release-v* (e.g. release-v0.9.270)
-    # transform release-parachains-v9270 to v0.9.270
-    - export BASEBRANCH=$(echo ${CI_COMMIT_BRANCH} | cut -d "-" -f 3 | sed -e "s/\(.\)\(.\)\(...\)/\10.\2.\3/")
-    # create PR to v* branch
-    - curl -u ${GITHUB_USER}:${GITHUB_TOKEN}
-      -d '{"title":"[benchmarks] Update weights for statemine/t","body":"This PR is generated automatically by CI.","head":"'${BRANCHNAME}'","base":"'${BASEBRANCH}'"}'
-      -X POST https://api.github.com/repos/paritytech/${CI_PROJECT_NAME}/pulls
-    # create PR to release-v* branch
-    - curl -u ${GITHUB_USER}:${GITHUB_TOKEN}
-      -d '{"title":"[benchmarks] Update weights for statemine/t","body":"This PR is generated automatically by CI.","head":"'${BRANCHNAME}'","base":"'release-${BASEBRANCH}'"}'
+      -d '{"title":"[benchmarks] Update weights for statemine/t","body":"This PR is generated automatically by CI. (Once merged please backport to master and node release branch.)","head":"'${BRANCHNAME}'","base":"'${CI_COMMIT_BRANCH}'"}'
       -X POST https://api.github.com/repos/paritytech/${CI_PROJECT_NAME}/pulls
   after_script:
     - rm -rf .git/config
@@ -669,5 +654,3 @@ cancel-pipeline:
     PR_NUM:                        "${PR_NUM}"
   trigger:
     project:                       "parity/infrastructure/ci_cd/pipeline-stopper"
-
-


### PR DESCRIPTION
Other generated PRs have wrong base and drag additional commits into the generated PR.

Not a good idea as it turns out.