### PR TITLE
GHA updates and pin

### DIFF
--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ jobs:
           protoc --version
 
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
 
       - name: Rust versions
         run:  rustup show

--- a/.github/workflows/fmt-check.yml
+++ b/.github/workflows/fmt-check.yml
@@ -31,7 +31,7 @@ jobs:
             target
           key: ${{ runner.os }}-${{ matrix.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
 
       - name: Cargo fmt
         uses: actions-rs/cargo@v1

--- a/.github/workflows/fmt-check.yml
+++ b/.github/workflows/fmt-check.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Rust nightly toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@b2417cde72dcf67f306c0ae8e0828a81bf0b189f # v1.0.7
         with:
           profile: minimal
           toolchain: nightly
@@ -23,7 +23,7 @@ jobs:
           components: clippy, rustfmt
 
       - name: Cache Dependencies & Build Outputs
-        uses: actions/cache@v3
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # v3.0.11
         with:
           path: |
             ~/.cargo/registry
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
 
       - name: Cargo fmt
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@ae10961054e4aa8b4aa7dffede299aaf087aa33b # v1.0.3
         with:
           command: fmt
           args: --all -- --check

--- a/.github/workflows/release-01_branch-check.yml
+++ b/.github/workflows/release-01_branch-check.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release-10_rc-automation.yml
+++ b/.github/workflows/release-10_rc-automation.yml
@@ -17,7 +17,7 @@ jobs:
             pre-releases: true
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
         with:
           fetch-depth: 0
       - id: compute_tag

--- a/.github/workflows/release-20_extrinsic-ordering-check-from-bin.yml
+++ b/.github/workflows/release-20_extrinsic-ordering-check-from-bin.yml
@@ -79,7 +79,7 @@ jobs:
         continue-on-error: true
 
       - name: Save output as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
         with:
           name: ${{ env.CHAIN }}
           path: |

--- a/.github/workflows/release-21_extrinsic-ordering-check-from-two.yml
+++ b/.github/workflows/release-21_extrinsic-ordering-check-from-two.yml
@@ -108,7 +108,7 @@ jobs:
           cat output.txt
 
       - name: Save output as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
         with:
           name: ${{ matrix.runtime }}
           path: |

--- a/.github/workflows/release-30_create-draft.yml
+++ b/.github/workflows/release-30_create-draft.yml
@@ -62,7 +62,7 @@ jobs:
             runtime: rococo-parachain
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
         with:
           ref: ${{ github.event.inputs.ref2 }}
 
@@ -79,7 +79,7 @@ jobs:
       - name: Build ${{ matrix.runtime }} runtime
         if: ${{ github.event.inputs.release_type != 'client' }}
         id: srtool_build
-        uses: chevdor/srtool-actions@v0.5.0
+        uses: chevdor/srtool-actions@v0.6.0
         with:
           image: paritytech/srtool
           chain: ${{ matrix.runtime }}
@@ -114,7 +114,7 @@ jobs:
       asset_upload_url: ${{ steps.create-release.outputs.upload_url }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
         with:
           fetch-depth: 0
           path: cumulus
@@ -228,7 +228,7 @@ jobs:
             runtime: rococo-parachain
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
         with:
           ref: ${{ github.event.inputs.ref2 }}
 

--- a/.github/workflows/release-30_create-draft.yml
+++ b/.github/workflows/release-30_create-draft.yml
@@ -120,7 +120,7 @@ jobs:
           path: cumulus
           ref: ${{ github.event.inputs.ref2 }}
 
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@eae47962baca661befdfd24e4d6c34ade04858f7 # v1.118.0
         with:
           ruby-version: 3.0.0
 
@@ -235,7 +235,7 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v3
 
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@eae47962baca661befdfd24e4d6c34ade04858f7 # v1.118.0
         with:
           ruby-version: 3.0.0
 

--- a/.github/workflows/release-30_create-draft.yml
+++ b/.github/workflows/release-30_create-draft.yml
@@ -93,14 +93,14 @@ jobs:
 
       - name: Upload ${{ matrix.runtime }} srtool json
         if: ${{ github.event.inputs.release_type != 'client' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
         with:
           name: ${{ matrix.runtime }}-srtool-json
           path: ${{ matrix.runtime }}-srtool-digest.json
 
       - name: Upload ${{ matrix.runtime }} runtime
         if: ${{ github.event.inputs.release_type != 'client' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
         with:
           name: ${{ matrix.runtime }}-runtime
           path: |
@@ -125,7 +125,7 @@ jobs:
           ruby-version: 3.0.0
 
       - name: Download srtool json output
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 # v3.0.0
 
       - name: Prepare tooling
         run: |
@@ -177,14 +177,14 @@ jobs:
 
       - name: Archive srtool json
         if: ${{ github.event.inputs.release_type != 'client' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
         with:
           name: srtool-json
           path: |
             **/*-srtool-digest.json
 
       - name: Archive context artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
         with:
           name: release-notes-context
           path: |
@@ -233,7 +233,7 @@ jobs:
           ref: ${{ github.event.inputs.ref2 }}
 
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 # v3.0.0
 
       - uses: ruby/setup-ruby@eae47962baca661befdfd24e4d6c34ade04858f7 # v1.118.0
         with:

--- a/.github/workflows/release-30_create-draft.yml
+++ b/.github/workflows/release-30_create-draft.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Cache target dir
         if: ${{ github.event.inputs.release_type != 'client' }}
-        uses: actions/cache@v3
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # v3.0.11
         with:
           path: "${{ github.workspace }}/runtime/${{ matrix.runtime }}/target"
           key: srtool-target-${{ matrix.runtime }}-${{ github.sha }}

--- a/.github/workflows/release-50_docker-manual.yml
+++ b/.github/workflows/release-50_docker-manual.yml
@@ -91,7 +91,7 @@ jobs:
           ./docker/scripts/build-injected-image.sh
 
       - name: Login to Dockerhub
-        uses: docker/login-action@v2
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/release-50_docker-manual.yml
+++ b/.github/workflows/release-50_docker-manual.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
         with:
           ref: ${{ github.event.release.tag_name }}
 

--- a/.github/workflows/release-50_docker.yml
+++ b/.github/workflows/release-50_docker.yml
@@ -90,7 +90,7 @@ jobs:
           ./docker/scripts/build-injected-image.sh
 
       - name: Login to Dockerhub
-        uses: docker/login-action@v2
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v2.1.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/release-50_docker.yml
+++ b/.github/workflows/release-50_docker.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
         with:
           ref: ${{ github.event.release.tag_name }}
 

--- a/.github/workflows/srtool.yml
+++ b/.github/workflows/srtool.yml
@@ -68,7 +68,7 @@ jobs:
 
       # it takes a while to build the runtime, so let's save the artifact as soon as we have it
       - name: Archive Artifacts for ${{ matrix.runtime }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
         with:
           name: ${{ matrix.runtime }}-runtime
           path: |
@@ -106,7 +106,7 @@ jobs:
             tee ${{ matrix.runtime }}-diff.txt
 
       - name: Archive Subwasm results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
         with:
           name: ${{ matrix.runtime }}-runtime
           path: |

--- a/.github/workflows/srtool.yml
+++ b/.github/workflows/srtool.yml
@@ -48,13 +48,13 @@ jobs:
           - category: testing
             runtime: rococo-parachain
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
         with:
           fetch-depth: 0
 
       - name: Srtool build
         id: srtool_build
-        uses: chevdor/srtool-actions@v0.5.0
+        uses: chevdor/srtool-actions@v0.6.0
         with:
           chain: ${{ matrix.runtime }}
           runtime_dir: parachains/runtimes/${{ matrix.category }}/${{ matrix.runtime }}


### PR DESCRIPTION
- bump all GHA deps
- pin external GHA deps

⚠️ This PR should only be merged after https://github.com/chevdor/srtool-actions/pull/15 and once the `chevdor/srtool-actions@v0.6.0` tag has been created.