### PR TITLE
[ci] Improve pipeline-cancel job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -640,7 +640,7 @@ zombienet-0005-migrate_solo_to_para:
 # This job cancels the whole pipeline if any of provided jobs fail.
 # In a DAG, every jobs chain is executed independently of others. The `fail_fast` principle suggests
 # to fail the pipeline as soon as possible to shorten the feedback loop.
-.cancel-pipeline:
+cancel-pipeline:
   stage:                           .post
   needs:
     - job:                         test-linux-stable
@@ -656,3 +656,5 @@ zombienet-0005-migrate_solo_to_para:
     PR_NUM:                        "${PR_NUM}"
   trigger:
     project:                       "parity/infrastructure/ci_cd/pipeline-stopper"
+    # remove branch, when pipeline-stopper for substrate and polakdot is updated to the same branch
+    branch:                        "as-improve"


### PR DESCRIPTION
PR improves `cancel-pipeline` job. Now the job will post a info message only once (it'll remove the previous ones)


cc https://github.com/paritytech/ci_cd/issues/548