### PR TITLE
bump zombienet version

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,7 +29,7 @@ variables:
   CI_IMAGE:                        "paritytech/ci-linux:production"
   DOCKER_OS:                       "debian:stretch"
   ARCH:                            "x86_64"
-  ZOMBIENET_IMAGE:                 "docker.io/paritytech/zombienet:v1.2.59"
+  ZOMBIENET_IMAGE:                 "docker.io/paritytech/zombienet:v1.2.75"
 
 .collect-artifacts:                &collect-artifacts
   artifacts:


### PR DESCRIPTION
This version includes the latest `polkadot.js` api module that works with the new weights (ref: https://github.com/polkadot-js/apps/issues/8188). `Note:` This will fix the system event assertions.
