### PR TITLE
Remove `parity-util-mem`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,7 +450,7 @@ dependencies = [
 [[package]]
 name = "beefy-gadget"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "array-bytes 4.2.0",
  "async-trait",
@@ -487,7 +487,7 @@ dependencies = [
 [[package]]
 name = "beefy-gadget-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "beefy-gadget",
  "futures",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "beefy-merkle-tree"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "sp-api",
  "sp-beefy",
@@ -2938,7 +2938,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -2961,7 +2961,7 @@ checksum = "85dcb89d2b10c5f6133de2efd8c11959ce9dbb46a2f7a4cab208c4eeda6ce1ab"
 [[package]]
 name = "frame-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2984,7 +2984,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "Inflector",
  "array-bytes 4.2.0",
@@ -3036,7 +3036,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -3047,7 +3047,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -3063,7 +3063,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3092,7 +3092,7 @@ dependencies = [
 [[package]]
 name = "frame-remote-externalities"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "env_logger 0.9.0",
  "log",
@@ -3109,7 +3109,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "bitflags",
  "frame-metadata",
@@ -3141,7 +3141,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -3155,7 +3155,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -3167,7 +3167,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3177,7 +3177,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "frame-support",
  "log",
@@ -3195,7 +3195,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3210,7 +3210,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -3219,7 +3219,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4117,7 +4117,7 @@ checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 [[package]]
 name = "kusama-runtime"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -4214,7 +4214,7 @@ dependencies = [
 [[package]]
 name = "kusama-runtime-constants"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -4234,35 +4234,31 @@ dependencies = [
 
 [[package]]
 name = "kvdb"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585089ceadba0197ffe9af6740ab350b325e3c1f5fccfbc3522e0250c750409b"
+checksum = "e7d770dcb02bf6835887c3a979b5107a04ff4bbde97a5f0928d27404a155add9"
 dependencies = [
- "parity-util-mem",
  "smallvec",
 ]
 
 [[package]]
 name = "kvdb-memorydb"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40d109c87bfb7759edd2a49b2649c1afe25af785d930ad6a38479b4dc70dd873"
+checksum = "bf7a85fe66f9ff9cd74e169fdd2c94c6e1e74c412c99a73b4df3200b5d3760b2"
 dependencies = [
  "kvdb",
- "parity-util-mem",
  "parking_lot 0.12.1",
 ]
 
 [[package]]
 name = "kvdb-rocksdb"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c076cc2cdbac89b9910c853a36c957d3862a779f31c2661174222cefb49ee597"
+checksum = "2182b8219fee6bd83aacaab7344e840179ae079d5216aa4e249b4d704646a844"
 dependencies = [
  "kvdb",
- "log",
  "num_cpus",
- "parity-util-mem",
  "parking_lot 0.12.1",
  "regex",
  "rocksdb",
@@ -4892,13 +4888,12 @@ dependencies = [
 
 [[package]]
 name = "memory-db"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ac11bb793c28fa095b7554466f53b3a60a2cd002afdac01bcf135cbd73a269"
+checksum = "5e0c7cba9ce19ac7ffd2053ac9f49843bbd3f4318feedfd74e85c19d5fb0ba66"
 dependencies = [
  "hash-db",
  "hashbrown",
- "parity-util-mem",
 ]
 
 [[package]]
@@ -4961,7 +4956,7 @@ dependencies = [
 [[package]]
 name = "mmr-gadget"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "futures",
  "log",
@@ -4981,7 +4976,7 @@ dependencies = [
 [[package]]
 name = "mmr-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "anyhow",
  "jsonrpsee",
@@ -5501,7 +5496,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5517,7 +5512,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5532,7 +5527,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5556,7 +5551,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5576,7 +5571,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5591,7 +5586,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5607,7 +5602,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "array-bytes 4.2.0",
  "beefy-merkle-tree",
@@ -5630,7 +5625,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5648,7 +5643,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5692,7 +5687,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5760,7 +5755,7 @@ dependencies = [
 [[package]]
 name = "pallet-conviction-voting"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -5777,7 +5772,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5795,7 +5790,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5819,7 +5814,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5832,7 +5827,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "5.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5850,7 +5845,7 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -5868,7 +5863,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5891,7 +5886,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -5907,7 +5902,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5927,7 +5922,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5944,7 +5939,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5961,7 +5956,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5978,7 +5973,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5994,7 +5989,7 @@ dependencies = [
 [[package]]
 name = "pallet-nis"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6010,7 +6005,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6027,7 +6022,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6047,7 +6042,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
 version = "1.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6057,7 +6052,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6074,7 +6069,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6097,7 +6092,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6114,7 +6109,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6143,7 +6138,7 @@ dependencies = [
 [[package]]
 name = "pallet-ranked-collective"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6161,7 +6156,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6176,7 +6171,7 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -6194,7 +6189,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6210,7 +6205,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6231,7 +6226,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6247,7 +6242,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6261,7 +6256,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6284,7 +6279,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -6295,7 +6290,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -6304,7 +6299,7 @@ dependencies = [
 [[package]]
 name = "pallet-state-trie-migration"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6321,7 +6316,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6350,7 +6345,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6368,7 +6363,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6387,7 +6382,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6403,7 +6398,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -6419,7 +6414,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -6431,7 +6426,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6463,7 +6458,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6479,7 +6474,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6494,7 +6489,7 @@ dependencies = [
 [[package]]
 name = "pallet-whitelist"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6509,7 +6504,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6527,7 +6522,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-benchmarks"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6744,33 +6739,6 @@ name = "parity-send-wrapper"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9777aa91b8ad9dd5aaa04a9b6bcb02c7f1deb952fca5a66034d5e63afc5c6f"
-
-[[package]]
-name = "parity-util-mem"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d32c34f4f5ca7f9196001c0aba5a1f9a5a12382c8944b8b0f90233282d1e8f8"
-dependencies = [
- "cfg-if",
- "hashbrown",
- "impl-trait-for-tuples",
- "parity-util-mem-derive",
- "parking_lot 0.12.1",
- "primitive-types",
- "smallvec",
- "winapi",
-]
-
-[[package]]
-name = "parity-util-mem-derive"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f557c32c6d268a07c921471619c0295f5efad3a0e76d4f97a05c091a51d110b2"
-dependencies = [
- "proc-macro2",
- "syn",
- "synstructure",
-]
 
 [[package]]
 name = "parity-wasm"
@@ -7071,7 +7039,7 @@ dependencies = [
 [[package]]
 name = "polkadot-approval-distribution"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "futures",
  "polkadot-node-network-protocol",
@@ -7086,7 +7054,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "futures",
  "polkadot-node-network-protocol",
@@ -7100,7 +7068,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-distribution"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "derive_more",
  "fatality",
@@ -7123,7 +7091,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-recovery"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "fatality",
  "futures",
@@ -7144,7 +7112,7 @@ dependencies = [
 [[package]]
 name = "polkadot-cli"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "clap 4.0.29",
  "frame-benchmarking-cli",
@@ -7161,7 +7129,6 @@ dependencies = [
  "sc-tracing",
  "sp-core",
  "sp-keyring",
- "sp-trie",
  "substrate-build-script-utils",
  "thiserror",
  "try-runtime-cli",
@@ -7170,7 +7137,7 @@ dependencies = [
 [[package]]
 name = "polkadot-client"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -7213,7 +7180,7 @@ dependencies = [
 [[package]]
 name = "polkadot-collator-protocol"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "always-assert",
  "bitvec",
@@ -7235,10 +7202,9 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "parity-scale-codec",
- "parity-util-mem",
  "scale-info",
  "sp-core",
  "sp-runtime",
@@ -7248,7 +7214,7 @@ dependencies = [
 [[package]]
 name = "polkadot-dispute-distribution"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "derive_more",
  "fatality",
@@ -7273,7 +7239,7 @@ dependencies = [
 [[package]]
 name = "polkadot-erasure-coding"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -7287,7 +7253,7 @@ dependencies = [
 [[package]]
 name = "polkadot-gossip-support"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "futures",
  "futures-timer",
@@ -7307,7 +7273,7 @@ dependencies = [
 [[package]]
 name = "polkadot-network-bridge"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "always-assert",
  "async-trait",
@@ -7331,7 +7297,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-collation-generation"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -7349,7 +7315,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "bitvec",
  "derive_more",
@@ -7378,7 +7344,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-av-store"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "bitvec",
  "futures",
@@ -7398,7 +7364,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-backing"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "bitvec",
  "fatality",
@@ -7417,7 +7383,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
@@ -7432,7 +7398,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-candidate-validation"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "async-trait",
  "futures",
@@ -7451,7 +7417,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-api"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
@@ -7466,7 +7432,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-selection"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "futures",
  "futures-timer",
@@ -7483,7 +7449,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "fatality",
  "futures",
@@ -7502,7 +7468,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "async-trait",
  "futures",
@@ -7520,7 +7486,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-provisioner"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "bitvec",
  "fatality",
@@ -7538,7 +7504,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "always-assert",
  "assert_matches",
@@ -7571,7 +7537,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-checker"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "futures",
  "polkadot-node-primitives",
@@ -7587,7 +7553,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-runtime-api"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "futures",
  "lru",
@@ -7602,7 +7568,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-jaeger"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "lazy_static",
  "log",
@@ -7620,7 +7586,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-metrics"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "bs58",
  "futures",
@@ -7639,7 +7605,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -7662,7 +7628,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "bounded-vec",
  "futures",
@@ -7684,7 +7650,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "polkadot-node-jaeger",
  "polkadot-node-subsystem-types",
@@ -7694,7 +7660,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-test-helpers"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "async-trait",
  "futures",
@@ -7712,7 +7678,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-types"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -7735,7 +7701,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-util"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -7746,7 +7712,6 @@ dependencies = [
  "lru",
  "parity-db",
  "parity-scale-codec",
- "parity-util-mem",
  "parking_lot 0.11.2",
  "pin-project",
  "polkadot-node-jaeger",
@@ -7768,14 +7733,13 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "async-trait",
  "futures",
  "futures-timer",
  "lru",
  "orchestra",
- "parity-util-mem",
  "parking_lot 0.12.1",
  "polkadot-node-metrics",
  "polkadot-node-network-protocol",
@@ -7785,18 +7749,18 @@ dependencies = [
  "sc-client-api",
  "sp-api",
  "sp-core",
+ "tikv-jemalloc-ctl",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-parachain"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "derive_more",
  "frame-support",
  "parity-scale-codec",
- "parity-util-mem",
  "polkadot-core-primitives",
  "scale-info",
  "serde",
@@ -7892,7 +7856,7 @@ dependencies = [
 [[package]]
 name = "polkadot-performance-test"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "env_logger 0.9.0",
  "kusama-runtime",
@@ -7907,12 +7871,11 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "bitvec",
  "hex-literal",
  "parity-scale-codec",
- "parity-util-mem",
  "polkadot-core-primitives",
  "polkadot-parachain",
  "scale-info",
@@ -7934,7 +7897,7 @@ dependencies = [
 [[package]]
 name = "polkadot-rpc"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "beefy-gadget",
  "beefy-gadget-rpc",
@@ -7966,7 +7929,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -8055,7 +8018,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-common"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -8103,7 +8066,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-constants"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -8115,7 +8078,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "bs58",
  "parity-scale-codec",
@@ -8127,7 +8090,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "bitflags",
  "bitvec",
@@ -8170,7 +8133,7 @@ dependencies = [
 [[package]]
 name = "polkadot-service"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "async-trait",
  "beefy-gadget",
@@ -8277,7 +8240,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-distribution"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "arrayvec 0.5.2",
  "fatality",
@@ -8298,7 +8261,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -8308,7 +8271,7 @@ dependencies = [
 [[package]]
 name = "polkadot-test-client"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-subsystem",
@@ -8333,7 +8296,7 @@ dependencies = [
 [[package]]
 name = "polkadot-test-runtime"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "bitvec",
  "frame-election-provider-support",
@@ -8394,7 +8357,7 @@ dependencies = [
 [[package]]
 name = "polkadot-test-service"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "frame-benchmarking",
  "frame-system",
@@ -9076,7 +9039,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "beefy-merkle-tree",
  "frame-benchmarking",
@@ -9161,7 +9124,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime-constants"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -9336,7 +9299,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "4.1.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "log",
  "sp-core",
@@ -9347,7 +9310,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "async-trait",
  "futures",
@@ -9374,7 +9337,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "futures",
  "futures-timer",
@@ -9397,7 +9360,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -9413,7 +9376,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "impl-trait-for-tuples",
  "memmap2",
@@ -9430,7 +9393,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -9441,7 +9404,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "array-bytes 4.2.0",
  "chrono",
@@ -9481,7 +9444,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "fnv",
  "futures",
@@ -9509,7 +9472,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -9534,7 +9497,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "async-trait",
  "futures",
@@ -9587,7 +9550,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -9628,7 +9591,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -9650,7 +9613,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -9663,7 +9626,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "async-trait",
  "futures",
@@ -9687,7 +9650,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "lazy_static",
  "lru",
@@ -9713,7 +9676,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -9729,7 +9692,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -9744,7 +9707,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "cfg-if",
  "libc",
@@ -9764,7 +9727,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "ahash",
  "array-bytes 4.2.0",
@@ -9805,7 +9768,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "finality-grandpa",
  "futures",
@@ -9826,13 +9789,12 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "ansi_term",
  "futures",
  "futures-timer",
  "log",
- "parity-util-mem",
  "sc-client-api",
  "sc-network-common",
  "sc-transaction-pool-api",
@@ -9843,7 +9805,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "array-bytes 4.2.0",
  "async-trait",
@@ -9858,7 +9820,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "array-bytes 4.2.0",
  "async-trait",
@@ -9905,7 +9867,7 @@ dependencies = [
 [[package]]
 name = "sc-network-bitswap"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "cid",
  "futures",
@@ -9925,7 +9887,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "async-trait",
  "bitflags",
@@ -9951,7 +9913,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "ahash",
  "futures",
@@ -9969,7 +9931,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "array-bytes 4.2.0",
  "futures",
@@ -9990,7 +9952,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "array-bytes 4.2.0",
  "async-trait",
@@ -10021,7 +9983,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "array-bytes 4.2.0",
  "futures",
@@ -10040,7 +10002,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "array-bytes 4.2.0",
  "bytes",
@@ -10070,7 +10032,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "futures",
  "libp2p",
@@ -10083,7 +10045,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -10092,7 +10054,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "futures",
  "hash-db",
@@ -10122,7 +10084,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -10145,7 +10107,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -10158,7 +10120,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "futures",
  "hex",
@@ -10177,7 +10139,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "async-trait",
  "directories",
@@ -10188,7 +10150,6 @@ dependencies = [
  "jsonrpsee",
  "log",
  "parity-scale-codec",
- "parity-util-mem",
  "parking_lot 0.12.1",
  "pin-project",
  "rand 0.7.3",
@@ -10248,12 +10209,10 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "log",
  "parity-scale-codec",
- "parity-util-mem",
- "parity-util-mem-derive",
  "parking_lot 0.12.1",
  "sc-client-api",
  "sp-core",
@@ -10262,7 +10221,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -10281,7 +10240,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "6.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "futures",
  "libc",
@@ -10300,7 +10259,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "chrono",
  "futures",
@@ -10318,7 +10277,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "ansi_term",
  "atty",
@@ -10349,7 +10308,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -10360,7 +10319,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "async-trait",
  "futures",
@@ -10368,7 +10327,6 @@ dependencies = [
  "linked-hash-map",
  "log",
  "parity-scale-codec",
- "parity-util-mem",
  "parking_lot 0.12.1",
  "sc-client-api",
  "sc-transaction-pool-api",
@@ -10387,7 +10345,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "async-trait",
  "futures",
@@ -10401,7 +10359,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "futures",
  "futures-timer",
@@ -10826,7 +10784,7 @@ checksum = "03b634d87b960ab1a38c4fe143b508576f075e7c978bfad18217645ebfdfa2ec"
 [[package]]
 name = "slot-range-helper"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -10902,7 +10860,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "hash-db",
  "log",
@@ -10920,7 +10878,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "blake2",
  "proc-macro-crate",
@@ -10932,7 +10890,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10945,7 +10903,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -10960,7 +10918,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10973,7 +10931,7 @@ dependencies = [
 [[package]]
 name = "sp-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -10985,7 +10943,7 @@ dependencies = [
 [[package]]
 name = "sp-beefy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11002,7 +10960,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -11014,7 +10972,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "futures",
  "log",
@@ -11032,7 +10990,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "async-trait",
  "futures",
@@ -11069,7 +11027,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "async-trait",
  "merlin",
@@ -11092,7 +11050,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11106,7 +11064,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11119,7 +11077,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "array-bytes 4.2.0",
  "base58",
@@ -11164,7 +11122,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "blake2",
  "byteorder",
@@ -11178,7 +11136,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11189,7 +11147,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.1",
@@ -11198,7 +11156,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11208,7 +11166,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.13.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -11219,7 +11177,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -11237,7 +11195,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -11251,7 +11209,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "bytes",
  "ed25519-dalek",
@@ -11278,7 +11236,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -11289,7 +11247,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.13.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "async-trait",
  "futures",
@@ -11306,7 +11264,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "4.1.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "thiserror",
  "zstd",
@@ -11315,7 +11273,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "ckb-merkle-mountain-range",
  "log",
@@ -11333,7 +11291,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11347,7 +11305,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -11357,7 +11315,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -11367,7 +11325,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -11377,14 +11335,13 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "either",
  "hash256-std-hasher",
  "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
- "parity-util-mem",
  "paste",
  "rand 0.7.3",
  "scale-info",
@@ -11400,7 +11357,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -11418,7 +11375,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -11430,7 +11387,7 @@ dependencies = [
 [[package]]
 name = "sp-sandbox"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -11453,7 +11410,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11467,7 +11424,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11478,7 +11435,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.13.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "hash-db",
  "log",
@@ -11500,12 +11457,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 
 [[package]]
 name = "sp-storage"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -11518,7 +11475,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "async-trait",
  "futures-timer",
@@ -11534,7 +11491,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "parity-scale-codec",
  "sp-std",
@@ -11546,7 +11503,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -11555,7 +11512,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "async-trait",
  "log",
@@ -11571,7 +11528,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "ahash",
  "hash-db",
@@ -11594,7 +11551,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -11611,7 +11568,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -11622,7 +11579,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "impl-trait-for-tuples",
  "log",
@@ -11635,7 +11592,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -11938,7 +11895,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "platforms",
 ]
@@ -11946,7 +11903,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures",
@@ -11967,7 +11924,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "futures-util",
  "hyper",
@@ -11980,7 +11937,7 @@ dependencies = [
 [[package]]
 name = "substrate-rpc-client"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "async-trait",
  "jsonrpsee",
@@ -11993,7 +11950,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-trie-migration-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "jsonrpsee",
  "log",
@@ -12014,7 +11971,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "array-bytes 4.2.0",
  "async-trait",
@@ -12061,7 +12018,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "5.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "ansi_term",
  "build-helper",
@@ -12169,7 +12126,7 @@ checksum = "13a4ec180a2de59b57434704ccfad967f789b12737738798fa08798cd5824c16"
 [[package]]
 name = "test-runtime-constants"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -12239,6 +12196,17 @@ dependencies = [
  "log",
  "ordered-float",
  "threadpool",
+]
+
+[[package]]
+name = "tikv-jemalloc-ctl"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e37706572f4b151dff7a0146e040804e9c26fe3a3118591112f05cf12a4216c1"
+dependencies = [
+ "libc",
+ "paste",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]
@@ -12449,7 +12417,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "polkadot-node-jaeger",
  "polkadot-primitives",
@@ -12460,7 +12428,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "expander 0.0.6",
  "proc-macro-crate",
@@ -12589,7 +12557,7 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 [[package]]
 name = "try-runtime-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#416a331399452521f3e9cf7e1394d020373a95c5"
+source = "git+https://github.com/paritytech/substrate?branch=master#11c50578549969979121577cde987ad3f9d95bd8"
 dependencies = [
  "clap 4.0.29",
  "frame-remote-externalities",
@@ -13255,7 +13223,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -13345,7 +13313,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime-constants"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -13685,7 +13653,7 @@ dependencies = [
 [[package]]
 name = "xcm"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "derivative",
  "impl-trait-for-tuples",
@@ -13699,7 +13667,7 @@ dependencies = [
 [[package]]
 name = "xcm-builder"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -13719,7 +13687,7 @@ dependencies = [
 [[package]]
 name = "xcm-executor"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -13737,7 +13705,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "0.9.33"
-source = "git+https://github.com/paritytech/polkadot?branch=master#09f2d1a1c60d0d41ff88e008480e8495b8488a17"
+source = "git+https://github.com/paritytech/polkadot?branch=master#9cf336ac8c77f5f8336cb8a97c344679291164bd"
 dependencies = [
  "Inflector",
  "proc-macro2",


### PR DESCRIPTION
Fully removes the `parity-util-mem` dependency. This just required upgrading to the latest versions of the polkadot crates.

## Related issue

See https://github.com/paritytech/substrate/issues/12658. This has already been done in `substrate` and `polkadot`.