### PR TITLE
Explicit recovery for announced candidate blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1578,6 +1578,7 @@ name = "cumulus-client-consensus-common"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "cumulus-primitives-core",
  "cumulus-relay-chain-interface",
  "cumulus-test-client",
  "dyn-clone",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1690,6 +1690,7 @@ dependencies = [
  "cumulus-client-pov-recovery",
  "cumulus-primitives-core",
  "cumulus-relay-chain-interface",
+ "futures",
  "parking_lot 0.12.1",
  "polkadot-primitives",
  "sc-client-api",

--- a/client/consensus/common/Cargo.toml
+++ b/client/consensus/common/Cargo.toml
@@ -25,6 +25,7 @@ sp-trie = { git = "https://github.com/paritytech/substrate", branch = "master" }
 polkadot-primitives = { git = "https://github.com/paritytech/polkadot", branch = "master" }
 
 # Cumulus
+cumulus-primitives-core = { path = "../../../primitives/core" }
 cumulus-relay-chain-interface = { path = "../../relay-chain-interface" }
 
 [dev-dependencies]

--- a/client/consensus/common/src/tests.rs
+++ b/client/consensus/common/src/tests.rs
@@ -120,15 +120,10 @@ fn build_block<B: InitBlockBuilder>(
 
 	let mut block = builder.build().unwrap().block;
 
-	// Simulate some form of post activity.
+	// Simulate some form of post activity (like a Seal or Other generic things).
 	// This is mostly used to excercise the `LevelMonitor` correct behavior.
 	// (in practice we want that header post-hash != pre-hash)
-	let post_digest = sp_runtime::DigestItem::Other(vec![1, 2, 3]);
-
-	// In order to get a header hash compatible with block import params containing some
-	// form of `post_digest`, we need to manually push the post digest within the header
-	// digest logs.
-	block.header.digest.push(post_digest);
+	block.header.digest.push(sp_runtime::DigestItem::Other(vec![1, 2, 3]));
 
 	block
 }

--- a/client/pov-recovery/src/active_candidate_recovery.rs
+++ b/client/pov-recovery/src/active_candidate_recovery.rs
@@ -42,19 +42,19 @@ impl<Block: BlockT> ActiveCandidateRecovery<Block> {
 		Self { recoveries: Default::default(), candidates: Default::default(), overseer_handle }
 	}
 
-	/// Recover the given `pending_candidate`.
+	/// Recover the given `candidate`.
 	pub async fn recover_candidate(
 		&mut self,
 		block_hash: Block::Hash,
-		pending_candidate: crate::PendingCandidate<Block>,
+		candidate: &crate::Candidate<Block>,
 	) {
 		let (tx, rx) = oneshot::channel();
 
 		self.overseer_handle
 			.send_msg(
 				AvailabilityRecoveryMessage::RecoverAvailableData(
-					pending_candidate.receipt,
-					pending_candidate.session_index,
+					candidate.receipt.clone(),
+					candidate.session_index,
 					None,
 					tx,
 				),

--- a/client/pov-recovery/src/lib.rs
+++ b/client/pov-recovery/src/lib.rs
@@ -362,7 +362,7 @@ where
 			let candidate = match self.candidates.get_mut(&hash) {
 				Some(candidate) => candidate,
 				None => {
-					tracing::error!(
+					tracing::debug!(
 						target: LOG_TARGET,
 						block_hash = ?hash,
 						"Cound not recover. Block was never announced as candidate"

--- a/client/pov-recovery/src/lib.rs
+++ b/client/pov-recovery/src/lib.rs
@@ -367,7 +367,7 @@ where
 					tracing::error!(
 						target: LOG_TARGET,
 						block_hash = ?hash,
-						"Cound not recover, block has never been announced as a candidate"
+						"Cound not recover. Block was never announced as candidate"
 					);
 					break false
 				},

--- a/client/pov-recovery/src/lib.rs
+++ b/client/pov-recovery/src/lib.rs
@@ -360,7 +360,7 @@ where
 
 		let do_recover = loop {
 			let candidate = match self.candidates.get_mut(&hash) {
-				Some(candidate) if !candidate.waiting_recovery => candidate,
+				Some(candidate) => candidate,
 				None => {
 					tracing::error!(
 						target: LOG_TARGET,
@@ -369,12 +369,10 @@ where
 					);
 					break false
 				},
-				// Recovery already in progress
-				_ => break false,
 			};
 
 			match self.parachain_client.block_status(&BlockId::Hash(hash)) {
-				Ok(BlockStatus::Unknown) => {
+				Ok(BlockStatus::Unknown) if !candidate.waiting_recovery => {
 					candidate.waiting_recovery = true;
 					to_recover.push(hash);
 				},

--- a/client/service/Cargo.toml
+++ b/client/service/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 
 [dependencies]
 parking_lot = "0.12.1"
+futures = "0.3.24"
 
 # Substrate
 sc-client-api = { git = "https://github.com/paritytech/substrate", branch = "master" }

--- a/client/service/src/lib.rs
+++ b/client/service/src/lib.rs
@@ -110,7 +110,7 @@ where
 		client.clone(),
 		relay_chain_interface.clone(),
 		announce_block.clone(),
-		recovery_chan_tx,
+		Some(recovery_chan_tx),
 	);
 
 	task_manager
@@ -198,7 +198,7 @@ where
 		client.clone(),
 		relay_chain_interface.clone(),
 		announce_block,
-		recovery_chan_tx,
+		Some(recovery_chan_tx),
 	);
 
 	task_manager

--- a/client/service/src/lib.rs
+++ b/client/service/src/lib.rs
@@ -19,7 +19,7 @@
 //! Provides functions for starting a collator node or a normal full node.
 
 use cumulus_client_consensus_common::ParachainConsensus;
-use cumulus_primitives_core::{CollectCollationInfo, ParaId};
+use cumulus_primitives_core::{CollectCollationInfo, ParaId, RecoveryDelay};
 use cumulus_relay_chain_interface::RelayChainInterface;
 use polkadot_primitives::v2::CollatorPair;
 
@@ -125,7 +125,7 @@ where
 		overseer_handle.clone(),
 		// We want that collators wait at maximum the relay chain slot duration before starting
 		// to recover blocks.
-		cumulus_client_pov_recovery::RecoveryDelay::WithMax { max: relay_chain_slot_duration },
+		RecoveryDelay { min: core::time::Duration::ZERO, max: relay_chain_slot_duration },
 		client.clone(),
 		import_queue,
 		relay_chain_interface.clone(),
@@ -216,10 +216,7 @@ where
 		// the recovery way before full nodes try to recover a certain block and then share the
 		// block with the network using "the normal way". Full nodes are just the "last resort"
 		// for block recovery.
-		cumulus_client_pov_recovery::RecoveryDelay::WithMinAndMax {
-			min: relay_chain_slot_duration * 25,
-			max: relay_chain_slot_duration * 50,
-		},
+		RecoveryDelay { min: relay_chain_slot_duration * 25, max: relay_chain_slot_duration * 50 },
 		client,
 		import_queue,
 		relay_chain_interface,

--- a/client/service/src/lib.rs
+++ b/client/service/src/lib.rs
@@ -191,7 +191,8 @@ where
 	RCInterface: RelayChainInterface + Clone + 'static,
 	IQ: ImportQueue<Block> + 'static,
 {
-	let (recovery_chan_tx, recovery_chan_rx) = mpsc::channel(64);
+	let (recovery_chan_tx, recovery_chan_rx) = mpsc::channel(RECOVERY_CHAN_SIZE);
+
 	let consensus = cumulus_client_consensus_common::run_parachain_consensus(
 		para_id,
 		client.clone(),

--- a/primitives/core/src/lib.rs
+++ b/primitives/core/src/lib.rs
@@ -217,12 +217,12 @@ pub struct RecoveryRequest<Block: BlockT> {
 	pub kind: RecoveryKind,
 }
 
-/// The delay between observing an unknown block and recovering this block.
+/// The delay between observing an unknown block and triggering the recovery of a block.
 #[derive(Clone, Copy)]
 pub struct RecoveryDelay {
-	/// Start recovering the block after at least `min` delay.
+	/// Start recovering after `min` delay.
 	pub min: Duration,
-	/// Start recovering the block in maximum of the given delay.
+	/// Start recovering before `max` delay.
 	pub max: Duration,
 }
 

--- a/primitives/core/src/lib.rs
+++ b/primitives/core/src/lib.rs
@@ -196,7 +196,7 @@ impl<B: BlockT> ParachainBlockData<B> {
 }
 
 /// Type of recovery to trigger.
-#[derive(PartialEq)]
+#[derive(Debug, PartialEq)]
 pub enum RecoveryKind {
 	/// Single block recovery.
 	Simple,


### PR DESCRIPTION
This PR augments https://github.com/paritytech/cumulus/pull/1559 with block recovery via PoV.

(target branch has been set to https://github.com/paritytech/cumulus/pull/1559 branch in order to better highlight the diff and have a more  focused conversation)

---

A recovery channel end is passed to the parachain consensus worker and it is used to trigger/stimulate block recovery whenever the best parachain block is not locally present yet.

The rx side of the channel can be whatever and not strictly necessarily the PoV recovery mechanism.

This code is very unlikely from being triggered in practice. But better safe than sorry.

---

The tests were not aligned yet to some  of the new interfaces, so CI failure is expected.  Feedback first :-) 