### PR TITLE
Companion for aura CompatibilityMode

### DIFF
--- a/client/consensus/aura/src/import_queue.rs
+++ b/client/consensus/aura/src/import_queue.rs
@@ -20,7 +20,7 @@ use codec::Codec;
 use cumulus_client_consensus_common::ParachainBlockImport;
 use sc_client_api::{backend::AuxStore, BlockOf, UsageProvider};
 use sc_consensus::{import_queue::DefaultImportQueue, BlockImport};
-use sc_consensus_aura::AuraVerifier;
+use sc_consensus_aura::{AuraVerifier, CompatibilityMode};
 use sc_consensus_slots::InherentDataProviderExt;
 use sc_telemetry::TelemetryHandle;
 use sp_api::{ApiExt, ProvideRuntimeApi};
@@ -92,6 +92,7 @@ where
 		registry,
 		check_for_equivocation: sc_consensus_aura::CheckForEquivocation::No,
 		telemetry,
+		compatibility_mode: CompatibilityMode::None,
 	})
 }
 
@@ -106,16 +107,17 @@ pub struct BuildVerifierParams<C, CIDP> {
 }
 
 /// Build the [`AuraVerifier`].
-pub fn build_verifier<P, C, CIDP>(
+pub fn build_verifier<P, C, CIDP, N>(
 	BuildVerifierParams { client, create_inherent_data_providers, telemetry }: BuildVerifierParams<
 		C,
 		CIDP,
 	>,
-) -> AuraVerifier<C, P, CIDP> {
+) -> AuraVerifier<C, P, CIDP, N> {
 	sc_consensus_aura::build_verifier(sc_consensus_aura::BuildVerifierParams {
 		client,
 		create_inherent_data_providers,
 		telemetry,
 		check_for_equivocation: sc_consensus_aura::CheckForEquivocation::No,
+		compatibility_mode: CompatibilityMode::None,
 	})
 }

--- a/client/consensus/aura/src/lib.rs
+++ b/client/consensus/aura/src/lib.rs
@@ -143,6 +143,7 @@ where
 				telemetry,
 				block_proposal_slot_portion,
 				max_block_proposal_slot_portion,
+				compatibility_mode: sc_consensus_aura::CompatibilityMode::None,
 			},
 		);
 

--- a/polkadot-parachain/src/service.rs
+++ b/polkadot-parachain/src/service.rs
@@ -1029,7 +1029,7 @@ where
 	let aura_verifier = move || {
 		let slot_duration = cumulus_client_consensus_aura::slot_duration(&*client2).unwrap();
 
-		Box::new(cumulus_client_consensus_aura::build_verifier::<<AuraId as AppKey>::Pair, _, _>(
+		Box::new(cumulus_client_consensus_aura::build_verifier::<<AuraId as AppKey>::Pair, _, _, _>(
 			cumulus_client_consensus_aura::BuildVerifierParams {
 				client: client2.clone(),
 				create_inherent_data_providers: move |_, _| async move {


### PR DESCRIPTION
As no parachain was launched with the broken authority set change handling we don't need to expose the compatibility mode.