### PR TITLE
`zombienet` store node's logs as artifacts

### DIFF
--- a/scripts/ci/gitlab/pipeline/zombienet.yml
+++ b/scripts/ci/gitlab/pipeline/zombienet.yml
@@ -12,6 +12,11 @@
     - export RELAY_IMAGE=${POLKADOT_IMAGE}
     - export COL_IMAGE=${COL_IMAGE}
 
+.zombienet-after-script:
+  after_script:
+    - mkdir -p ./zombienet-logs
+    - cp /tmp/zombie*/logs/* ./zombienet-logs/
+
 # common settings for all zombienet jobs
 .zombienet-common:
   stage:                           zombienet
@@ -23,6 +28,13 @@
     POLKADOT_IMAGE:                "docker.io/paritypr/polkadot-debug:master"
     GH_DIR:                        "https://github.com/paritytech/cumulus/tree/${CI_COMMIT_SHORT_SHA}/zombienet/tests"
     COL_IMAGE:                     "docker.io/paritypr/test-parachain:${CI_COMMIT_REF_NAME}-${CI_COMMIT_SHORT_SHA}"
+    FF_DISABLE_UMASK_FOR_DOCKER_EXECUTOR: 1
+  artifacts:
+    name:                          "${CI_JOB_NAME}_${CI_COMMIT_REF_NAME}"
+    when:                          always
+    expire_in:                     2 days
+    paths:
+      - ./zombienet-logs
   allow_failure:                   true
   retry: 2
   tags:
@@ -33,6 +45,7 @@ zombienet-0001-sync_blocks_from_tip_without_connected_collator:
     - .zombienet-common
     - .zombienet-refs
     - .zombienet-before-script
+    - .zombienet-after-script
   script:
     - /home/nonroot/zombie-net/scripts/ci/run-test-env-manager.sh
         --github-remote-dir="${GH_DIR}"
@@ -44,6 +57,7 @@ zombienet-0002-pov_recovery:
     - .zombienet-common
     - .zombienet-refs
     - .zombienet-before-script
+    - .zombienet-after-script
   script:
     - /home/nonroot/zombie-net/scripts/ci/run-test-env-manager.sh
         --github-remote-dir="${GH_DIR}"
@@ -55,6 +69,7 @@ zombienet-0003-full_node_catching_up:
     - .zombienet-common
     - .zombienet-refs
     - .zombienet-before-script
+    - .zombienet-after-script
   script:
     - /home/nonroot/zombie-net/scripts/ci/run-test-env-manager.sh
         --github-remote-dir="${GH_DIR}"
@@ -66,6 +81,7 @@ zombienet-0004-runtime_upgrade:
     - .zombienet-common
     - .zombienet-refs
     - .zombienet-before-script
+    - .zombienet-after-script
   needs:
     - !reference [.zombienet-common, needs]
     - job:                         build-test-parachain
@@ -86,6 +102,7 @@ zombienet-0005-migrate_solo_to_para:
     - .zombienet-common
     - .zombienet-refs
     - .zombienet-before-script
+    - .zombienet-after-script
   needs:
     - !reference [.zombienet-common, needs]
     - job:                         build-test-parachain
@@ -104,6 +121,7 @@ zombienet-0006-rpc_collator_builds_blocks:
     - .zombienet-common
     - .zombienet-refs
     - .zombienet-before-script
+    - .zombienet-after-script
   script:
     - /home/nonroot/zombie-net/scripts/ci/run-test-env-manager.sh
         --github-remote-dir="${GH_DIR}"


### PR DESCRIPTION
- Store log information in artifacts so external contributors can access those if their are needed for debugging.

Thanks!