### PR TITLE
Dependency not needed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1961,12 +1961,10 @@ dependencies = [
  "cumulus-relay-chain-interface",
  "futures",
  "futures-timer",
- "polkadot-cli",
  "polkadot-client",
  "polkadot-primitives",
  "polkadot-service",
  "polkadot-test-client",
- "sc-cli",
  "sc-client-api",
  "sc-sysinfo",
  "sc-telemetry",
@@ -1977,6 +1975,7 @@ dependencies = [
  "sp-keyring",
  "sp-runtime",
  "sp-state-machine",
+ "substrate-build-script-utils",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1975,7 +1975,6 @@ dependencies = [
  "sp-keyring",
  "sp-runtime",
  "sp-state-machine",
- "substrate-build-script-utils",
 ]
 
 [[package]]

--- a/client/relay-chain-inprocess-interface/Cargo.toml
+++ b/client/relay-chain-inprocess-interface/Cargo.toml
@@ -36,6 +36,3 @@ sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "master
 # Polkadot
 polkadot-primitives = { git = "https://github.com/paritytech/polkadot", branch = "master" }
 polkadot-test-client = { git = "https://github.com/paritytech/polkadot", branch = "master" }
-
-[build-dependencies]
-substrate-build-script-utils = { git = "https://github.com/paritytech/substrate", branch = "master" }

--- a/client/relay-chain-inprocess-interface/Cargo.toml
+++ b/client/relay-chain-inprocess-interface/Cargo.toml
@@ -10,7 +10,6 @@ futures = "0.3.24"
 futures-timer = "3.0.2"
 
 # Substrate
-sc-cli = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sc-telemetry = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sc-tracing = { git = "https://github.com/paritytech/substrate", branch = "master" }
@@ -22,7 +21,6 @@ sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master
 sp-state-machine = { git = "https://github.com/paritytech/substrate", branch = "master" }
 
 # Polkadot
-polkadot-cli = { git = "https://github.com/paritytech/polkadot", branch = "master", default-features = false, features = ["cli"] }
 polkadot-client = { git = "https://github.com/paritytech/polkadot", branch = "master" }
 polkadot-service = { git = "https://github.com/paritytech/polkadot", branch = "master" }
 
@@ -38,3 +36,6 @@ sp-keyring = { git = "https://github.com/paritytech/substrate", branch = "master
 # Polkadot
 polkadot-primitives = { git = "https://github.com/paritytech/polkadot", branch = "master" }
 polkadot-test-client = { git = "https://github.com/paritytech/polkadot", branch = "master" }
+
+[build-dependencies]
+substrate-build-script-utils = { git = "https://github.com/paritytech/substrate", branch = "master" }

--- a/client/relay-chain-inprocess-interface/build.rs
+++ b/client/relay-chain-inprocess-interface/build.rs
@@ -1,7 +1,0 @@
-use substrate_build_script_utils::{generate_cargo_keys, rerun_if_git_head_changed};
-
-fn main() {
-	generate_cargo_keys();
-
-	rerun_if_git_head_changed();
-}

--- a/client/relay-chain-inprocess-interface/build.rs
+++ b/client/relay-chain-inprocess-interface/build.rs
@@ -1,0 +1,7 @@
+use substrate_build_script_utils::{generate_cargo_keys, rerun_if_git_head_changed};
+
+fn main() {
+	generate_cargo_keys();
+
+	rerun_if_git_head_changed();
+}

--- a/client/relay-chain-inprocess-interface/src/lib.rs
+++ b/client/relay-chain-inprocess-interface/src/lib.rs
@@ -31,7 +31,6 @@ use polkadot_client::{ClientHandle, ExecuteWithClient, FullBackend};
 use polkadot_service::{
 	AuxStore, BabeApi, CollatorPair, Configuration, Handle, NewFull, TaskManager,
 };
-use sc_cli::SubstrateCli;
 use sc_client_api::{
 	blockchain::BlockStatus, Backend, BlockchainEvents, HeaderBackend, ImportNotifications,
 	StorageProof, UsageProvider,
@@ -363,8 +362,8 @@ pub fn build_inprocess_relay_chain(
 ) -> RelayChainResult<(Arc<(dyn RelayChainInterface + 'static)>, Option<CollatorPair>)> {
 	// This is essentially a hack, but we want to ensure that we send the correct node version
 	// to the telemetry.
-	polkadot_config.impl_version = polkadot_cli::Cli::impl_version();
-	polkadot_config.impl_name = polkadot_cli::Cli::impl_name();
+	polkadot_config.impl_version = "Parity Polkadot".to_string();
+	polkadot_config.impl_name = env!("SUBSTRATE_CLI_IMPL_VERSION").into();
 
 	let (full_node, collator_key) = build_polkadot_full_node(
 		polkadot_config,

--- a/client/relay-chain-inprocess-interface/src/lib.rs
+++ b/client/relay-chain-inprocess-interface/src/lib.rs
@@ -360,11 +360,6 @@ pub fn build_inprocess_relay_chain(
 	task_manager: &mut TaskManager,
 	hwbench: Option<sc_sysinfo::HwBench>,
 ) -> RelayChainResult<(Arc<(dyn RelayChainInterface + 'static)>, Option<CollatorPair>)> {
-	// This is essentially a hack, but we want to ensure that we send the correct node version
-	// to the telemetry.
-	polkadot_config.impl_version = "Parity Polkadot".to_string();
-	polkadot_config.impl_name = env!("SUBSTRATE_CLI_IMPL_VERSION").into();
-
 	let (full_node, collator_key) = build_polkadot_full_node(
 		polkadot_config,
 		parachain_config,

--- a/polkadot-parachain/src/command.rs
+++ b/polkadot-parachain/src/command.rs
@@ -311,7 +311,7 @@ impl SubstrateCli for Cli {
 
 impl SubstrateCli for RelayChainCli {
 	fn impl_name() -> String {
-		"Polkadot parachain".into()
+		"Parity Polkadot".into()
 	}
 
 	fn impl_version() -> String {


### PR DESCRIPTION
When building the `substrate-parachain-template`, the `polkadot-cli` dependency contributed 1 min build time on my machine but isn't actually needed. In that workspace it was only used by this crate so hopefully this will knock a cool 1 min of the build time on my fast machine.
(It won't help cumulus repo build times as 3-4 other things in this repo do depend on `polkadot-cli` - I'm assuming they do so for good reason...)

Before one after the other:

![image](https://user-images.githubusercontent.com/803976/194372190-e0b57067-f958-4831-8342-b0adf2524f31.png)

After both compiling at once:

![image](https://user-images.githubusercontent.com/803976/194372105-6abcf01f-edbf-4996-b317-5e6080cbd4fe.png)
