### PR TITLE
Minor fix of pallet-collator-selection benchmark error

### DIFF
--- a/pallets/collator-selection/src/benchmarking.rs
+++ b/pallets/collator-selection/src/benchmarking.rs
@@ -147,7 +147,7 @@ benchmarks! {
 	// worse case is when we have all the max-candidate slots filled except one, and we fill that
 	// one.
 	register_as_candidate {
-		let c in 1 .. T::MaxCandidates::get();
+		let c in 1 .. T::MaxCandidates::get() - 1;
 
 		<CandidacyBond<T>>::put(T::Currency::minimum_balance());
 		<DesiredCandidates<T>>::put(c + 1);


### PR DESCRIPTION
It's a minor PR to fix the error when benchmarking `pallet-collator-selection`, steps to reproduce:

1. clone the `cumulus` repo
2. `cargo build --features=runtime-benchmarks --release`
3. `./target/release/polkadot-parachain benchmark pallet --chain=statemine-dev --execution=wasm --db-cache=20 --pallet=pallet-collator-selection --extrinsic=* --steps=20 --repeat=50`
4. observe error from `pallet_collator_selection.register_as_candidate`: `Error: Input("TooManyCandidates")`

Problem is we try to register another candidate while having `MaxCandidates` candidates as the initial setup already. I didn't add extra comments as there's one already, but the code doesn't match.