### PR TITLE
Fix target of some Matrix notifications

### DIFF
--- a/.github/workflows/release-10_rc-automation.yml
+++ b/.github/workflows/release-10_rc-automation.yml
@@ -9,6 +9,12 @@ on:
 jobs:
   tag_rc:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        channel:
+          - name: 'Cumulus Release Coordination'
+            room: '!ZrLPsivsytpkdJfVaa:matrix.parity.io'
+            pre-releases: true
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -67,11 +73,11 @@ jobs:
           assignees: release-engineering
           filename: .github/ISSUE_TEMPLATE/release-runtime.md
 
-      - name: Send Matrix message
+      - name: Matrix notification to ${{ matrix.channel.name }}
         uses: s3krit/matrix-message-action@70ad3fb812ee0e45ff8999d6af11cafad11a6ecf # v0.0.3
         if: steps.create-issue-checklist-client.outputs.url != '' && steps.create-issue-checklist-runtime.outputs.url != ''
         with:
-          room_id: ${{ secrets.INTERNAL_CUMULUS_MATRIX_ROOM_ID }}
+          room_id: ${{ matrix.channel.room }}
           access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
           server: "matrix.parity.io"
           message: |

--- a/.github/workflows/release-30_create-draft.yml
+++ b/.github/workflows/release-30_create-draft.yml
@@ -271,11 +271,17 @@ jobs:
     if: ${{ github.event.inputs.notification == 'true' }}
     runs-on: ubuntu-latest
     needs: publish-draft-release
+    strategy:
+      matrix:
+        channel:
+          - name: 'Cumulus Release Coordination'
+            room: '!ZrLPsivsytpkdJfVaa:matrix.parity.io'
+            pre-releases: true
     steps:
-      - name: Internal polkadot channel
-        uses: s3krit/matrix-message-action@v0.0.3
+      - name: Matrix notification to ${{ matrix.channel.name }}
+        uses: s3krit/matrix-message-action@70ad3fb812ee0e45ff8999d6af11cafad11a6ecf # v0.0.3
         with:
-          room_id: ${{ secrets.INTERNAL_CUMULUS_MATRIX_ROOM_ID }}
+          room_id: ${{ matrix.channel.room }}
           access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
           message: |
             **New draft for ${{ github.repository }}**: ${{ github.event.inputs.ref2 }}<br/>

--- a/.github/workflows/release-99_bot-announce.yml
+++ b/.github/workflows/release-99_bot-announce.yml
@@ -18,8 +18,8 @@ jobs:
             pre-release: true
 
     steps:
-      - name: send message
-        uses: s3krit/matrix-message-action@v0.0.3
+      - name: Matrix notification to ${{ matrix.channel.name }}
+        uses: s3krit/matrix-message-action@70ad3fb812ee0e45ff8999d6af11cafad11a6ecf # v0.0.3
         with:
           room_id: ${{ matrix.channel.room }}
           access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}


### PR DESCRIPTION
This PR swaps the usage of secrets (which are no secrets) by workflow matrices so we can also notifity several rooms.