### PR TITLE
Add Offchain Worker to Parachain Config by Default

### DIFF
--- a/parachain-template/node/src/service.rs
+++ b/parachain-template/node/src/service.rs
@@ -210,6 +210,15 @@ async fn start_node_impl(
 			warp_sync: None,
 		})?;
 
+	if parachain_config.offchain_worker.enabled {
+		sc_service::build_offchain_workers(
+			&parachain_config,
+			task_manager.spawn_handle(),
+			client.clone(),
+			network.clone(),
+		);
+	}
+
 	let rpc_builder = {
 		let client = client.clone();
 		let transaction_pool = transaction_pool.clone();


### PR DESCRIPTION
See relevant [StackExchange](https://substrate.stackexchange.com/questions/5726/offchain-worker-not-initializing-cumulus-parachain-template) question.

We were developing on the Substrate Parachain Template, and couldn't figure out why offchain workers were not initializing. From my POV, this should be enabled here, just as it is on the Substrate Node Template. Opening up a PR to save others time in the future and prevent them from running into a similar issue.