### PR TITLE
Allow try-runtime for contracts-rococo

### DIFF
--- a/polkadot-parachain/src/command.rs
+++ b/polkadot-parachain/src/command.rs
@@ -628,7 +628,7 @@ pub fn run() -> Result<()> {
 				}),
 				Runtime::ContractsRococo => runner.async_run(|config| {
 					Ok((
-						cmd.run::<Block, crates::service::ContractsRococoRuntimeExecutor>(config),
+						cmd.run::<Block, crate::service::ContractsRococoRuntimeExecutor>(config),
 						task_manager,
 					))
 				}),

--- a/polkadot-parachain/src/command.rs
+++ b/polkadot-parachain/src/command.rs
@@ -626,6 +626,12 @@ pub fn run() -> Result<()> {
 						task_manager,
 					))
 				}),
+				Runtime::ContractsRococo => runner.async_run(|config| {
+					Ok((
+						cmd.run::<Block, crates::service::ContractsRococoRuntimeExecutor>(config),
+						task_manager,
+					))
+				}),
 				_ => Err("Chain doesn't support try-runtime".into()),
 			}
 		},

--- a/polkadot-parachain/src/service.rs
+++ b/polkadot-parachain/src/service.rs
@@ -150,6 +150,21 @@ impl sc_executor::NativeExecutionDispatch for CollectivesPolkadotRuntimeExecutor
 	}
 }
 
+// Native contracts executor instance.
+pub struct ContractsRococoRuntimeExecutor;
+
+impl sc_executor::NativeExecutionDispatch for ContractsRococoRuntimeExecutor {
+	type ExtendHostFunctions = frame_benchmarking::benchmarking::HostFunctions;
+
+	fn dispatch(method: &str, data: &[u8]) -> Option<Vec<u8>> {
+		contracts_rococo_runtime::api::dispatch(method, data)
+	}
+
+	fn native_version() -> sc_executor::NativeVersion {
+		contracts_rococo_runtime::native_version()
+	}
+}
+
 /// Starts a `ServiceBuilder` for a full service.
 ///
 /// Use this macro if you don't actually need the full service, but just the builder in order to


### PR DESCRIPTION
We forgot to add contract to the `try-runtime` CLI.