### PR TITLE
Safer blocks removal on ParachainBlockImport level overflow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1588,6 +1588,7 @@ dependencies = [
  "polkadot-primitives",
  "sc-client-api",
  "sc-consensus",
+ "sc-service",
  "sp-blockchain",
  "sp-consensus",
  "sp-runtime",

--- a/client/consensus/common/Cargo.toml
+++ b/client/consensus/common/Cargo.toml
@@ -16,6 +16,7 @@ tracing = "0.1.37"
 # Substrate
 sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sc-consensus = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-service = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sp-consensus = { git = "https://github.com/paritytech/substrate", branch = "master" }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "master" }

--- a/client/consensus/common/src/level_monitor.rs
+++ b/client/consensus/common/src/level_monitor.rs
@@ -204,7 +204,10 @@ where
 
 		let level = self.levels.get(&number)?;
 
-		for blk_hash in level.iter().filter(|hash| **hash != best_hash) {
+		for blk_hash in level
+			.iter()
+			.filter(|hash| **hash != best_hash && self.freshness.get(*hash) != Some(&0u32.into()))
+		{
 			// Search for the fresher leaf information for this block
 			let candidate_info = leaves
 				.iter()

--- a/polkadot-parachain/src/service.rs
+++ b/polkadot-parachain/src/service.rs
@@ -536,6 +536,12 @@ where
 		s => s.to_string().into(),
 	})?;
 
+	block_import.spawn_relay_chain_observer(
+		relay_chain_interface.clone(),
+		para_id,
+		task_manager.spawn_handle(),
+	);
+
 	let block_announce_validator =
 		BlockAnnounceValidator::new(relay_chain_interface.clone(), para_id);
 


### PR DESCRIPTION
**This PR is still a draft and has been opened to share some ideas about a safer way to remove outstanding parachain blocks that are suspected to be stale.**

---

The parachain block import is supported by an asynchronous task that listens to the Relay Chain imported block in order to gain the status of its outstanding parablocks.

The blocks that are known to be available on the relaychain are marked (*somehow*) in order to prevent their removal during the monitor removal procedure.

---

The target branch has been temporary set to the opened https://github.com/paritytech/cumulus/pull/1559 to better highlight the extension

---

The improvement is not hard *per se* but I'm currently trying to figure out what where is the best place to fetch this info from the relay chain wrt code design.

---

### Strategy

We want to somehow "mark" the blocks that are already "available" on the relay chain.

To do this we are going to:
1. listen to the `RelayChainInterface::import_notification_stream` messages
2. for each relay chain imported block I'm going to call `RelayChainInterface::persisted_validation_data(hash: RelayHash, para_id: ParaId)`

With this I should be able to get the parachain header associated with that relay chain `hash`:

```
https://github.com/paritytech/cumulus/blob/981b5d01eb5d0aab0926793e00a7fb933680cf34/client/network/src/lib.rs#L238-L259
```

Then I'm going to take the hash of this para-header and *somehow* mark the corresponding entry in the monitor cache as "available" (this is to prevent removal).

---

### Open Question

I currently have a task that listens to the relay chain import updates coming from `RelayChain::import_notification_stream`. 

One way is to spawn this task silently when I instance the `ParachainBlockImport`...
In this case I'll also need to pass some extra stuff to the constructor such as the task manager.

But currently I've exposed a public method to start it explicitly (indeed it may be an optional and undesired feature, since somehow adds some extra work in the para node).

I don't know if this is actually the "best" design for the job or if is better to spawn in the constructor directly...

I always imagined the block import more as a *"soul-less"* component used by some other subsystem
(i.e. queue or authoring) and not something that silently spawns a task :-D 
