### PR TITLE
Single ParachainBlockImport instance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -469,7 +469,7 @@ dependencies = [
 [[package]]
 name = "beefy-gadget"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -506,7 +506,7 @@ dependencies = [
 [[package]]
 name = "beefy-gadget-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "beefy-gadget",
  "beefy-primitives",
@@ -526,7 +526,7 @@ dependencies = [
 [[package]]
 name = "beefy-merkle-tree"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "beefy-primitives",
  "sp-api",
@@ -536,10 +536,11 @@ dependencies = [
 [[package]]
 name = "beefy-primitives"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
+ "serde",
  "sp-api",
  "sp-application-crypto",
  "sp-core",
@@ -2801,7 +2802,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -2824,7 +2825,7 @@ checksum = "85dcb89d2b10c5f6133de2efd8c11959ce9dbb46a2f7a4cab208c4eeda6ce1ab"
 [[package]]
 name = "frame-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2847,7 +2848,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "Inflector",
  "array-bytes",
@@ -2898,7 +2899,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2909,7 +2910,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -2925,7 +2926,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2954,7 +2955,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "bitflags",
  "frame-metadata",
@@ -2986,7 +2987,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -3000,7 +3001,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -3012,7 +3013,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3022,7 +3023,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-support",
  "log",
@@ -3040,7 +3041,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3055,7 +3056,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -3064,7 +3065,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -3925,7 +3926,7 @@ checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 [[package]]
 name = "kusama-runtime"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "beefy-primitives",
  "bitvec",
@@ -4023,7 +4024,7 @@ dependencies = [
 [[package]]
 name = "kusama-runtime-constants"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -5247,7 +5248,7 @@ checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
 [[package]]
 name = "pallet-alliance"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "array-bytes",
  "frame-benchmarking",
@@ -5268,7 +5269,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-tx-payment"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5285,7 +5286,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5299,7 +5300,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5315,7 +5316,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5331,7 +5332,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5346,7 +5347,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5370,7 +5371,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5390,7 +5391,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5405,7 +5406,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "beefy-primitives",
  "frame-support",
@@ -5421,7 +5422,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "array-bytes",
  "beefy-merkle-tree",
@@ -5444,7 +5445,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5462,7 +5463,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5506,7 +5507,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5523,7 +5524,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "bitflags",
  "frame-benchmarking",
@@ -5552,7 +5553,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-primitives"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "bitflags",
  "parity-scale-codec",
@@ -5564,7 +5565,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5574,7 +5575,7 @@ dependencies = [
 [[package]]
 name = "pallet-conviction-voting"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -5591,7 +5592,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5609,7 +5610,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5633,7 +5634,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5646,7 +5647,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "5.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5664,7 +5665,7 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5685,7 +5686,7 @@ dependencies = [
 [[package]]
 name = "pallet-gilt"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5700,7 +5701,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5723,7 +5724,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -5739,7 +5740,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5759,7 +5760,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5776,7 +5777,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5793,7 +5794,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "ckb-merkle-mountain-range",
  "frame-benchmarking",
@@ -5811,7 +5812,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr-rpc"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -5826,7 +5827,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5842,7 +5843,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5859,7 +5860,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5879,7 +5880,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
 version = "1.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -5889,7 +5890,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5906,7 +5907,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5929,7 +5930,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5946,7 +5947,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5961,7 +5962,7 @@ dependencies = [
 [[package]]
 name = "pallet-randomness-collective-flip"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5975,7 +5976,7 @@ dependencies = [
 [[package]]
 name = "pallet-ranked-collective"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5993,7 +5994,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6008,7 +6009,7 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -6026,7 +6027,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6042,7 +6043,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6063,7 +6064,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6079,7 +6080,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6093,7 +6094,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6116,7 +6117,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -6127,7 +6128,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -6136,7 +6137,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6165,7 +6166,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6183,7 +6184,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6202,7 +6203,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6218,7 +6219,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -6233,7 +6234,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -6244,7 +6245,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6261,7 +6262,7 @@ dependencies = [
 [[package]]
 name = "pallet-uniques"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6276,7 +6277,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6292,7 +6293,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6307,7 +6308,7 @@ dependencies = [
 [[package]]
 name = "pallet-whitelist"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6322,7 +6323,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6340,7 +6341,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-benchmarks"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6894,7 +6895,7 @@ dependencies = [
 [[package]]
 name = "polkadot-approval-distribution"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "futures",
  "polkadot-node-network-protocol",
@@ -6909,7 +6910,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "futures",
  "polkadot-node-network-protocol",
@@ -6923,7 +6924,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-distribution"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "derive_more",
  "fatality",
@@ -6946,7 +6947,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-recovery"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "fatality",
  "futures",
@@ -6967,7 +6968,7 @@ dependencies = [
 [[package]]
 name = "polkadot-cli"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "clap 4.0.11",
  "frame-benchmarking-cli",
@@ -6993,7 +6994,7 @@ dependencies = [
 [[package]]
 name = "polkadot-client"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "beefy-primitives",
  "frame-benchmarking",
@@ -7034,7 +7035,7 @@ dependencies = [
 [[package]]
 name = "polkadot-collator-protocol"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "always-assert",
  "bitvec",
@@ -7056,7 +7057,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "parity-scale-codec",
  "parity-util-mem",
@@ -7069,7 +7070,7 @@ dependencies = [
 [[package]]
 name = "polkadot-dispute-distribution"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "derive_more",
  "fatality",
@@ -7094,7 +7095,7 @@ dependencies = [
 [[package]]
 name = "polkadot-erasure-coding"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -7108,7 +7109,7 @@ dependencies = [
 [[package]]
 name = "polkadot-gossip-support"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "futures",
  "futures-timer",
@@ -7128,7 +7129,7 @@ dependencies = [
 [[package]]
 name = "polkadot-network-bridge"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "always-assert",
  "async-trait",
@@ -7152,7 +7153,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-collation-generation"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -7170,7 +7171,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "bitvec",
  "derive_more",
@@ -7199,7 +7200,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-av-store"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "bitvec",
  "futures",
@@ -7219,7 +7220,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-backing"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "bitvec",
  "fatality",
@@ -7238,7 +7239,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
@@ -7253,7 +7254,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-candidate-validation"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "async-trait",
  "futures",
@@ -7271,7 +7272,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-api"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
@@ -7286,7 +7287,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-selection"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "futures",
  "futures-timer",
@@ -7303,7 +7304,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "fatality",
  "futures",
@@ -7322,7 +7323,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "async-trait",
  "futures",
@@ -7339,7 +7340,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-provisioner"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "bitvec",
  "fatality",
@@ -7357,7 +7358,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "always-assert",
  "assert_matches",
@@ -7389,7 +7390,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-checker"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "futures",
  "polkadot-node-primitives",
@@ -7405,7 +7406,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-runtime-api"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "futures",
  "memory-lru",
@@ -7421,7 +7422,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-jaeger"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "async-std",
  "lazy_static",
@@ -7439,7 +7440,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-metrics"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "bs58",
  "futures",
@@ -7458,7 +7459,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -7481,7 +7482,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "bounded-vec",
  "futures",
@@ -7503,7 +7504,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "polkadot-node-jaeger",
  "polkadot-node-subsystem-types",
@@ -7513,7 +7514,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-test-helpers"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "async-trait",
  "futures",
@@ -7531,7 +7532,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-types"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -7554,7 +7555,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-util"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -7587,7 +7588,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "async-trait",
  "futures",
@@ -7610,7 +7611,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "derive_more",
  "frame-support",
@@ -7708,7 +7709,7 @@ dependencies = [
 [[package]]
 name = "polkadot-performance-test"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "env_logger 0.9.0",
  "kusama-runtime",
@@ -7723,7 +7724,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "bitvec",
  "frame-system",
@@ -7753,7 +7754,7 @@ dependencies = [
 [[package]]
 name = "polkadot-rpc"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "beefy-gadget",
  "beefy-gadget-rpc",
@@ -7785,7 +7786,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "beefy-primitives",
  "bitvec",
@@ -7874,7 +7875,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-common"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "beefy-primitives",
  "bitvec",
@@ -7921,7 +7922,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-constants"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -7933,7 +7934,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "bs58",
  "parity-scale-codec",
@@ -7945,7 +7946,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "bitflags",
  "bitvec",
@@ -7988,7 +7989,7 @@ dependencies = [
 [[package]]
 name = "polkadot-service"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "async-trait",
  "beefy-gadget",
@@ -8093,7 +8094,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-distribution"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "arrayvec 0.5.2",
  "fatality",
@@ -8114,7 +8115,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -8124,7 +8125,7 @@ dependencies = [
 [[package]]
 name = "polkadot-test-client"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-subsystem",
@@ -8149,7 +8150,7 @@ dependencies = [
 [[package]]
 name = "polkadot-test-runtime"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "beefy-primitives",
  "bitvec",
@@ -8210,7 +8211,7 @@ dependencies = [
 [[package]]
 name = "polkadot-test-service"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "frame-benchmarking",
  "frame-system",
@@ -8789,7 +8790,7 @@ checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 [[package]]
 name = "remote-externalities"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "env_logger 0.9.0",
  "jsonrpsee",
@@ -8908,7 +8909,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "beefy-merkle-tree",
  "beefy-primitives",
@@ -8992,7 +8993,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime-constants"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -9153,7 +9154,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "4.1.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "log",
  "sp-core",
@@ -9164,7 +9165,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "async-trait",
  "futures",
@@ -9191,7 +9192,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "futures",
  "futures-timer",
@@ -9214,7 +9215,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -9230,7 +9231,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "impl-trait-for-tuples",
  "memmap2 0.5.0",
@@ -9247,7 +9248,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -9258,7 +9259,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "array-bytes",
  "chrono",
@@ -9298,7 +9299,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "fnv",
  "futures",
@@ -9326,7 +9327,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -9351,7 +9352,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "async-trait",
  "futures",
@@ -9375,7 +9376,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "async-trait",
  "futures",
@@ -9404,7 +9405,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -9446,7 +9447,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -9468,7 +9469,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -9481,7 +9482,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "async-trait",
  "futures",
@@ -9505,7 +9506,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "lazy_static",
  "lru 0.7.7",
@@ -9532,7 +9533,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -9548,7 +9549,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -9563,7 +9564,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -9583,7 +9584,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "ahash",
  "array-bytes",
@@ -9624,7 +9625,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "finality-grandpa",
  "futures",
@@ -9645,7 +9646,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "ansi_term",
  "futures",
@@ -9662,7 +9663,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -9677,7 +9678,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -9724,7 +9725,7 @@ dependencies = [
 [[package]]
 name = "sc-network-bitswap"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "cid",
  "futures",
@@ -9744,7 +9745,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "async-trait",
  "bitflags",
@@ -9770,7 +9771,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "ahash",
  "futures",
@@ -9788,7 +9789,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "array-bytes",
  "futures",
@@ -9809,7 +9810,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "array-bytes",
  "fork-tree",
@@ -9839,7 +9840,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "array-bytes",
  "futures",
@@ -9858,7 +9859,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "array-bytes",
  "bytes",
@@ -9888,7 +9889,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "futures",
  "libp2p",
@@ -9901,7 +9902,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -9910,7 +9911,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "futures",
  "hash-db",
@@ -9940,7 +9941,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -9963,7 +9964,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -9976,7 +9977,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "futures",
  "hex",
@@ -9995,7 +9996,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "async-trait",
  "directories",
@@ -10066,7 +10067,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -10080,7 +10081,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -10099,7 +10100,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "6.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "futures",
  "libc",
@@ -10118,7 +10119,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "chrono",
  "futures",
@@ -10136,7 +10137,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "ansi_term",
  "atty",
@@ -10167,7 +10168,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -10178,7 +10179,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "async-trait",
  "futures",
@@ -10205,7 +10206,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "async-trait",
  "futures",
@@ -10219,7 +10220,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "futures",
  "futures-timer",
@@ -10637,7 +10638,7 @@ checksum = "03b634d87b960ab1a38c4fe143b508576f075e7c978bfad18217645ebfdfa2ec"
 [[package]]
 name = "slot-range-helper"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -10713,7 +10714,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "hash-db",
  "log",
@@ -10731,7 +10732,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "blake2",
  "proc-macro-crate",
@@ -10743,7 +10744,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10756,7 +10757,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -10771,7 +10772,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10784,7 +10785,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -10796,7 +10797,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -10808,7 +10809,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "futures",
  "log",
@@ -10826,7 +10827,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "async-trait",
  "futures",
@@ -10845,7 +10846,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -10863,7 +10864,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "async-trait",
  "merlin",
@@ -10886,7 +10887,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10900,7 +10901,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10913,7 +10914,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "array-bytes",
  "base58",
@@ -10959,7 +10960,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "blake2",
  "byteorder",
@@ -10973,7 +10974,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10984,7 +10985,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.1",
@@ -10993,7 +10994,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11003,7 +11004,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.12.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -11014,7 +11015,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -11032,7 +11033,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -11046,7 +11047,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "bytes",
  "futures",
@@ -11072,7 +11073,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -11083,7 +11084,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.12.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "async-trait",
  "futures",
@@ -11100,7 +11101,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "4.1.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "thiserror",
  "zstd",
@@ -11109,7 +11110,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -11125,7 +11126,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11139,7 +11140,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -11149,7 +11150,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -11159,7 +11160,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -11169,7 +11170,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -11192,7 +11193,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -11210,7 +11211,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -11222,7 +11223,7 @@ dependencies = [
 [[package]]
 name = "sp-sandbox"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -11236,7 +11237,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "serde",
  "serde_json",
@@ -11245,7 +11246,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11259,7 +11260,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11270,7 +11271,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.12.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "hash-db",
  "log",
@@ -11292,12 +11293,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 
 [[package]]
 name = "sp-storage"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -11310,7 +11311,7 @@ dependencies = [
 [[package]]
 name = "sp-tasks"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "log",
  "sp-core",
@@ -11323,7 +11324,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "async-trait",
  "futures-timer",
@@ -11339,7 +11340,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "parity-scale-codec",
  "sp-std",
@@ -11351,7 +11352,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -11360,7 +11361,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "async-trait",
  "log",
@@ -11376,7 +11377,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "ahash",
  "hash-db",
@@ -11399,7 +11400,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -11416,7 +11417,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -11427,7 +11428,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "impl-trait-for-tuples",
  "log",
@@ -11440,7 +11441,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -11736,7 +11737,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "platforms",
 ]
@@ -11744,7 +11745,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures",
@@ -11765,7 +11766,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "futures-util",
  "hyper",
@@ -11778,7 +11779,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-trie-migration-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "jsonrpsee",
  "log",
@@ -11799,7 +11800,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -11825,7 +11826,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-utils"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "futures",
  "substrate-test-utils-derive",
@@ -11835,7 +11836,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-utils-derive"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -11846,7 +11847,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "5.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "ansi_term",
  "build-helper",
@@ -11954,7 +11955,7 @@ checksum = "13a4ec180a2de59b57434704ccfad967f789b12737738798fa08798cd5824c16"
 [[package]]
 name = "test-runtime-constants"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -12234,7 +12235,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "polkadot-node-jaeger",
  "polkadot-primitives",
@@ -12245,7 +12246,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "expander 0.0.6",
  "proc-macro-crate",
@@ -12372,7 +12373,7 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 [[package]]
 name = "try-runtime-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#415648d87848dfa02955e3bea73f55503b852bc1"
+source = "git+https://github.com/paritytech/substrate?branch=master#e34b840b8818856a5bb8dbfe91d5b8a918e44fb8"
 dependencies = [
  "clap 4.0.11",
  "frame-try-runtime",
@@ -12961,7 +12962,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "beefy-primitives",
  "bitvec",
@@ -13051,7 +13052,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime-constants"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -13334,7 +13335,7 @@ dependencies = [
 [[package]]
 name = "xcm"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "derivative",
  "impl-trait-for-tuples",
@@ -13348,7 +13349,7 @@ dependencies = [
 [[package]]
 name = "xcm-builder"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -13368,7 +13369,7 @@ dependencies = [
 [[package]]
 name = "xcm-executor"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -13386,7 +13387,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "0.9.29"
-source = "git+https://github.com/paritytech/polkadot?branch=master#8e57f2ce9a85951f3476069de2711a3f9a500ac6"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6e1baff5de3246dc14548c8f3b17633077ba8f6a"
 dependencies = [
  "Inflector",
  "proc-macro2",

--- a/client/consensus/aura/src/import_queue.rs
+++ b/client/consensus/aura/src/import_queue.rs
@@ -17,6 +17,7 @@
 //! Parachain specific wrapper for the AuRa import queue.
 
 use codec::Codec;
+use cumulus_client_consensus_common::ParachainBlockImport;
 use sc_client_api::{backend::AuxStore, BlockOf, UsageProvider};
 use sc_consensus::{import_queue::DefaultImportQueue, BlockImport};
 use sc_consensus_aura::AuraVerifier;
@@ -33,10 +34,10 @@ use sp_runtime::traits::Block as BlockT;
 use std::{fmt::Debug, hash::Hash, sync::Arc};
 use substrate_prometheus_endpoint::Registry;
 
-/// Parameters of [`import_queue`].
+/// Parameters for [`import_queue`].
 pub struct ImportQueueParams<'a, I, C, CIDP, S> {
 	/// The block import to use.
-	pub block_import: I,
+	pub block_import: ParachainBlockImport<I>,
 	/// The client to interact with the chain.
 	pub client: Arc<C>,
 	/// The inherent data providers, to create the inherent data.

--- a/client/consensus/aura/src/lib.rs
+++ b/client/consensus/aura/src/lib.rs
@@ -23,7 +23,9 @@
 //! For more information about AuRa, the Substrate crate should be checked.
 
 use codec::{Decode, Encode};
-use cumulus_client_consensus_common::{ParachainCandidate, ParachainConsensus};
+use cumulus_client_consensus_common::{
+	ParachainBlockImport, ParachainCandidate, ParachainConsensus,
+};
 use cumulus_primitives_core::{relay_chain::v2::Hash as PHash, PersistedValidationData};
 
 use futures::lock::Mutex;
@@ -67,6 +69,22 @@ impl<B, CIDP, W> Clone for AuraConsensus<B, CIDP, W> {
 			_phantom: PhantomData,
 		}
 	}
+}
+
+/// Parameters of [`AuraConsensus::build`].
+pub struct BuildAuraConsensusParams<PF, BI, CIDP, Client, BS, SO> {
+	pub proposer_factory: PF,
+	pub create_inherent_data_providers: CIDP,
+	pub block_import: ParachainBlockImport<BI>,
+	pub para_client: Arc<Client>,
+	pub backoff_authoring_blocks: Option<BS>,
+	pub sync_oracle: SO,
+	pub keystore: SyncCryptoStorePtr,
+	pub force_authoring: bool,
+	pub slot_duration: SlotDuration,
+	pub telemetry: Option<TelemetryHandle>,
+	pub block_proposal_slot_portion: SlotProportion,
+	pub max_block_proposal_slot_portion: Option<SlotProportion>,
 }
 
 impl<B, CIDP> AuraConsensus<B, CIDP, ()>
@@ -213,20 +231,4 @@ where
 
 		Some(ParachainCandidate { block: res.block, proof: res.storage_proof })
 	}
-}
-
-/// Parameters of [`AuraConsensus::build`].
-pub struct BuildAuraConsensusParams<PF, BI, CIDP, Client, BS, SO> {
-	pub proposer_factory: PF,
-	pub create_inherent_data_providers: CIDP,
-	pub block_import: BI,
-	pub para_client: Arc<Client>,
-	pub backoff_authoring_blocks: Option<BS>,
-	pub sync_oracle: SO,
-	pub keystore: SyncCryptoStorePtr,
-	pub force_authoring: bool,
-	pub slot_duration: SlotDuration,
-	pub telemetry: Option<TelemetryHandle>,
-	pub block_proposal_slot_portion: SlotProportion,
-	pub max_block_proposal_slot_portion: Option<SlotProportion>,
 }

--- a/client/consensus/relay-chain/src/import_queue.rs
+++ b/client/consensus/relay-chain/src/import_queue.rs
@@ -16,6 +16,8 @@
 
 use std::{marker::PhantomData, sync::Arc};
 
+use cumulus_client_consensus_common::ParachainBlockImport;
+
 use sc_consensus::{
 	import_queue::{BasicQueue, Verifier as VerifierT},
 	BlockImport, BlockImportParams,
@@ -101,21 +103,16 @@ where
 }
 
 /// Start an import queue for a Cumulus collator that does not uses any special authoring logic.
-///
-/// `BI` should be a `ParachainBlockImport` or a wrapper around it;
-///  if not, important functional logic will be omitted.
-/// TODO: better docs
-/// TODO: can we just get rid of the BI generic and directly expect a `ParachainBlockImport`?
-pub fn import_queue<Client, Block: BlockT, BI, CIDP>(
+pub fn import_queue<Client, Block: BlockT, I, CIDP>(
 	client: Arc<Client>,
-	block_import: BI,
+	block_import: ParachainBlockImport<I>,
 	create_inherent_data_providers: CIDP,
 	spawner: &impl sp_core::traits::SpawnEssentialNamed,
 	registry: Option<&substrate_prometheus_endpoint::Registry>,
-) -> ClientResult<BasicQueue<Block, BI::Transaction>>
+) -> ClientResult<BasicQueue<Block, I::Transaction>>
 where
-	BI: BlockImport<Block, Error = ConsensusError> + Send + Sync + 'static,
-	BI::Transaction: Send,
+	I: BlockImport<Block, Error = ConsensusError> + Send + Sync + 'static,
+	I::Transaction: Send,
 	Client: ProvideRuntimeApi<Block> + Send + Sync + 'static,
 	<Client as ProvideRuntimeApi<Block>>::Api: BlockBuilderApi<Block>,
 	CIDP: CreateInherentDataProviders<Block, ()> + 'static,

--- a/client/consensus/relay-chain/src/lib.rs
+++ b/client/consensus/relay-chain/src/lib.rs
@@ -54,13 +54,12 @@ pub use import_queue::{import_queue, Verifier};
 const LOG_TARGET: &str = "cumulus-consensus-relay-chain";
 
 /// The implementation of the relay-chain provided consensus for parachains.
-/// TODO: can we use directly ParachainBlockImport in place of BI?
 pub struct RelayChainConsensus<B, PF, BI, RCInterface, CIDP> {
 	para_id: ParaId,
 	_phantom: PhantomData<B>,
 	proposer_factory: Arc<Mutex<PF>>,
 	create_inherent_data_providers: Arc<CIDP>,
-	block_import: Arc<futures::lock::Mutex<BI>>,
+	block_import: Arc<futures::lock::Mutex<ParachainBlockImport<BI>>>,
 	relay_chain_interface: RCInterface,
 }
 
@@ -87,17 +86,11 @@ where
 	CIDP: CreateInherentDataProviders<B, (PHash, PersistedValidationData)>,
 {
 	/// Create a new instance of relay-chain provided consensus.
-	///
-	/// Note: in order to perform the correct parachian logic this should
-	/// be a `ParachainBlockImport` or a wrapper of it.
-	///
-	/// TODO: better doc
-	/// TODO: Can we just pass a ParachainBlockImport<BI: BlockImport>?
 	pub fn new(
 		para_id: ParaId,
 		proposer_factory: PF,
 		create_inherent_data_providers: CIDP,
-		block_import: BI,
+		block_import: ParachainBlockImport<BI>,
 		relay_chain_interface: RCInterface,
 	) -> Self {
 		Self {
@@ -227,16 +220,13 @@ pub struct BuildRelayChainConsensusParams<PF, BI, CIDP, RCInterface> {
 	pub para_id: ParaId,
 	pub proposer_factory: PF,
 	pub create_inherent_data_providers: CIDP,
-	pub block_import: BI,
+	pub block_import: ParachainBlockImport<BI>,
 	pub relay_chain_interface: RCInterface,
 }
 
 /// Build the [`RelayChainConsensus`].
 ///
 /// Returns a boxed [`ParachainConsensus`].
-///
-/// TODO: doc about BI
-/// TODO: can't we pass a ParachainBlockImport directly?
 pub fn build_relay_chain_consensus<Block, PF, BI, CIDP, RCInterface>(
 	BuildRelayChainConsensusParams {
 		para_id,

--- a/client/consensus/relay-chain/src/lib.rs
+++ b/client/consensus/relay-chain/src/lib.rs
@@ -54,12 +54,13 @@ pub use import_queue::{import_queue, Verifier};
 const LOG_TARGET: &str = "cumulus-consensus-relay-chain";
 
 /// The implementation of the relay-chain provided consensus for parachains.
+/// TODO: can we use directly ParachainBlockImport in place of BI?
 pub struct RelayChainConsensus<B, PF, BI, RCInterface, CIDP> {
 	para_id: ParaId,
 	_phantom: PhantomData<B>,
 	proposer_factory: Arc<Mutex<PF>>,
 	create_inherent_data_providers: Arc<CIDP>,
-	block_import: Arc<futures::lock::Mutex<ParachainBlockImport<BI>>>,
+	block_import: Arc<futures::lock::Mutex<BI>>,
 	relay_chain_interface: RCInterface,
 }
 
@@ -86,6 +87,12 @@ where
 	CIDP: CreateInherentDataProviders<B, (PHash, PersistedValidationData)>,
 {
 	/// Create a new instance of relay-chain provided consensus.
+	///
+	/// Note: in order to perform the correct parachian logic this should
+	/// be a `ParachainBlockImport` or a wrapper of it.
+	///
+	/// TODO: better doc
+	/// TODO: Can we just pass a ParachainBlockImport<BI: BlockImport>?
 	pub fn new(
 		para_id: ParaId,
 		proposer_factory: PF,
@@ -97,9 +104,7 @@ where
 			para_id,
 			proposer_factory: Arc::new(Mutex::new(proposer_factory)),
 			create_inherent_data_providers: Arc::new(create_inherent_data_providers),
-			block_import: Arc::new(futures::lock::Mutex::new(ParachainBlockImport::new(
-				block_import,
-			))),
+			block_import: Arc::new(futures::lock::Mutex::new(block_import)),
 			relay_chain_interface,
 			_phantom: PhantomData,
 		}
@@ -229,6 +234,9 @@ pub struct BuildRelayChainConsensusParams<PF, BI, CIDP, RCInterface> {
 /// Build the [`RelayChainConsensus`].
 ///
 /// Returns a boxed [`ParachainConsensus`].
+///
+/// TODO: doc about BI
+/// TODO: can't we pass a ParachainBlockImport directly?
 pub fn build_relay_chain_consensus<Block, PF, BI, CIDP, RCInterface>(
 	BuildRelayChainConsensusParams {
 		para_id,

--- a/polkadot-parachain/src/service.rs
+++ b/polkadot-parachain/src/service.rs
@@ -69,6 +69,10 @@ type HostFunctions = sp_io::SubstrateHostFunctions;
 type HostFunctions =
 	(sp_io::SubstrateHostFunctions, frame_benchmarking::benchmarking::HostFunctions);
 
+type ParachainClient<RuntimeApi> = TFullClient<Block, RuntimeApi, WasmExecutor<HostFunctions>>;
+
+type ParachainBackend = TFullBackend<Block>;
+
 /// Native executor instance.
 pub struct ShellRuntimeExecutor;
 
@@ -153,45 +157,33 @@ pub fn new_partial<RuntimeApi, BIQ>(
 	build_import_queue: BIQ,
 ) -> Result<
 	PartialComponents<
-		TFullClient<Block, RuntimeApi, WasmExecutor<HostFunctions>>,
-		TFullBackend<Block>,
+		ParachainClient<RuntimeApi>,
+		ParachainBackend,
 		(),
-		sc_consensus::DefaultImportQueue<
-			Block,
-			TFullClient<Block, RuntimeApi, WasmExecutor<HostFunctions>>,
-		>,
-		sc_transaction_pool::FullPool<
-			Block,
-			TFullClient<Block, RuntimeApi, WasmExecutor<HostFunctions>>,
-		>,
+		sc_consensus::DefaultImportQueue<Block, ParachainClient<RuntimeApi>>,
+		sc_transaction_pool::FullPool<Block, ParachainClient<RuntimeApi>>,
 		(Option<Telemetry>, Option<TelemetryWorkerHandle>),
 	>,
 	sc_service::Error,
 >
 where
-	RuntimeApi: ConstructRuntimeApi<Block, TFullClient<Block, RuntimeApi, WasmExecutor<HostFunctions>>>
-		+ Send
-		+ Sync
-		+ 'static,
+	RuntimeApi: ConstructRuntimeApi<Block, ParachainClient<RuntimeApi>> + Send + Sync + 'static,
 	RuntimeApi::RuntimeApi: sp_transaction_pool::runtime_api::TaggedTransactionQueue<Block>
 		+ sp_api::Metadata<Block>
 		+ sp_session::SessionKeys<Block>
 		+ sp_api::ApiExt<
 			Block,
-			StateBackend = sc_client_api::StateBackendFor<TFullBackend<Block>, Block>,
+			StateBackend = sc_client_api::StateBackendFor<ParachainBackend, Block>,
 		> + sp_offchain::OffchainWorkerApi<Block>
 		+ sp_block_builder::BlockBuilder<Block>,
-	sc_client_api::StateBackendFor<TFullBackend<Block>, Block>: sp_api::StateBackend<BlakeTwo256>,
+	sc_client_api::StateBackendFor<ParachainBackend, Block>: sp_api::StateBackend<BlakeTwo256>,
 	BIQ: FnOnce(
-		Arc<TFullClient<Block, RuntimeApi, WasmExecutor<HostFunctions>>>,
+		Arc<ParachainClient<RuntimeApi>>,
 		&Configuration,
 		Option<TelemetryHandle>,
 		&TaskManager,
 	) -> Result<
-		sc_consensus::DefaultImportQueue<
-			Block,
-			TFullClient<Block, RuntimeApi, WasmExecutor<HostFunctions>>,
-		>,
+		sc_consensus::DefaultImportQueue<Block, ParachainClient<RuntimeApi>>,
 		sc_service::Error,
 	>,
 {
@@ -292,54 +284,38 @@ async fn start_shell_node_impl<RuntimeApi, RB, BIQ, BIC>(
 	build_import_queue: BIQ,
 	build_consensus: BIC,
 	hwbench: Option<sc_sysinfo::HwBench>,
-) -> sc_service::error::Result<(
-	TaskManager,
-	Arc<TFullClient<Block, RuntimeApi, WasmExecutor<HostFunctions>>>,
-)>
+) -> sc_service::error::Result<(TaskManager, Arc<ParachainClient<RuntimeApi>>)>
 where
-	RuntimeApi: ConstructRuntimeApi<Block, TFullClient<Block, RuntimeApi, WasmExecutor<HostFunctions>>>
-		+ Send
-		+ Sync
-		+ 'static,
+	RuntimeApi: ConstructRuntimeApi<Block, ParachainClient<RuntimeApi>> + Send + Sync + 'static,
 	RuntimeApi::RuntimeApi: sp_transaction_pool::runtime_api::TaggedTransactionQueue<Block>
 		+ sp_api::Metadata<Block>
 		+ sp_session::SessionKeys<Block>
 		+ sp_api::ApiExt<
 			Block,
-			StateBackend = sc_client_api::StateBackendFor<TFullBackend<Block>, Block>,
+			StateBackend = sc_client_api::StateBackendFor<ParachainBackend, Block>,
 		> + sp_offchain::OffchainWorkerApi<Block>
 		+ sp_block_builder::BlockBuilder<Block>
 		+ cumulus_primitives_core::CollectCollationInfo<Block>,
-	sc_client_api::StateBackendFor<TFullBackend<Block>, Block>: sp_api::StateBackend<BlakeTwo256>,
-	RB: Fn(
-			Arc<TFullClient<Block, RuntimeApi, WasmExecutor<HostFunctions>>>,
-		) -> Result<jsonrpsee::RpcModule<()>, sc_service::Error>
+	sc_client_api::StateBackendFor<ParachainBackend, Block>: sp_api::StateBackend<BlakeTwo256>,
+	RB: Fn(Arc<ParachainClient<RuntimeApi>>) -> Result<jsonrpsee::RpcModule<()>, sc_service::Error>
 		+ Send
 		+ 'static,
 	BIQ: FnOnce(
-		Arc<TFullClient<Block, RuntimeApi, WasmExecutor<HostFunctions>>>,
+		Arc<ParachainClient<RuntimeApi>>,
 		&Configuration,
 		Option<TelemetryHandle>,
 		&TaskManager,
 	) -> Result<
-		sc_consensus::DefaultImportQueue<
-			Block,
-			TFullClient<Block, RuntimeApi, WasmExecutor<HostFunctions>>,
-		>,
+		sc_consensus::DefaultImportQueue<Block, ParachainClient<RuntimeApi>>,
 		sc_service::Error,
 	>,
 	BIC: FnOnce(
-		Arc<TFullClient<Block, RuntimeApi, WasmExecutor<HostFunctions>>>,
+		Arc<ParachainClient<RuntimeApi>>,
 		Option<&Registry>,
 		Option<TelemetryHandle>,
 		&TaskManager,
 		Arc<dyn RelayChainInterface>,
-		Arc<
-			sc_transaction_pool::FullPool<
-				Block,
-				TFullClient<Block, RuntimeApi, WasmExecutor<HostFunctions>>,
-			>,
-		>,
+		Arc<sc_transaction_pool::FullPool<Block, ParachainClient<RuntimeApi>>>,
 		Arc<NetworkService<Block, Hash>>,
 		SyncCryptoStorePtr,
 		bool,
@@ -488,56 +464,40 @@ async fn start_node_impl<RuntimeApi, RB, BIQ, BIC>(
 	build_import_queue: BIQ,
 	build_consensus: BIC,
 	hwbench: Option<sc_sysinfo::HwBench>,
-) -> sc_service::error::Result<(
-	TaskManager,
-	Arc<TFullClient<Block, RuntimeApi, WasmExecutor<HostFunctions>>>,
-)>
+) -> sc_service::error::Result<(TaskManager, Arc<ParachainClient<RuntimeApi>>)>
 where
-	RuntimeApi: ConstructRuntimeApi<Block, TFullClient<Block, RuntimeApi, WasmExecutor<HostFunctions>>>
-		+ Send
-		+ Sync
-		+ 'static,
+	RuntimeApi: ConstructRuntimeApi<Block, ParachainClient<RuntimeApi>> + Send + Sync + 'static,
 	RuntimeApi::RuntimeApi: sp_transaction_pool::runtime_api::TaggedTransactionQueue<Block>
 		+ sp_api::Metadata<Block>
 		+ sp_session::SessionKeys<Block>
 		+ sp_api::ApiExt<
 			Block,
-			StateBackend = sc_client_api::StateBackendFor<TFullBackend<Block>, Block>,
+			StateBackend = sc_client_api::StateBackendFor<ParachainBackend, Block>,
 		> + sp_offchain::OffchainWorkerApi<Block>
 		+ sp_block_builder::BlockBuilder<Block>
 		+ cumulus_primitives_core::CollectCollationInfo<Block>
 		+ pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>
 		+ frame_rpc_system::AccountNonceApi<Block, AccountId, Nonce>,
-	sc_client_api::StateBackendFor<TFullBackend<Block>, Block>: sp_api::StateBackend<BlakeTwo256>,
-	RB: Fn(
-			Arc<TFullClient<Block, RuntimeApi, WasmExecutor<HostFunctions>>>,
-		) -> Result<jsonrpsee::RpcModule<()>, sc_service::Error>
+	sc_client_api::StateBackendFor<ParachainBackend, Block>: sp_api::StateBackend<BlakeTwo256>,
+	RB: Fn(Arc<ParachainClient<RuntimeApi>>) -> Result<jsonrpsee::RpcModule<()>, sc_service::Error>
 		+ Send
 		+ 'static,
 	BIQ: FnOnce(
-			Arc<TFullClient<Block, RuntimeApi, WasmExecutor<HostFunctions>>>,
+			Arc<ParachainClient<RuntimeApi>>,
 			&Configuration,
 			Option<TelemetryHandle>,
 			&TaskManager,
 		) -> Result<
-			sc_consensus::DefaultImportQueue<
-				Block,
-				TFullClient<Block, RuntimeApi, WasmExecutor<HostFunctions>>,
-			>,
+			sc_consensus::DefaultImportQueue<Block, ParachainClient<RuntimeApi>>,
 			sc_service::Error,
 		> + 'static,
 	BIC: FnOnce(
-		Arc<TFullClient<Block, RuntimeApi, WasmExecutor<HostFunctions>>>,
+		Arc<ParachainClient<RuntimeApi>>,
 		Option<&Registry>,
 		Option<TelemetryHandle>,
 		&TaskManager,
 		Arc<dyn RelayChainInterface>,
-		Arc<
-			sc_transaction_pool::FullPool<
-				Block,
-				TFullClient<Block, RuntimeApi, WasmExecutor<HostFunctions>>,
-			>,
-		>,
+		Arc<sc_transaction_pool::FullPool<Block, ParachainClient<RuntimeApi>>>,
 		Arc<NetworkService<Block, Hash>>,
 		SyncCryptoStorePtr,
 		bool,
@@ -686,17 +646,12 @@ where
 
 /// Build the import queue for the rococo parachain runtime.
 pub fn rococo_parachain_build_import_queue(
-	client: Arc<
-		TFullClient<Block, rococo_parachain_runtime::RuntimeApi, WasmExecutor<HostFunctions>>,
-	>,
+	client: Arc<ParachainClient<rococo_parachain_runtime::RuntimeApi>>,
 	config: &Configuration,
 	telemetry: Option<TelemetryHandle>,
 	task_manager: &TaskManager,
 ) -> Result<
-	sc_consensus::DefaultImportQueue<
-		Block,
-		TFullClient<Block, rococo_parachain_runtime::RuntimeApi, WasmExecutor<HostFunctions>>,
-	>,
+	sc_consensus::DefaultImportQueue<Block, ParachainClient<rococo_parachain_runtime::RuntimeApi>>,
 	sc_service::Error,
 > {
 	let slot_duration = cumulus_client_consensus_aura::slot_duration(&*client)?;
@@ -738,7 +693,7 @@ pub async fn start_rococo_parachain_node(
 	hwbench: Option<sc_sysinfo::HwBench>,
 ) -> sc_service::error::Result<(
 	TaskManager,
-	Arc<TFullClient<Block, rococo_parachain_runtime::RuntimeApi, WasmExecutor<HostFunctions>>>,
+	Arc<ParachainClient<rococo_parachain_runtime::RuntimeApi>>,
 )> {
 	start_node_impl::<rococo_parachain_runtime::RuntimeApi, _, _, _>(
 		parachain_config,
@@ -820,31 +775,22 @@ pub async fn start_rococo_parachain_node(
 
 /// Build the import queue for the shell runtime.
 pub fn shell_build_import_queue<RuntimeApi>(
-	client: Arc<TFullClient<Block, RuntimeApi, WasmExecutor<HostFunctions>>>,
+	client: Arc<ParachainClient<RuntimeApi>>,
 	config: &Configuration,
 	_: Option<TelemetryHandle>,
 	task_manager: &TaskManager,
-) -> Result<
-	sc_consensus::DefaultImportQueue<
-		Block,
-		TFullClient<Block, RuntimeApi, WasmExecutor<HostFunctions>>,
-	>,
-	sc_service::Error,
->
+) -> Result<sc_consensus::DefaultImportQueue<Block, ParachainClient<RuntimeApi>>, sc_service::Error>
 where
-	RuntimeApi: ConstructRuntimeApi<Block, TFullClient<Block, RuntimeApi, WasmExecutor<HostFunctions>>>
-		+ Send
-		+ Sync
-		+ 'static,
+	RuntimeApi: ConstructRuntimeApi<Block, ParachainClient<RuntimeApi>> + Send + Sync + 'static,
 	RuntimeApi::RuntimeApi: sp_transaction_pool::runtime_api::TaggedTransactionQueue<Block>
 		+ sp_api::Metadata<Block>
 		+ sp_session::SessionKeys<Block>
 		+ sp_api::ApiExt<
 			Block,
-			StateBackend = sc_client_api::StateBackendFor<TFullBackend<Block>, Block>,
+			StateBackend = sc_client_api::StateBackendFor<ParachainBackend, Block>,
 		> + sp_offchain::OffchainWorkerApi<Block>
 		+ sp_block_builder::BlockBuilder<Block>,
-	sc_client_api::StateBackendFor<TFullBackend<Block>, Block>: sp_api::StateBackend<BlakeTwo256>,
+	sc_client_api::StateBackendFor<ParachainBackend, Block>: sp_api::StateBackend<BlakeTwo256>,
 {
 	cumulus_client_consensus_relay_chain::import_queue(
 		client.clone(),
@@ -863,25 +809,19 @@ pub async fn start_shell_node<RuntimeApi>(
 	collator_options: CollatorOptions,
 	id: ParaId,
 	hwbench: Option<sc_sysinfo::HwBench>,
-) -> sc_service::error::Result<(
-	TaskManager,
-	Arc<TFullClient<Block, RuntimeApi, WasmExecutor<HostFunctions>>>,
-)>
+) -> sc_service::error::Result<(TaskManager, Arc<ParachainClient<RuntimeApi>>)>
 where
-	RuntimeApi: ConstructRuntimeApi<Block, TFullClient<Block, RuntimeApi, WasmExecutor<HostFunctions>>>
-		+ Send
-		+ Sync
-		+ 'static,
+	RuntimeApi: ConstructRuntimeApi<Block, ParachainClient<RuntimeApi>> + Send + Sync + 'static,
 	RuntimeApi::RuntimeApi: sp_transaction_pool::runtime_api::TaggedTransactionQueue<Block>
 		+ sp_api::Metadata<Block>
 		+ sp_session::SessionKeys<Block>
 		+ sp_api::ApiExt<
 			Block,
-			StateBackend = sc_client_api::StateBackendFor<TFullBackend<Block>, Block>,
+			StateBackend = sc_client_api::StateBackendFor<ParachainBackend, Block>,
 		> + sp_offchain::OffchainWorkerApi<Block>
 		+ sp_block_builder::BlockBuilder<Block>
 		+ cumulus_primitives_core::CollectCollationInfo<Block>,
-	sc_client_api::StateBackendFor<TFullBackend<Block>, Block>: sp_api::StateBackend<BlakeTwo256>,
+	sc_client_api::StateBackendFor<ParachainBackend, Block>: sp_api::StateBackend<BlakeTwo256>,
 {
 	start_shell_node_impl::<RuntimeApi, _, _, _>(
 		parachain_config,
@@ -1048,32 +988,23 @@ where
 
 /// Build the import queue for Statemint and other Aura-based runtimes.
 pub fn aura_build_import_queue<RuntimeApi, AuraId: AppKey>(
-	client: Arc<TFullClient<Block, RuntimeApi, WasmExecutor<HostFunctions>>>,
+	client: Arc<ParachainClient<RuntimeApi>>,
 	config: &Configuration,
 	telemetry_handle: Option<TelemetryHandle>,
 	task_manager: &TaskManager,
-) -> Result<
-	sc_consensus::DefaultImportQueue<
-		Block,
-		TFullClient<Block, RuntimeApi, WasmExecutor<HostFunctions>>,
-	>,
-	sc_service::Error,
->
+) -> Result<sc_consensus::DefaultImportQueue<Block, ParachainClient<RuntimeApi>>, sc_service::Error>
 where
-	RuntimeApi: ConstructRuntimeApi<Block, TFullClient<Block, RuntimeApi, WasmExecutor<HostFunctions>>>
-		+ Send
-		+ Sync
-		+ 'static,
+	RuntimeApi: ConstructRuntimeApi<Block, ParachainClient<RuntimeApi>> + Send + Sync + 'static,
 	RuntimeApi::RuntimeApi: sp_transaction_pool::runtime_api::TaggedTransactionQueue<Block>
 		+ sp_api::Metadata<Block>
 		+ sp_session::SessionKeys<Block>
 		+ sp_api::ApiExt<
 			Block,
-			StateBackend = sc_client_api::StateBackendFor<TFullBackend<Block>, Block>,
+			StateBackend = sc_client_api::StateBackendFor<ParachainBackend, Block>,
 		> + sp_offchain::OffchainWorkerApi<Block>
 		+ sp_block_builder::BlockBuilder<Block>
 		+ sp_consensus_aura::AuraApi<Block, <<AuraId as AppKey>::Pair as Pair>::Public>,
-	sc_client_api::StateBackendFor<TFullBackend<Block>, Block>: sp_api::StateBackend<BlakeTwo256>,
+	sc_client_api::StateBackendFor<ParachainBackend, Block>: sp_api::StateBackend<BlakeTwo256>,
 	<<AuraId as AppKey>::Pair as Pair>::Signature:
 		TryFrom<Vec<u8>> + std::hash::Hash + sp_runtime::traits::Member + Codec,
 {
@@ -1131,28 +1062,22 @@ pub async fn start_generic_aura_node<RuntimeApi, AuraId: AppKey>(
 	collator_options: CollatorOptions,
 	id: ParaId,
 	hwbench: Option<sc_sysinfo::HwBench>,
-) -> sc_service::error::Result<(
-	TaskManager,
-	Arc<TFullClient<Block, RuntimeApi, WasmExecutor<HostFunctions>>>,
-)>
+) -> sc_service::error::Result<(TaskManager, Arc<ParachainClient<RuntimeApi>>)>
 where
-	RuntimeApi: ConstructRuntimeApi<Block, TFullClient<Block, RuntimeApi, WasmExecutor<HostFunctions>>>
-		+ Send
-		+ Sync
-		+ 'static,
+	RuntimeApi: ConstructRuntimeApi<Block, ParachainClient<RuntimeApi>> + Send + Sync + 'static,
 	RuntimeApi::RuntimeApi: sp_transaction_pool::runtime_api::TaggedTransactionQueue<Block>
 		+ sp_api::Metadata<Block>
 		+ sp_session::SessionKeys<Block>
 		+ sp_api::ApiExt<
 			Block,
-			StateBackend = sc_client_api::StateBackendFor<TFullBackend<Block>, Block>,
+			StateBackend = sc_client_api::StateBackendFor<ParachainBackend, Block>,
 		> + sp_offchain::OffchainWorkerApi<Block>
 		+ sp_block_builder::BlockBuilder<Block>
 		+ cumulus_primitives_core::CollectCollationInfo<Block>
 		+ sp_consensus_aura::AuraApi<Block, <<AuraId as AppKey>::Pair as Pair>::Public>
 		+ pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>
 		+ frame_rpc_system::AccountNonceApi<Block, AccountId, Nonce>,
-	sc_client_api::StateBackendFor<TFullBackend<Block>, Block>: sp_api::StateBackend<BlakeTwo256>,
+	sc_client_api::StateBackendFor<ParachainBackend, Block>: sp_api::StateBackend<BlakeTwo256>,
 	<<AuraId as AppKey>::Pair as Pair>::Signature:
 		TryFrom<Vec<u8>> + std::hash::Hash + sp_runtime::traits::Member + Codec,
 {
@@ -1302,56 +1227,40 @@ async fn start_contracts_rococo_node_impl<RuntimeApi, RB, BIQ, BIC>(
 	build_import_queue: BIQ,
 	build_consensus: BIC,
 	hwbench: Option<sc_sysinfo::HwBench>,
-) -> sc_service::error::Result<(
-	TaskManager,
-	Arc<TFullClient<Block, RuntimeApi, WasmExecutor<HostFunctions>>>,
-)>
+) -> sc_service::error::Result<(TaskManager, Arc<ParachainClient<RuntimeApi>>)>
 where
-	RuntimeApi: ConstructRuntimeApi<Block, TFullClient<Block, RuntimeApi, WasmExecutor<HostFunctions>>>
-		+ Send
-		+ Sync
-		+ 'static,
+	RuntimeApi: ConstructRuntimeApi<Block, ParachainClient<RuntimeApi>> + Send + Sync + 'static,
 	RuntimeApi::RuntimeApi: sp_transaction_pool::runtime_api::TaggedTransactionQueue<Block>
 		+ sp_api::Metadata<Block>
 		+ sp_session::SessionKeys<Block>
 		+ sp_api::ApiExt<
 			Block,
-			StateBackend = sc_client_api::StateBackendFor<TFullBackend<Block>, Block>,
+			StateBackend = sc_client_api::StateBackendFor<ParachainBackend, Block>,
 		> + sp_offchain::OffchainWorkerApi<Block>
 		+ sp_block_builder::BlockBuilder<Block>
 		+ cumulus_primitives_core::CollectCollationInfo<Block>
 		+ pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>
 		+ frame_rpc_system::AccountNonceApi<Block, AccountId, Nonce>,
-	sc_client_api::StateBackendFor<TFullBackend<Block>, Block>: sp_api::StateBackend<BlakeTwo256>,
-	RB: Fn(
-			Arc<TFullClient<Block, RuntimeApi, WasmExecutor<HostFunctions>>>,
-		) -> Result<jsonrpsee::RpcModule<()>, sc_service::Error>
+	sc_client_api::StateBackendFor<ParachainBackend, Block>: sp_api::StateBackend<BlakeTwo256>,
+	RB: Fn(Arc<ParachainClient<RuntimeApi>>) -> Result<jsonrpsee::RpcModule<()>, sc_service::Error>
 		+ Send
 		+ 'static,
 	BIQ: FnOnce(
-			Arc<TFullClient<Block, RuntimeApi, WasmExecutor<HostFunctions>>>,
+			Arc<ParachainClient<RuntimeApi>>,
 			&Configuration,
 			Option<TelemetryHandle>,
 			&TaskManager,
 		) -> Result<
-			sc_consensus::DefaultImportQueue<
-				Block,
-				TFullClient<Block, RuntimeApi, WasmExecutor<HostFunctions>>,
-			>,
+			sc_consensus::DefaultImportQueue<Block, ParachainClient<RuntimeApi>>,
 			sc_service::Error,
 		> + 'static,
 	BIC: FnOnce(
-		Arc<TFullClient<Block, RuntimeApi, WasmExecutor<HostFunctions>>>,
+		Arc<ParachainClient<RuntimeApi>>,
 		Option<&Registry>,
 		Option<TelemetryHandle>,
 		&TaskManager,
 		Arc<dyn RelayChainInterface>,
-		Arc<
-			sc_transaction_pool::FullPool<
-				Block,
-				TFullClient<Block, RuntimeApi, WasmExecutor<HostFunctions>>,
-			>,
-		>,
+		Arc<sc_transaction_pool::FullPool<Block, ParachainClient<RuntimeApi>>>,
 		Arc<NetworkService<Block, Hash>>,
 		SyncCryptoStorePtr,
 		bool,
@@ -1500,17 +1409,12 @@ where
 
 #[allow(clippy::type_complexity)]
 pub fn contracts_rococo_build_import_queue(
-	client: Arc<
-		TFullClient<Block, contracts_rococo_runtime::RuntimeApi, WasmExecutor<HostFunctions>>,
-	>,
+	client: Arc<ParachainClient<contracts_rococo_runtime::RuntimeApi>>,
 	config: &Configuration,
 	telemetry: Option<TelemetryHandle>,
 	task_manager: &TaskManager,
 ) -> Result<
-	sc_consensus::DefaultImportQueue<
-		Block,
-		TFullClient<Block, contracts_rococo_runtime::RuntimeApi, WasmExecutor<HostFunctions>>,
-	>,
+	sc_consensus::DefaultImportQueue<Block, ParachainClient<contracts_rococo_runtime::RuntimeApi>>,
 	sc_service::Error,
 > {
 	let slot_duration = cumulus_client_consensus_aura::slot_duration(&*client)?;
@@ -1552,7 +1456,7 @@ pub async fn start_contracts_rococo_node(
 	hwbench: Option<sc_sysinfo::HwBench>,
 ) -> sc_service::error::Result<(
 	TaskManager,
-	Arc<TFullClient<Block, contracts_rococo_runtime::RuntimeApi, WasmExecutor<HostFunctions>>>,
+	Arc<ParachainClient<contracts_rococo_runtime::RuntimeApi>>,
 )> {
 	start_contracts_rococo_node_impl::<contracts_rococo_runtime::RuntimeApi, _, _, _>(
 		parachain_config,

--- a/polkadot-parachain/src/service.rs
+++ b/polkadot-parachain/src/service.rs
@@ -18,7 +18,7 @@ use codec::Codec;
 use cumulus_client_cli::CollatorOptions;
 use cumulus_client_consensus_aura::{AuraConsensus, BuildAuraConsensusParams, SlotProportion};
 use cumulus_client_consensus_common::{
-	ParachainBlockImport, ParachainCandidate, ParachainConsensus,
+	ParachainBlockImport as TParachainBlockImport, ParachainCandidate, ParachainConsensus,
 };
 use cumulus_client_network::BlockAnnounceValidator;
 use cumulus_client_service::{
@@ -72,6 +72,8 @@ type HostFunctions =
 type ParachainClient<RuntimeApi> = TFullClient<Block, RuntimeApi, WasmExecutor<HostFunctions>>;
 
 type ParachainBackend = TFullBackend<Block>;
+
+type ParachainBlockImport<RuntimeApi> = TParachainBlockImport<Arc<ParachainClient<RuntimeApi>>>;
 
 /// Native executor instance.
 pub struct ShellRuntimeExecutor;
@@ -162,7 +164,7 @@ pub fn new_partial<RuntimeApi, BIQ>(
 		(),
 		sc_consensus::DefaultImportQueue<Block, ParachainClient<RuntimeApi>>,
 		sc_transaction_pool::FullPool<Block, ParachainClient<RuntimeApi>>,
-		(Option<Telemetry>, Option<TelemetryWorkerHandle>),
+		(ParachainBlockImport<RuntimeApi>, Option<Telemetry>, Option<TelemetryWorkerHandle>),
 	>,
 	sc_service::Error,
 >
@@ -179,6 +181,7 @@ where
 	sc_client_api::StateBackendFor<ParachainBackend, Block>: sp_api::StateBackend<BlakeTwo256>,
 	BIQ: FnOnce(
 		Arc<ParachainClient<RuntimeApi>>,
+		ParachainBlockImport<RuntimeApi>,
 		&Configuration,
 		Option<TelemetryHandle>,
 		&TaskManager,
@@ -229,8 +232,11 @@ where
 		client.clone(),
 	);
 
+	let block_import = ParachainBlockImport::new(client.clone());
+
 	let import_queue = build_import_queue(
 		client.clone(),
+		block_import.clone(),
 		config,
 		telemetry.as_ref().map(|telemetry| telemetry.handle()),
 		&task_manager,
@@ -244,7 +250,7 @@ where
 		task_manager,
 		transaction_pool,
 		select_chain: (),
-		other: (telemetry, telemetry_worker_handle),
+		other: (block_import, telemetry, telemetry_worker_handle),
 	};
 
 	Ok(params)
@@ -279,7 +285,7 @@ async fn start_shell_node_impl<RuntimeApi, RB, BIQ, BIC>(
 	parachain_config: Configuration,
 	polkadot_config: Configuration,
 	collator_options: CollatorOptions,
-	id: ParaId,
+	para_id: ParaId,
 	rpc_ext_builder: RB,
 	build_import_queue: BIQ,
 	build_consensus: BIC,
@@ -298,10 +304,10 @@ where
 		+ cumulus_primitives_core::CollectCollationInfo<Block>,
 	sc_client_api::StateBackendFor<ParachainBackend, Block>: sp_api::StateBackend<BlakeTwo256>,
 	RB: Fn(Arc<ParachainClient<RuntimeApi>>) -> Result<jsonrpsee::RpcModule<()>, sc_service::Error>
-		+ Send
 		+ 'static,
 	BIQ: FnOnce(
 		Arc<ParachainClient<RuntimeApi>>,
+		ParachainBlockImport<RuntimeApi>,
 		&Configuration,
 		Option<TelemetryHandle>,
 		&TaskManager,
@@ -311,6 +317,7 @@ where
 	>,
 	BIC: FnOnce(
 		Arc<ParachainClient<RuntimeApi>>,
+		ParachainBlockImport<RuntimeApi>,
 		Option<&Registry>,
 		Option<TelemetryHandle>,
 		&TaskManager,
@@ -324,7 +331,7 @@ where
 	let parachain_config = prepare_node_config(parachain_config);
 
 	let params = new_partial::<RuntimeApi, BIQ>(&parachain_config, build_import_queue)?;
-	let (mut telemetry, telemetry_worker_handle) = params.other;
+	let (block_import, mut telemetry, telemetry_worker_handle) = params.other;
 
 	let client = params.client.clone();
 	let backend = params.backend.clone();
@@ -345,7 +352,8 @@ where
 		s => s.to_string().into(),
 	})?;
 
-	let block_announce_validator = BlockAnnounceValidator::new(relay_chain_interface.clone(), id);
+	let block_announce_validator =
+		BlockAnnounceValidator::new(relay_chain_interface.clone(), para_id);
 
 	let force_authoring = parachain_config.force_authoring;
 	let validator = parachain_config.role.is_authority();
@@ -405,6 +413,7 @@ where
 	if validator {
 		let parachain_consensus = build_consensus(
 			client.clone(),
+			block_import,
 			prometheus_registry.as_ref(),
 			telemetry.as_ref().map(|t| t.handle()),
 			&task_manager,
@@ -418,7 +427,7 @@ where
 		let spawner = task_manager.spawn_handle();
 
 		let params = StartCollatorParams {
-			para_id: id,
+			para_id,
 			block_status: client.clone(),
 			announce_block,
 			client: client.clone(),
@@ -437,7 +446,7 @@ where
 			client: client.clone(),
 			announce_block,
 			task_manager: &mut task_manager,
-			para_id: id,
+			para_id,
 			relay_chain_interface,
 			relay_chain_slot_duration,
 			import_queue,
@@ -459,7 +468,7 @@ async fn start_node_impl<RuntimeApi, RB, BIQ, BIC>(
 	parachain_config: Configuration,
 	polkadot_config: Configuration,
 	collator_options: CollatorOptions,
-	id: ParaId,
+	para_id: ParaId,
 	_rpc_ext_builder: RB,
 	build_import_queue: BIQ,
 	build_consensus: BIC,
@@ -479,21 +488,20 @@ where
 		+ pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>
 		+ frame_rpc_system::AccountNonceApi<Block, AccountId, Nonce>,
 	sc_client_api::StateBackendFor<ParachainBackend, Block>: sp_api::StateBackend<BlakeTwo256>,
-	RB: Fn(Arc<ParachainClient<RuntimeApi>>) -> Result<jsonrpsee::RpcModule<()>, sc_service::Error>
-		+ Send
-		+ 'static,
+	RB: Fn(Arc<ParachainClient<RuntimeApi>>) -> Result<jsonrpsee::RpcModule<()>, sc_service::Error>,
 	BIQ: FnOnce(
-			Arc<ParachainClient<RuntimeApi>>,
-			&Configuration,
-			Option<TelemetryHandle>,
-			&TaskManager,
-		) -> Result<
-			sc_consensus::DefaultImportQueue<Block, ParachainClient<RuntimeApi>>,
-			sc_service::Error,
-		> + 'static,
-	BIC: FnOnce(
-		ParachainBlockImport,
 		Arc<ParachainClient<RuntimeApi>>,
+		ParachainBlockImport<RuntimeApi>,
+		&Configuration,
+		Option<TelemetryHandle>,
+		&TaskManager,
+	) -> Result<
+		sc_consensus::DefaultImportQueue<Block, ParachainClient<RuntimeApi>>,
+		sc_service::Error,
+	>,
+	BIC: FnOnce(
+		Arc<ParachainClient<RuntimeApi>>,
+		ParachainBlockImport<RuntimeApi>,
 		Option<&Registry>,
 		Option<TelemetryHandle>,
 		&TaskManager,
@@ -507,7 +515,7 @@ where
 	let parachain_config = prepare_node_config(parachain_config);
 
 	let params = new_partial::<RuntimeApi, BIQ>(&parachain_config, build_import_queue)?;
-	let (mut telemetry, telemetry_worker_handle) = params.other;
+	let (block_import, mut telemetry, telemetry_worker_handle) = params.other;
 
 	let client = params.client.clone();
 	let backend = params.backend.clone();
@@ -527,7 +535,8 @@ where
 		s => s.to_string().into(),
 	})?;
 
-	let block_announce_validator = BlockAnnounceValidator::new(relay_chain_interface.clone(), id);
+	let block_announce_validator =
+		BlockAnnounceValidator::new(relay_chain_interface.clone(), para_id);
 
 	let force_authoring = parachain_config.force_authoring;
 	let validator = parachain_config.role.is_authority();
@@ -599,6 +608,7 @@ where
 	if validator {
 		let parachain_consensus = build_consensus(
 			client.clone(),
+			block_import,
 			prometheus_registry.as_ref(),
 			telemetry.as_ref().map(|t| t.handle()),
 			&task_manager,
@@ -612,7 +622,7 @@ where
 		let spawner = task_manager.spawn_handle();
 
 		let params = StartCollatorParams {
-			para_id: id,
+			para_id,
 			block_status: client.clone(),
 			announce_block,
 			client: client.clone(),
@@ -631,7 +641,7 @@ where
 			client: client.clone(),
 			announce_block,
 			task_manager: &mut task_manager,
-			para_id: id,
+			para_id,
 			relay_chain_interface,
 			relay_chain_slot_duration,
 			import_queue,
@@ -648,6 +658,7 @@ where
 /// Build the import queue for the rococo parachain runtime.
 pub fn rococo_parachain_build_import_queue(
 	client: Arc<ParachainClient<rococo_parachain_runtime::RuntimeApi>>,
+	block_import: ParachainBlockImport<rococo_parachain_runtime::RuntimeApi>,
 	config: &Configuration,
 	telemetry: Option<TelemetryHandle>,
 	task_manager: &TaskManager,
@@ -665,7 +676,7 @@ pub fn rococo_parachain_build_import_queue(
 		_,
 		_,
 	>(cumulus_client_consensus_aura::ImportQueueParams {
-		block_import: client.clone(),
+		block_import,
 		client,
 		create_inherent_data_providers: move |_, _| async move {
 			let timestamp = sp_timestamp::InherentDataProvider::from_system_time();
@@ -690,7 +701,7 @@ pub async fn start_rococo_parachain_node(
 	parachain_config: Configuration,
 	polkadot_config: Configuration,
 	collator_options: CollatorOptions,
-	id: ParaId,
+	para_id: ParaId,
 	hwbench: Option<sc_sysinfo::HwBench>,
 ) -> sc_service::error::Result<(
 	TaskManager,
@@ -700,11 +711,11 @@ pub async fn start_rococo_parachain_node(
 		parachain_config,
 		polkadot_config,
 		collator_options,
-		id,
+		para_id,
 		|_| Ok(RpcModule::new(())),
 		rococo_parachain_build_import_queue,
-		|block_import,
-		 client,
+		|client,
+		 block_import,
 		 prometheus_registry,
 		 telemetry,
 		 task_manager,
@@ -735,7 +746,7 @@ pub async fn start_rococo_parachain_node(
 								relay_parent,
 								&relay_chain_interface,
 								&validation_data,
-								id,
+								para_id,
 							).await;
 
 							let timestamp = sp_timestamp::InherentDataProvider::from_system_time();
@@ -755,7 +766,7 @@ pub async fn start_rococo_parachain_node(
 							Ok((slot, timestamp, parachain_inherent))
 						}
 					},
-					block_import: client.clone(),
+					block_import,
 					para_client: client,
 					backoff_authoring_blocks: Option::<()>::None,
 					sync_oracle,
@@ -778,6 +789,7 @@ pub async fn start_rococo_parachain_node(
 /// Build the import queue for the shell runtime.
 pub fn shell_build_import_queue<RuntimeApi>(
 	client: Arc<ParachainClient<RuntimeApi>>,
+	block_import: ParachainBlockImport<RuntimeApi>,
 	config: &Configuration,
 	_: Option<TelemetryHandle>,
 	task_manager: &TaskManager,
@@ -796,7 +808,7 @@ where
 {
 	cumulus_client_consensus_relay_chain::import_queue(
 		client.clone(),
-		client,
+		block_import,
 		|_, _| async { Ok(()) },
 		&task_manager.spawn_essential_handle(),
 		config.prometheus_registry(),
@@ -809,7 +821,7 @@ pub async fn start_shell_node<RuntimeApi>(
 	parachain_config: Configuration,
 	polkadot_config: Configuration,
 	collator_options: CollatorOptions,
-	id: ParaId,
+	para_id: ParaId,
 	hwbench: Option<sc_sysinfo::HwBench>,
 ) -> sc_service::error::Result<(TaskManager, Arc<ParachainClient<RuntimeApi>>)>
 where
@@ -829,10 +841,11 @@ where
 		parachain_config,
 		polkadot_config,
 		collator_options,
-		id,
+		para_id,
 		|_| Ok(RpcModule::new(())),
 		shell_build_import_queue,
 		|client,
+		 block_import,
 		 prometheus_registry,
 		 telemetry,
 		 task_manager,
@@ -843,7 +856,7 @@ where
 		 _| {
 			let proposer_factory = sc_basic_authorship::ProposerFactory::with_proof_recording(
 				task_manager.spawn_handle(),
-				client.clone(),
+				client,
 				transaction_pool,
 				prometheus_registry,
 				telemetry,
@@ -851,9 +864,9 @@ where
 
 			Ok(cumulus_client_consensus_relay_chain::build_relay_chain_consensus(
 				cumulus_client_consensus_relay_chain::BuildRelayChainConsensusParams {
-					para_id: id,
+					para_id,
 					proposer_factory,
-					block_import: client,
+					block_import,
 					relay_chain_interface: relay_chain_interface.clone(),
 					create_inherent_data_providers: move |_, (relay_parent, validation_data)| {
 						let relay_chain_interface = relay_chain_interface.clone();
@@ -863,7 +876,7 @@ where
 								relay_parent,
 								&relay_chain_interface,
 								&validation_data,
-								id,
+								para_id,
 							).await;
 							let parachain_inherent = parachain_inherent.ok_or_else(|| {
 								Box::<dyn std::error::Error + Send + Sync>::from(
@@ -991,6 +1004,7 @@ where
 /// Build the import queue for Statemint and other Aura-based runtimes.
 pub fn aura_build_import_queue<RuntimeApi, AuraId: AppKey>(
 	client: Arc<ParachainClient<RuntimeApi>>,
+	block_import: ParachainBlockImport<RuntimeApi>,
 	config: &Configuration,
 	telemetry_handle: Option<TelemetryHandle>,
 	task_manager: &TaskManager,
@@ -1047,13 +1061,7 @@ where
 	let registry = config.prometheus_registry();
 	let spawner = task_manager.spawn_essential_handle();
 
-	Ok(BasicQueue::new(
-		verifier,
-		Box::new(ParachainBlockImport::new(client)),
-		None,
-		&spawner,
-		registry,
-	))
+	Ok(BasicQueue::new(verifier, Box::new(block_import), None, &spawner, registry))
 }
 
 /// Start an aura powered parachain node.
@@ -1062,7 +1070,7 @@ pub async fn start_generic_aura_node<RuntimeApi, AuraId: AppKey>(
 	parachain_config: Configuration,
 	polkadot_config: Configuration,
 	collator_options: CollatorOptions,
-	id: ParaId,
+	para_id: ParaId,
 	hwbench: Option<sc_sysinfo::HwBench>,
 ) -> sc_service::error::Result<(TaskManager, Arc<ParachainClient<RuntimeApi>>)>
 where
@@ -1087,10 +1095,11 @@ where
 		parachain_config,
 		polkadot_config,
 		collator_options,
-		id,
+		para_id,
 		|_| Ok(RpcModule::new(())),
 		aura_build_import_queue::<_, AuraId>,
 		|client,
+		 block_import,
 		 prometheus_registry,
 		 telemetry,
 		 task_manager,
@@ -1099,8 +1108,9 @@ where
 		 sync_oracle,
 		 keystore,
 		 force_authoring| {
-			let client2 = client.clone();
 			let spawn_handle = task_manager.spawn_handle();
+			let client2 = client.clone();
+			let block_import2 = block_import.clone();
 			let transaction_pool2 = transaction_pool.clone();
 			let telemetry2 = telemetry.clone();
 			let prometheus_registry2 = prometheus_registry.map(|r| (*r).clone());
@@ -1129,7 +1139,7 @@ where
 											relay_parent,
 											&relay_chain_for_aura,
 											&validation_data,
-											id,
+											para_id,
 										).await;
 
 									let timestamp =
@@ -1151,8 +1161,8 @@ where
 									Ok((slot, timestamp, parachain_inherent))
 								}
 							},
-						block_import: client2.clone(),
-						para_client: client2.clone(),
+						block_import: block_import2,
+						para_client: client2,
 						backoff_authoring_blocks: Option::<()>::None,
 						sync_oracle,
 						keystore,
@@ -1178,9 +1188,9 @@ where
 			let relay_chain_consensus =
 				cumulus_client_consensus_relay_chain::build_relay_chain_consensus(
 					cumulus_client_consensus_relay_chain::BuildRelayChainConsensusParams {
-						para_id: id,
+						para_id,
 						proposer_factory,
-						block_import: client.clone(),
+						block_import,
 						relay_chain_interface: relay_chain_interface.clone(),
 						create_inherent_data_providers:
 							move |_, (relay_parent, validation_data)| {
@@ -1191,7 +1201,7 @@ where
 										relay_parent,
 										&relay_chain_interface,
 										&validation_data,
-										id,
+										para_id,
 									).await;
 									let parachain_inherent =
 										parachain_inherent.ok_or_else(|| {
@@ -1224,7 +1234,7 @@ async fn start_contracts_rococo_node_impl<RuntimeApi, RB, BIQ, BIC>(
 	parachain_config: Configuration,
 	polkadot_config: Configuration,
 	collator_options: CollatorOptions,
-	id: ParaId,
+	para_id: ParaId,
 	_rpc_ext_builder: RB,
 	build_import_queue: BIQ,
 	build_consensus: BIC,
@@ -1244,20 +1254,20 @@ where
 		+ pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>
 		+ frame_rpc_system::AccountNonceApi<Block, AccountId, Nonce>,
 	sc_client_api::StateBackendFor<ParachainBackend, Block>: sp_api::StateBackend<BlakeTwo256>,
-	RB: Fn(Arc<ParachainClient<RuntimeApi>>) -> Result<jsonrpsee::RpcModule<()>, sc_service::Error>
-		+ Send
-		+ 'static,
+	RB: Fn(Arc<ParachainClient<RuntimeApi>>) -> Result<jsonrpsee::RpcModule<()>, sc_service::Error>,
 	BIQ: FnOnce(
-			Arc<ParachainClient<RuntimeApi>>,
-			&Configuration,
-			Option<TelemetryHandle>,
-			&TaskManager,
-		) -> Result<
-			sc_consensus::DefaultImportQueue<Block, ParachainClient<RuntimeApi>>,
-			sc_service::Error,
-		> + 'static,
+		Arc<ParachainClient<RuntimeApi>>,
+		ParachainBlockImport<RuntimeApi>,
+		&Configuration,
+		Option<TelemetryHandle>,
+		&TaskManager,
+	) -> Result<
+		sc_consensus::DefaultImportQueue<Block, ParachainClient<RuntimeApi>>,
+		sc_service::Error,
+	>,
 	BIC: FnOnce(
 		Arc<ParachainClient<RuntimeApi>>,
+		ParachainBlockImport<RuntimeApi>,
 		Option<&Registry>,
 		Option<TelemetryHandle>,
 		&TaskManager,
@@ -1271,7 +1281,7 @@ where
 	let parachain_config = prepare_node_config(parachain_config);
 
 	let params = new_partial::<RuntimeApi, BIQ>(&parachain_config, build_import_queue)?;
-	let (mut telemetry, telemetry_worker_handle) = params.other;
+	let (block_import, mut telemetry, telemetry_worker_handle) = params.other;
 
 	let client = params.client.clone();
 	let backend = params.backend.clone();
@@ -1291,7 +1301,8 @@ where
 		s => s.to_string().into(),
 	})?;
 
-	let block_announce_validator = BlockAnnounceValidator::new(relay_chain_interface.clone(), id);
+	let block_announce_validator =
+		BlockAnnounceValidator::new(relay_chain_interface.clone(), para_id);
 
 	let force_authoring = parachain_config.force_authoring;
 	let validator = parachain_config.role.is_authority();
@@ -1363,6 +1374,7 @@ where
 	if validator {
 		let parachain_consensus = build_consensus(
 			client.clone(),
+			block_import,
 			prometheus_registry.as_ref(),
 			telemetry.as_ref().map(|t| t.handle()),
 			&task_manager,
@@ -1376,7 +1388,7 @@ where
 		let spawner = task_manager.spawn_handle();
 
 		let params = StartCollatorParams {
-			para_id: id,
+			para_id,
 			block_status: client.clone(),
 			announce_block,
 			client: client.clone(),
@@ -1395,7 +1407,7 @@ where
 			client: client.clone(),
 			announce_block,
 			task_manager: &mut task_manager,
-			para_id: id,
+			para_id,
 			relay_chain_interface,
 			relay_chain_slot_duration,
 			import_queue,
@@ -1412,6 +1424,7 @@ where
 #[allow(clippy::type_complexity)]
 pub fn contracts_rococo_build_import_queue(
 	client: Arc<ParachainClient<contracts_rococo_runtime::RuntimeApi>>,
+	block_import: ParachainBlockImport<contracts_rococo_runtime::RuntimeApi>,
 	config: &Configuration,
 	telemetry: Option<TelemetryHandle>,
 	task_manager: &TaskManager,
@@ -1421,6 +1434,7 @@ pub fn contracts_rococo_build_import_queue(
 > {
 	let slot_duration = cumulus_client_consensus_aura::slot_duration(&*client)?;
 
+	// TODO: check out how this is different from the direct relay chain import...
 	cumulus_client_consensus_aura::import_queue::<
 		sp_consensus_aura::sr25519::AuthorityPair,
 		_,
@@ -1429,7 +1443,7 @@ pub fn contracts_rococo_build_import_queue(
 		_,
 		_,
 	>(cumulus_client_consensus_aura::ImportQueueParams {
-		block_import: client.clone(),
+		block_import,
 		client,
 		create_inherent_data_providers: move |_, _| async move {
 			let timestamp = sp_timestamp::InherentDataProvider::from_system_time();
@@ -1454,7 +1468,7 @@ pub async fn start_contracts_rococo_node(
 	parachain_config: Configuration,
 	polkadot_config: Configuration,
 	collator_options: CollatorOptions,
-	id: ParaId,
+	para_id: ParaId,
 	hwbench: Option<sc_sysinfo::HwBench>,
 ) -> sc_service::error::Result<(
 	TaskManager,
@@ -1464,10 +1478,11 @@ pub async fn start_contracts_rococo_node(
 		parachain_config,
 		polkadot_config,
 		collator_options,
-		id,
+		para_id,
 		|_| Ok(RpcModule::new(())),
 		contracts_rococo_build_import_queue,
 		|client,
+		 block_import,
 		 prometheus_registry,
 		 telemetry,
 		 task_manager,
@@ -1497,7 +1512,7 @@ pub async fn start_contracts_rococo_node(
 									relay_parent,
 									&relay_chain_interface,
 									&validation_data,
-									id,
+									para_id,
 								).await;
 
 							let timestamp = sp_timestamp::InherentDataProvider::from_system_time();
@@ -1517,7 +1532,7 @@ pub async fn start_contracts_rococo_node(
 							Ok((slot, timestamp, parachain_inherent))
 						}
 					},
-					block_import: client.clone(),
+					block_import,
 					para_client: client,
 					backoff_authoring_blocks: Option::<()>::None,
 					sync_oracle,

--- a/polkadot-parachain/src/service.rs
+++ b/polkadot-parachain/src/service.rs
@@ -1434,7 +1434,6 @@ pub fn contracts_rococo_build_import_queue(
 > {
 	let slot_duration = cumulus_client_consensus_aura::slot_duration(&*client)?;
 
-	// TODO: check out how this is different from the direct relay chain import...
 	cumulus_client_consensus_aura::import_queue::<
 		sp_consensus_aura::sr25519::AuthorityPair,
 		_,

--- a/primitives/parachain-inherent/src/mock.rs
+++ b/primitives/parachain-inherent/src/mock.rs
@@ -20,7 +20,6 @@ use cumulus_primitives_core::{
 	relay_chain, InboundDownwardMessage, InboundHrmpMessage, ParaId, PersistedValidationData,
 };
 use sc_client_api::{Backend, StorageProvider};
-use sp_api::BlockId;
 use sp_core::twox_128;
 use sp_inherents::{InherentData, InherentDataProvider};
 use sp_runtime::traits::Block;
@@ -116,7 +115,7 @@ impl MockXcmConfig {
 	) -> Self {
 		let starting_dmq_mqc_head = client
 			.storage(
-				&BlockId::Hash(parent_block),
+				&parent_block,
 				&sp_storage::StorageKey(
 					[twox_128(&parachain_system_name.0), twox_128(b"LastDmqMqcHead")]
 						.concat()
@@ -131,7 +130,7 @@ impl MockXcmConfig {
 
 		let starting_hrmp_mqc_heads = client
 			.storage(
-				&BlockId::Hash(parent_block),
+				&parent_block,
 				&sp_storage::StorageKey(
 					[twox_128(&parachain_system_name.0), twox_128(b"LastHrmpMqcHeads")]
 						.concat()


### PR DESCRIPTION
This PR allows to share a single `ParachainBlockImport` instance between the import queue and authoring engine, thus to have a shared state between the two components.

The implementation roughly follows the same design already used by Substrate node components.

---

The feature will be immediately used by https://github.com/paritytech/cumulus/pull/1559