### PR TITLE
Backport 0.9.30 bumps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7743,7 +7743,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot-parachain"
-version = "0.9.290"
+version = "0.9.300"
 dependencies = [
  "assert_cmd",
  "async-trait",

--- a/parachains/runtimes/assets/statemine/src/lib.rs
+++ b/parachains/runtimes/assets/statemine/src/lib.rs
@@ -87,7 +87,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("statemine"),
 	impl_name: create_runtime_str!("statemine"),
 	authoring_version: 1,
-	spec_version: 9290,
+	spec_version: 9300,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 8,

--- a/parachains/runtimes/assets/statemint/src/lib.rs
+++ b/parachains/runtimes/assets/statemint/src/lib.rs
@@ -117,7 +117,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("statemint"),
 	impl_name: create_runtime_str!("statemint"),
 	authoring_version: 1,
-	spec_version: 9290,
+	spec_version: 9300,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 8,

--- a/parachains/runtimes/assets/westmint/src/lib.rs
+++ b/parachains/runtimes/assets/westmint/src/lib.rs
@@ -85,7 +85,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("westmint"),
 	impl_name: create_runtime_str!("westmint"),
 	authoring_version: 1,
-	spec_version: 9290,
+	spec_version: 9300,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 8,

--- a/parachains/runtimes/collectives/collectives-polkadot/src/lib.rs
+++ b/parachains/runtimes/collectives/collectives-polkadot/src/lib.rs
@@ -102,7 +102,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("collectives"),
 	impl_name: create_runtime_str!("collectives"),
 	authoring_version: 1,
-	spec_version: 9290,
+	spec_version: 9300,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 0,

--- a/parachains/runtimes/contracts/contracts-rococo/src/lib.rs
+++ b/parachains/runtimes/contracts/contracts-rococo/src/lib.rs
@@ -116,7 +116,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("contracts-rococo"),
 	impl_name: create_runtime_str!("contracts-rococo"),
 	authoring_version: 1,
-	spec_version: 9290,
+	spec_version: 9300,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/parachains/runtimes/starters/seedling/src/lib.rs
+++ b/parachains/runtimes/starters/seedling/src/lib.rs
@@ -65,7 +65,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("seedling"),
 	impl_name: create_runtime_str!("seedling"),
 	authoring_version: 1,
-	spec_version: 9290,
+	spec_version: 9300,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/polkadot-parachain/Cargo.toml
+++ b/polkadot-parachain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polkadot-parachain"
-version = "0.9.290"
+version = "0.9.300"
 authors = ["Parity Technologies <admin@parity.io>"]
 build = "build.rs"
 edition = "2021"


### PR DESCRIPTION
This PR backports the version bump from the 0.9.30 release into master.