### PR TITLE
Migrate Weights properly to v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1749,6 +1749,7 @@ dependencies = [
  "cumulus-primitives-core",
  "frame-support",
  "frame-system",
+ "log",
  "parity-scale-codec",
  "scale-info",
  "sp-core",

--- a/pallets/dmp-queue/Cargo.toml
+++ b/pallets/dmp-queue/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", features = [ "derive" ], default-features = false }
+log = { version = "0.4.17", default-features = false }
 scale-info = { version = "2.2.0", default-features = false, features = ["derive"] }
 
 # Substrate
@@ -32,6 +33,7 @@ std = [
 	"scale-info/std",
 	"frame-support/std",
 	"frame-system/std",
+	"log/std",
 	"sp-io/std",
 	"sp-runtime/std",
 	"sp-std/std",

--- a/pallets/dmp-queue/src/lib.rs
+++ b/pallets/dmp-queue/src/lib.rs
@@ -124,6 +124,10 @@ pub mod pallet {
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+		fn on_runtime_upgrade() -> Weight {
+			migration::migrate_to_latest::<T>()
+		}
+
 		fn on_idle(_now: T::BlockNumber, max_weight: Weight) -> Weight {
 			// on_idle processes additional messages with any remaining block weight.
 			Self::service_queue(max_weight)

--- a/pallets/dmp-queue/src/migration.rs
+++ b/pallets/dmp-queue/src/migration.rs
@@ -17,7 +17,11 @@
 //! A module that is responsible for migration of storage.
 
 use crate::{Config, Pallet, Store};
-use frame_support::{pallet_prelude::*, traits::StorageVersion, weights::{constants::WEIGHT_PER_MILLIS, Weight}};
+use frame_support::{
+	pallet_prelude::*,
+	traits::StorageVersion,
+	weights::{constants::WEIGHT_PER_MILLIS, Weight},
+};
 use xcm::latest::Weight as XcmWeight;
 
 /// The current storage version.
@@ -37,21 +41,19 @@ pub fn migrate_to_latest<T: Config>() -> Weight {
 }
 
 mod v0 {
-    use super::*;
-    use codec::{Decode, Encode};
+	use super::*;
+	use codec::{Decode, Encode};
 
-    #[derive(Decode, Encode, Debug)]
-    pub struct ConfigData {
-        pub max_individual: XcmWeight,
-    }
+	#[derive(Decode, Encode, Debug)]
+	pub struct ConfigData {
+		pub max_individual: XcmWeight,
+	}
 
-    impl Default for ConfigData {
-        fn default() -> Self {
-            ConfigData {
-                max_individual: 10u64 * WEIGHT_PER_MILLIS.ref_time(),
-            }
-        }
-    }
+	impl Default for ConfigData {
+		fn default() -> Self {
+			ConfigData { max_individual: 10u64 * WEIGHT_PER_MILLIS.ref_time() }
+		}
+	}
 }
 
 /// Migrates `QueueConfigData` from v1 (using only reference time weights) to v2 (with
@@ -61,9 +63,7 @@ mod v0 {
 /// `migrate_to_latest`.
 pub fn migrate_to_v1<T: Config>() -> Weight {
 	let translate = |pre: v0::ConfigData| -> super::ConfigData {
-		super::ConfigData {
-			max_individual: Weight::from_ref_time(pre.max_individual),
-		}
+		super::ConfigData { max_individual: Weight::from_ref_time(pre.max_individual) }
 	};
 
 	if let Err(_) = <Pallet<T> as Store>::Configuration::translate(|pre| pre.map(translate)) {
@@ -83,9 +83,7 @@ mod tests {
 
 	#[test]
 	fn test_migration_to_v1() {
-		let v0 = v0::ConfigData {
-			max_individual: 30_000_000_000,
-		};
+		let v0 = v0::ConfigData { max_individual: 30_000_000_000 };
 
 		new_test_ext().execute_with(|| {
 			frame_support::storage::unhashed::put_raw(

--- a/pallets/dmp-queue/src/migration.rs
+++ b/pallets/dmp-queue/src/migration.rs
@@ -26,7 +26,7 @@ pub const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
 /// Migrates the pallet storage to the most recent version, checking and setting the
 /// `StorageVersion`.
 pub fn migrate_to_latest<T: Config>() -> Weight {
-	let mut weight = Weight::zero();
+	let mut weight = T::DbWeight::get().reads(1);
 
 	if StorageVersion::get::<Pallet<T>>() == 0 {
 		weight += migrate_to_v1::<T>();

--- a/pallets/dmp-queue/src/migration.rs
+++ b/pallets/dmp-queue/src/migration.rs
@@ -1,0 +1,103 @@
+// Copyright 2022 Parity Technologies (UK) Ltd.
+// This file is part of Polkadot.
+
+// Polkadot is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Polkadot is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Polkadot.  If not, see <http://www.gnu.org/licenses/>.
+
+//! A module that is responsible for migration of storage.
+
+use crate::{Config, Pallet, Store};
+use frame_support::{pallet_prelude::*, traits::StorageVersion, weights::{constants::WEIGHT_PER_MILLIS, Weight}};
+use xcm::latest::Weight as XcmWeight;
+
+/// The current storage version.
+pub const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
+
+/// Migrates the pallet storage to the most recent version, checking and setting the
+/// `StorageVersion`.
+pub fn migrate_to_latest<T: Config>() -> Weight {
+	let mut weight = Weight::zero();
+
+	if StorageVersion::get::<Pallet<T>>() == 0 {
+		weight += migrate_to_v1::<T>();
+		StorageVersion::new(1).put::<Pallet<T>>();
+	}
+
+	weight
+}
+
+mod v0 {
+    use super::*;
+    use codec::{Decode, Encode};
+
+    #[derive(Decode, Encode, Debug)]
+    pub struct ConfigData {
+        pub max_individual: XcmWeight,
+    }
+
+    impl Default for ConfigData {
+        fn default() -> Self {
+            ConfigData {
+                max_individual: 10u64 * WEIGHT_PER_MILLIS.ref_time(),
+            }
+        }
+    }
+}
+
+/// Migrates `QueueConfigData` from v1 (using only reference time weights) to v2 (with
+/// 2D weights).
+///
+/// NOTE: Only use this function if you know what you're doing. Default to using
+/// `migrate_to_latest`.
+pub fn migrate_to_v1<T: Config>() -> Weight {
+	let translate = |pre: v0::ConfigData| -> super::ConfigData {
+		super::ConfigData {
+			max_individual: Weight::from_ref_time(pre.max_individual),
+		}
+	};
+
+	if let Err(_) = <Pallet<T> as Store>::Configuration::translate(|pre| pre.map(translate)) {
+		log::error!(
+			target: "dmp_queue",
+			"unexpected error when performing translation of the QueueConfig type during storage upgrade to v2"
+		);
+	}
+
+	T::DbWeight::get().reads_writes(1, 1)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::tests::{new_test_ext, Test};
+
+	#[test]
+	fn test_migration_to_v1() {
+		let v0 = v0::ConfigData {
+			max_individual: 30_000_000_000,
+		};
+
+		new_test_ext().execute_with(|| {
+			frame_support::storage::unhashed::put_raw(
+				&crate::Configuration::<Test>::hashed_key(),
+				&v0.encode(),
+			);
+
+			migrate_to_v1::<Test>();
+
+			let v1 = crate::Configuration::<Test>::get();
+
+			assert_eq!(v0.max_individual, v1.max_individual.ref_time());
+		});
+	}
+}

--- a/pallets/xcmp-queue/src/benchmarking.rs
+++ b/pallets/xcmp-queue/src/benchmarking.rs
@@ -22,7 +22,7 @@ use frame_system::RawOrigin;
 
 benchmarks! {
 	set_config_with_u32 {}: update_resume_threshold(RawOrigin::Root, 100)
-	set_config_with_weight {}: update_weight_restrict_decay(RawOrigin::Root, Weight::from_ref_time(3_000_000))
+	set_config_with_weight {}: update_weight_restrict_decay(RawOrigin::Root, 3_000_000)
 }
 
 impl_benchmark_test_suite!(Pallet, crate::mock::new_test_ext(), crate::mock::Test);

--- a/pallets/xcmp-queue/src/lib.rs
+++ b/pallets/xcmp-queue/src/lib.rs
@@ -54,7 +54,7 @@ use rand_chacha::{
 use scale_info::TypeInfo;
 use sp_runtime::{traits::Hash, RuntimeDebug};
 use sp_std::{convert::TryFrom, prelude::*};
-use xcm::{latest::prelude::*, VersionedXcm, WrapVersion, MAX_XCM_DECODE_DEPTH};
+use xcm::{latest::{prelude::*, Weight as XcmWeight}, VersionedXcm, WrapVersion, MAX_XCM_DECODE_DEPTH};
 use xcm_executor::traits::ConvertOrigin;
 
 pub use pallet::*;
@@ -130,11 +130,11 @@ pub mod pallet {
 		///
 		/// Events:
 		/// - `OverweightServiced`: On success.
-		#[pallet::weight((weight_limit.saturating_add(Weight::from_ref_time(1_000_000)), DispatchClass::Operational,))]
+		#[pallet::weight((Weight::from_ref_time(weight_limit.saturating_add(1_000_000)), DispatchClass::Operational,))]
 		pub fn service_overweight(
 			origin: OriginFor<T>,
 			index: OverweightIndex,
-			weight_limit: Weight,
+			weight_limit: XcmWeight,
 		) -> DispatchResultWithPostInfo {
 			T::ExecuteOverweightOrigin::ensure_origin(origin)?;
 
@@ -145,7 +145,7 @@ pub mod pallet {
 				&mut data.as_slice(),
 			)
 			.map_err(|_| Error::<T>::BadXcm)?;
-			let used = Self::handle_xcm_message(sender, sent_at, xcm, weight_limit)
+			let used = Self::handle_xcm_message(sender, sent_at, xcm, Weight::from_ref_time(weight_limit))
 				.map_err(|_| Error::<T>::WeightOverLimit)?;
 			Overweight::<T>::remove(index);
 			Self::deposit_event(Event::OverweightServiced { index, used });
@@ -222,9 +222,9 @@ pub mod pallet {
 		/// - `origin`: Must pass `Root`.
 		/// - `new`: Desired value for `QueueConfigData.threshold_weight`
 		#[pallet::weight((T::WeightInfo::set_config_with_weight(), DispatchClass::Operational,))]
-		pub fn update_threshold_weight(origin: OriginFor<T>, new: Weight) -> DispatchResult {
+		pub fn update_threshold_weight(origin: OriginFor<T>, new: XcmWeight) -> DispatchResult {
 			ensure_root(origin)?;
-			QueueConfig::<T>::mutate(|data| data.threshold_weight = new);
+			QueueConfig::<T>::mutate(|data| data.threshold_weight = Weight::from_ref_time(new));
 
 			Ok(())
 		}
@@ -235,9 +235,9 @@ pub mod pallet {
 		/// - `origin`: Must pass `Root`.
 		/// - `new`: Desired value for `QueueConfigData.weight_restrict_decay`.
 		#[pallet::weight((T::WeightInfo::set_config_with_weight(), DispatchClass::Operational,))]
-		pub fn update_weight_restrict_decay(origin: OriginFor<T>, new: Weight) -> DispatchResult {
+		pub fn update_weight_restrict_decay(origin: OriginFor<T>, new: XcmWeight) -> DispatchResult {
 			ensure_root(origin)?;
-			QueueConfig::<T>::mutate(|data| data.weight_restrict_decay = new);
+			QueueConfig::<T>::mutate(|data| data.weight_restrict_decay = Weight::from_ref_time(new));
 
 			Ok(())
 		}
@@ -250,10 +250,10 @@ pub mod pallet {
 		#[pallet::weight((T::WeightInfo::set_config_with_weight(), DispatchClass::Operational,))]
 		pub fn update_xcmp_max_individual_weight(
 			origin: OriginFor<T>,
-			new: Weight,
+			new: XcmWeight,
 		) -> DispatchResult {
 			ensure_root(origin)?;
-			QueueConfig::<T>::mutate(|data| data.xcmp_max_individual_weight = new);
+			QueueConfig::<T>::mutate(|data| data.xcmp_max_individual_weight = Weight::from_ref_time(new));
 
 			Ok(())
 		}

--- a/pallets/xcmp-queue/src/lib.rs
+++ b/pallets/xcmp-queue/src/lib.rs
@@ -54,7 +54,10 @@ use rand_chacha::{
 use scale_info::TypeInfo;
 use sp_runtime::{traits::Hash, RuntimeDebug};
 use sp_std::{convert::TryFrom, prelude::*};
-use xcm::{latest::{prelude::*, Weight as XcmWeight}, VersionedXcm, WrapVersion, MAX_XCM_DECODE_DEPTH};
+use xcm::{
+	latest::{prelude::*, Weight as XcmWeight},
+	VersionedXcm, WrapVersion, MAX_XCM_DECODE_DEPTH,
+};
 use xcm_executor::traits::ConvertOrigin;
 
 pub use pallet::*;
@@ -145,8 +148,9 @@ pub mod pallet {
 				&mut data.as_slice(),
 			)
 			.map_err(|_| Error::<T>::BadXcm)?;
-			let used = Self::handle_xcm_message(sender, sent_at, xcm, Weight::from_ref_time(weight_limit))
-				.map_err(|_| Error::<T>::WeightOverLimit)?;
+			let used =
+				Self::handle_xcm_message(sender, sent_at, xcm, Weight::from_ref_time(weight_limit))
+					.map_err(|_| Error::<T>::WeightOverLimit)?;
 			Overweight::<T>::remove(index);
 			Self::deposit_event(Event::OverweightServiced { index, used });
 			Ok(Some(used.saturating_add(Weight::from_ref_time(1_000_000))).into())
@@ -235,9 +239,14 @@ pub mod pallet {
 		/// - `origin`: Must pass `Root`.
 		/// - `new`: Desired value for `QueueConfigData.weight_restrict_decay`.
 		#[pallet::weight((T::WeightInfo::set_config_with_weight(), DispatchClass::Operational,))]
-		pub fn update_weight_restrict_decay(origin: OriginFor<T>, new: XcmWeight) -> DispatchResult {
+		pub fn update_weight_restrict_decay(
+			origin: OriginFor<T>,
+			new: XcmWeight,
+		) -> DispatchResult {
 			ensure_root(origin)?;
-			QueueConfig::<T>::mutate(|data| data.weight_restrict_decay = Weight::from_ref_time(new));
+			QueueConfig::<T>::mutate(|data| {
+				data.weight_restrict_decay = Weight::from_ref_time(new)
+			});
 
 			Ok(())
 		}
@@ -253,7 +262,9 @@ pub mod pallet {
 			new: XcmWeight,
 		) -> DispatchResult {
 			ensure_root(origin)?;
-			QueueConfig::<T>::mutate(|data| data.xcmp_max_individual_weight = Weight::from_ref_time(new));
+			QueueConfig::<T>::mutate(|data| {
+				data.xcmp_max_individual_weight = Weight::from_ref_time(new)
+			});
 
 			Ok(())
 		}

--- a/pallets/xcmp-queue/src/migration.rs
+++ b/pallets/xcmp-queue/src/migration.rs
@@ -17,7 +17,11 @@
 //! A module that is responsible for migration of storage.
 
 use crate::{Config, Pallet, Store};
-use frame_support::{pallet_prelude::*, traits::StorageVersion, weights::{constants::WEIGHT_PER_MILLIS, Weight}};
+use frame_support::{
+	pallet_prelude::*,
+	traits::StorageVersion,
+	weights::{constants::WEIGHT_PER_MILLIS, Weight},
+};
 use xcm::latest::Weight as XcmWeight;
 
 /// The current storage version.

--- a/pallets/xcmp-queue/src/migration.rs
+++ b/pallets/xcmp-queue/src/migration.rs
@@ -26,7 +26,7 @@ pub const STORAGE_VERSION: StorageVersion = StorageVersion::new(2);
 /// Migrates the pallet storage to the most recent version, checking and setting the
 /// `StorageVersion`.
 pub fn migrate_to_latest<T: Config>() -> Weight {
-	let mut weight = Weight::zero();
+	let mut weight = T::DbWeight::get().reads(1);
 
 	if StorageVersion::get::<Pallet<T>>() == 1 {
 		weight += migrate_to_v2::<T>();

--- a/pallets/xcmp-queue/src/migration.rs
+++ b/pallets/xcmp-queue/src/migration.rs
@@ -17,25 +17,26 @@
 //! A module that is responsible for migration of storage.
 
 use crate::{Config, Pallet, Store};
-use frame_support::{pallet_prelude::*, traits::StorageVersion, weights::Weight};
+use frame_support::{pallet_prelude::*, traits::StorageVersion, weights::{constants::WEIGHT_PER_MILLIS, Weight}};
+use xcm::latest::Weight as XcmWeight;
 
 /// The current storage version.
-pub const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
+pub const STORAGE_VERSION: StorageVersion = StorageVersion::new(2);
 
 /// Migrates the pallet storage to the most recent version, checking and setting the
 /// `StorageVersion`.
 pub fn migrate_to_latest<T: Config>() -> Weight {
 	let mut weight = Weight::zero();
 
-	if StorageVersion::get::<Pallet<T>>() == 0 {
-		weight += migrate_to_v1::<T>();
-		StorageVersion::new(1).put::<Pallet<T>>();
+	if StorageVersion::get::<Pallet<T>>() == 1 {
+		weight += migrate_to_v2::<T>();
+		StorageVersion::new(2).put::<Pallet<T>>();
 	}
 
 	weight
 }
 
-mod v0 {
+mod v1 {
 	use super::*;
 	use codec::{Decode, Encode};
 
@@ -44,8 +45,9 @@ mod v0 {
 		pub suspend_threshold: u32,
 		pub drop_threshold: u32,
 		pub resume_threshold: u32,
-		pub threshold_weight: Weight,
-		pub weight_restrict_decay: Weight,
+		pub threshold_weight: XcmWeight,
+		pub weight_restrict_decay: XcmWeight,
+		pub xcmp_max_individual_weight: XcmWeight,
 	}
 
 	impl Default for QueueConfigData {
@@ -54,37 +56,35 @@ mod v0 {
 				suspend_threshold: 2,
 				drop_threshold: 5,
 				resume_threshold: 1,
-				threshold_weight: Weight::from_ref_time(100_000),
-				weight_restrict_decay: Weight::from_ref_time(2),
+				threshold_weight: 100_000,
+				weight_restrict_decay: 2,
+				xcmp_max_individual_weight: 20u64 * WEIGHT_PER_MILLIS.ref_time(),
 			}
 		}
 	}
 }
 
-/// Migrates `QueueConfigData` from v0 (without the `xcmp_max_individual_weight` field) to v1 (with
-/// max individual weight).
-/// Uses the `Default` implementation of `QueueConfigData` to choose a value for
-/// `xcmp_max_individual_weight`.
+/// Migrates `QueueConfigData` from v1 (using only reference time weights) to v2 (with
+/// 2D weights).
 ///
 /// NOTE: Only use this function if you know what you're doing. Default to using
 /// `migrate_to_latest`.
-pub fn migrate_to_v1<T: Config>() -> Weight {
-	let translate = |pre: v0::QueueConfigData| -> super::QueueConfigData {
+pub fn migrate_to_v2<T: Config>() -> Weight {
+	let translate = |pre: v1::QueueConfigData| -> super::QueueConfigData {
 		super::QueueConfigData {
 			suspend_threshold: pre.suspend_threshold,
 			drop_threshold: pre.drop_threshold,
 			resume_threshold: pre.resume_threshold,
-			threshold_weight: pre.threshold_weight,
-			weight_restrict_decay: pre.weight_restrict_decay,
-			xcmp_max_individual_weight: super::QueueConfigData::default()
-				.xcmp_max_individual_weight,
+			threshold_weight: Weight::from_ref_time(pre.threshold_weight),
+			weight_restrict_decay: Weight::from_ref_time(pre.weight_restrict_decay),
+			xcmp_max_individual_weight: Weight::from_ref_time(pre.xcmp_max_individual_weight),
 		}
 	};
 
 	if let Err(_) = <Pallet<T> as Store>::QueueConfig::translate(|pre| pre.map(translate)) {
 		log::error!(
 			target: super::LOG_TARGET,
-			"unexpected error when performing translation of the QueueConfig type during storage upgrade to v1"
+			"unexpected error when performing translation of the QueueConfig type during storage upgrade to v2"
 		);
 	}
 
@@ -97,32 +97,32 @@ mod tests {
 	use crate::mock::{new_test_ext, Test};
 
 	#[test]
-	fn test_migration_to_v1() {
-		let v0 = v0::QueueConfigData {
+	fn test_migration_to_v2() {
+		let v1 = v1::QueueConfigData {
 			suspend_threshold: 5,
 			drop_threshold: 12,
 			resume_threshold: 3,
-			threshold_weight: Weight::from_ref_time(333_333),
-			weight_restrict_decay: Weight::from_ref_time(1),
+			threshold_weight: 333_333,
+			weight_restrict_decay: 1,
+			xcmp_max_individual_weight: 10_000_000_000,
 		};
 
 		new_test_ext().execute_with(|| {
-			// Put the v0 version in the state
 			frame_support::storage::unhashed::put_raw(
 				&crate::QueueConfig::<Test>::hashed_key(),
-				&v0.encode(),
+				&v1.encode(),
 			);
 
-			migrate_to_v1::<Test>();
+			migrate_to_v2::<Test>();
 
-			let v1 = crate::QueueConfig::<Test>::get();
+			let v2 = crate::QueueConfig::<Test>::get();
 
-			assert_eq!(v0.suspend_threshold, v1.suspend_threshold);
-			assert_eq!(v0.drop_threshold, v1.drop_threshold);
-			assert_eq!(v0.resume_threshold, v1.resume_threshold);
-			assert_eq!(v0.threshold_weight, v1.threshold_weight);
-			assert_eq!(v0.weight_restrict_decay, v1.weight_restrict_decay);
-			assert_eq!(v1.xcmp_max_individual_weight, Weight::from_ref_time(20_000_000_000));
+			assert_eq!(v1.suspend_threshold, v2.suspend_threshold);
+			assert_eq!(v1.drop_threshold, v2.drop_threshold);
+			assert_eq!(v1.resume_threshold, v2.resume_threshold);
+			assert_eq!(v1.threshold_weight, v2.threshold_weight.ref_time());
+			assert_eq!(v1.weight_restrict_decay, v2.weight_restrict_decay.ref_time());
+			assert_eq!(v1.xcmp_max_individual_weight, v2.xcmp_max_individual_weight.ref_time());
 		});
 	}
 }

--- a/pallets/xcmp-queue/src/tests.rs
+++ b/pallets/xcmp-queue/src/tests.rs
@@ -187,15 +187,9 @@ fn update_threshold_weight_works() {
 	new_test_ext().execute_with(|| {
 		let data: QueueConfigData = <QueueConfig<Test>>::get();
 		assert_eq!(data.threshold_weight, Weight::from_ref_time(100_000));
-		assert_ok!(XcmpQueue::update_threshold_weight(
-			RuntimeOrigin::root(),
-			10_000
-		));
+		assert_ok!(XcmpQueue::update_threshold_weight(RuntimeOrigin::root(), 10_000));
 		assert_noop!(
-			XcmpQueue::update_threshold_weight(
-				RuntimeOrigin::signed(5),
-				10_000_000
-			),
+			XcmpQueue::update_threshold_weight(RuntimeOrigin::signed(5), 10_000_000),
 			BadOrigin
 		);
 		let data: QueueConfigData = <QueueConfig<Test>>::get();

--- a/pallets/xcmp-queue/src/tests.rs
+++ b/pallets/xcmp-queue/src/tests.rs
@@ -96,7 +96,7 @@ fn handle_invalid_data() {
 fn service_overweight_unknown() {
 	new_test_ext().execute_with(|| {
 		assert_noop!(
-			XcmpQueue::service_overweight(RuntimeOrigin::root(), 0, Weight::from_ref_time(1000)),
+			XcmpQueue::service_overweight(RuntimeOrigin::root(), 0, 1000),
 			Error::<Test>::BadOverweightIndex,
 		);
 	});
@@ -109,7 +109,7 @@ fn service_overweight_bad_xcm_format() {
 		Overweight::<Test>::insert(0, (ParaId::from(1000), 0, bad_xcm));
 
 		assert_noop!(
-			XcmpQueue::service_overweight(RuntimeOrigin::root(), 0, Weight::from_ref_time(1000)),
+			XcmpQueue::service_overweight(RuntimeOrigin::root(), 0, 1000),
 			Error::<Test>::BadXcm
 		);
 	});
@@ -189,12 +189,12 @@ fn update_threshold_weight_works() {
 		assert_eq!(data.threshold_weight, Weight::from_ref_time(100_000));
 		assert_ok!(XcmpQueue::update_threshold_weight(
 			RuntimeOrigin::root(),
-			Weight::from_ref_time(10_000)
+			10_000
 		));
 		assert_noop!(
 			XcmpQueue::update_threshold_weight(
 				RuntimeOrigin::signed(5),
-				Weight::from_ref_time(10_000_000)
+				10_000_000
 			),
 			BadOrigin
 		);
@@ -209,15 +209,9 @@ fn update_weight_restrict_decay_works() {
 	new_test_ext().execute_with(|| {
 		let data: QueueConfigData = <QueueConfig<Test>>::get();
 		assert_eq!(data.weight_restrict_decay, Weight::from_ref_time(2));
-		assert_ok!(XcmpQueue::update_weight_restrict_decay(
-			RuntimeOrigin::root(),
-			Weight::from_ref_time(5)
-		));
+		assert_ok!(XcmpQueue::update_weight_restrict_decay(RuntimeOrigin::root(), 5));
 		assert_noop!(
-			XcmpQueue::update_weight_restrict_decay(
-				RuntimeOrigin::signed(6),
-				Weight::from_ref_time(4)
-			),
+			XcmpQueue::update_weight_restrict_decay(RuntimeOrigin::signed(6), 4),
 			BadOrigin
 		);
 		let data: QueueConfigData = <QueueConfig<Test>>::get();
@@ -233,12 +227,12 @@ fn update_xcmp_max_individual_weight() {
 		assert_eq!(data.xcmp_max_individual_weight, 20u64 * WEIGHT_PER_MILLIS);
 		assert_ok!(XcmpQueue::update_xcmp_max_individual_weight(
 			RuntimeOrigin::root(),
-			30u64 * WEIGHT_PER_MILLIS
+			30u64 * WEIGHT_PER_MILLIS.ref_time()
 		));
 		assert_noop!(
 			XcmpQueue::update_xcmp_max_individual_weight(
 				RuntimeOrigin::signed(3),
-				10u64 * WEIGHT_PER_MILLIS
+				10u64 * WEIGHT_PER_MILLIS.ref_time()
 			),
 			BadOrigin
 		);

--- a/parachain-template/runtime/src/lib.rs
+++ b/parachain-template/runtime/src/lib.rs
@@ -217,7 +217,8 @@ const AVERAGE_ON_INITIALIZE_RATIO: Perbill = Perbill::from_percent(5);
 const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
 
 /// We allow for 0.5 of a second of compute with a 12 second average block time.
-const MAXIMUM_BLOCK_WEIGHT: Weight = WEIGHT_PER_SECOND.saturating_div(2)
+const MAXIMUM_BLOCK_WEIGHT: Weight = WEIGHT_PER_SECOND
+	.saturating_div(2)
 	.set_proof_size(cumulus_primitives_core::relay_chain::v2::MAX_POV_SIZE as u64);
 
 /// The version information used to identify this runtime when compiled natively.

--- a/parachains/common/src/lib.rs
+++ b/parachains/common/src/lib.rs
@@ -92,7 +92,8 @@ mod constants {
 	pub const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
 
 	/// We allow for 0.5 seconds of compute with a 6 second average block time.
-	pub const MAXIMUM_BLOCK_WEIGHT: Weight = WEIGHT_PER_SECOND.saturating_div(2)
+	pub const MAXIMUM_BLOCK_WEIGHT: Weight = WEIGHT_PER_SECOND
+		.saturating_div(2)
 		.set_proof_size(polkadot_primitives::v2::MAX_POV_SIZE as u64);
 }
 

--- a/parachains/runtimes/starters/seedling/src/lib.rs
+++ b/parachains/runtimes/starters/seedling/src/lib.rs
@@ -85,7 +85,8 @@ const AVERAGE_ON_INITIALIZE_RATIO: Perbill = Perbill::from_percent(10);
 /// by  Operational  extrinsics.
 const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
 /// We allow for .5 seconds of compute with a 12 second average block time.
-const MAXIMUM_BLOCK_WEIGHT: Weight = WEIGHT_PER_SECOND.saturating_div(2)
+const MAXIMUM_BLOCK_WEIGHT: Weight = WEIGHT_PER_SECOND
+	.saturating_div(2)
 	.set_proof_size(cumulus_primitives_core::relay_chain::v2::MAX_POV_SIZE as u64);
 
 parameter_types! {

--- a/parachains/runtimes/starters/shell/src/lib.rs
+++ b/parachains/runtimes/starters/shell/src/lib.rs
@@ -92,7 +92,8 @@ const AVERAGE_ON_INITIALIZE_RATIO: Perbill = Perbill::from_percent(10);
 /// by  Operational  extrinsics.
 const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
 /// We allow for .5 seconds of compute with a 12 second average block time.
-const MAXIMUM_BLOCK_WEIGHT: Weight = WEIGHT_PER_SECOND.saturating_div(2)
+const MAXIMUM_BLOCK_WEIGHT: Weight = WEIGHT_PER_SECOND
+	.saturating_div(2)
 	.set_proof_size(cumulus_primitives_core::relay_chain::v2::MAX_POV_SIZE as u64);
 
 parameter_types! {

--- a/parachains/runtimes/testing/penpal/src/lib.rs
+++ b/parachains/runtimes/testing/penpal/src/lib.rs
@@ -230,7 +230,8 @@ const AVERAGE_ON_INITIALIZE_RATIO: Perbill = Perbill::from_percent(5);
 const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
 
 /// We allow for 0.5 of a second of compute with a 12 second average block time.
-const MAXIMUM_BLOCK_WEIGHT: Weight = WEIGHT_PER_SECOND.saturating_div(2)
+const MAXIMUM_BLOCK_WEIGHT: Weight = WEIGHT_PER_SECOND
+	.saturating_div(2)
 	.set_proof_size(cumulus_primitives_core::relay_chain::v2::MAX_POV_SIZE as u64);
 
 /// The version information used to identify this runtime when compiled natively.

--- a/parachains/runtimes/testing/rococo-parachain/src/lib.rs
+++ b/parachains/runtimes/testing/rococo-parachain/src/lib.rs
@@ -134,7 +134,8 @@ const AVERAGE_ON_INITIALIZE_RATIO: Perbill = Perbill::from_percent(10);
 /// by  Operational  extrinsics.
 const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
 /// We allow for .5 seconds of compute with a 12 second average block time.
-const MAXIMUM_BLOCK_WEIGHT: Weight = WEIGHT_PER_SECOND.saturating_div(2)
+const MAXIMUM_BLOCK_WEIGHT: Weight = WEIGHT_PER_SECOND
+	.saturating_div(2)
 	.set_proof_size(cumulus_primitives_core::relay_chain::v2::MAX_POV_SIZE as u64);
 
 parameter_types! {

--- a/test/runtime/src/lib.rs
+++ b/test/runtime/src/lib.rs
@@ -140,7 +140,8 @@ const AVERAGE_ON_INITIALIZE_RATIO: Perbill = Perbill::from_percent(10);
 /// by  Operational  extrinsics.
 const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
 /// We allow for .5 seconds of compute with a 12 second average block time.
-const MAXIMUM_BLOCK_WEIGHT: Weight = WEIGHT_PER_SECOND.saturating_div(2)
+const MAXIMUM_BLOCK_WEIGHT: Weight = WEIGHT_PER_SECOND
+	.saturating_div(2)
 	.set_proof_size(cumulus_primitives_core::relay_chain::v2::MAX_POV_SIZE as u64);
 
 parameter_types! {


### PR DESCRIPTION
Since migration to weights v2, we need to ensure that any pallets that store `Weight` structs or contain an extrinsic with a `Weight` parameter to migrate properly.