### PR TITLE
Enable Docker section in the release notes

### DIFF
--- a/scripts/ci/changelog/templates/docker_image.md.tera
+++ b/scripts/ci/changelog/templates/docker_image.md.tera
@@ -1,11 +1,11 @@
-<!--
+
 ## Docker images
 
 The docker image for this release can be found in [Docker hub](https://hub.docker.com/r/parity/polkadot-parachain/tags?page=1&ordering=last_updated).
+(It will be available a few minutes after the release has been published).
 
 You may also pull it with:
 
 ```
 docker pull parity/polkadot-parachain:latest
 ```
--->

--- a/scripts/ci/changelog/templates/template.md.tera
+++ b/scripts/ci/changelog/templates/template.md.tera
@@ -32,4 +32,7 @@ This release contains the changes from `{{ env.REF1 }}` to `{{ env.REF2 }}`.
 {% endif %}
 
 {% include "changes.md.tera" -%}
+
+{% if env.RELEASE_TYPE and env.RELEASE_TYPE == "client" -%}
 {% include "docker_image.md.tera" -%}
+{% endif %}


### PR DESCRIPTION
The Docker section was already in the reklease notes but it was not visible by default and also not restricted to the client releases.

This PR enables the docker section in the release notes, for the client releases only.