### PR TITLE
remove shift session manager from bridge-hub-rococo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -994,7 +994,6 @@ dependencies = [
  "pallet-bridge-relayers",
  "pallet-collator-selection",
  "pallet-session",
- "pallet-shift-session-manager",
  "pallet-timestamp",
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ members = [
 	"bridges/modules/messages",
 	"bridges/modules/parachains",
 	"bridges/modules/relayers",
-	"bridges/modules/shift-session-manager",
 	"bridges/primitives/messages",
 	"bridges/primitives/runtime",
 	"bridges/primitives/chain-bridge-hub-rococo",

--- a/parachains/runtimes/bridge-hubs/bridge-hub-rococo/Cargo.toml
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-rococo/Cargo.toml
@@ -79,7 +79,6 @@ pallet-bridge-grandpa = { path = "../../../../bridges/modules/grandpa", default-
 pallet-bridge-messages = { path = "../../../../bridges/modules/messages", default-features = false }
 pallet-bridge-parachains = { path = "../../../../bridges/modules/parachains", default-features = false }
 pallet-bridge-relayers = { path = "../../../../bridges/modules/relayers", default-features = false }
-pallet-shift-session-manager = { path = "../../../../bridges/modules/shift-session-manager", default-features = false }
 bridge-runtime-common = { path = "../../../../bridges/bin/runtime-common", default-features = false }
 
 [dev-dependencies]
@@ -121,7 +120,6 @@ std = [
 	"pallet-bridge-messages/std",
 	"pallet-bridge-parachains/std",
 	"pallet-bridge-relayers/std",
-	"pallet-shift-session-manager/std",
 	"pallet-collator-selection/std",
 	"pallet-session/std",
 	"pallet-timestamp/std",

--- a/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/lib.rs
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/lib.rs
@@ -573,9 +573,6 @@ impl pallet_bridge_messages::Config<WithBridgeHubRococoMessagesInstance> for Run
 	>;
 }
 
-/// Add shift session manager
-impl pallet_shift_session_manager::Config for Runtime {}
-
 // Create the runtime by composing the FRAME pallets that were previously configured.
 construct_runtime!(
 	pub enum Runtime where
@@ -607,9 +604,6 @@ construct_runtime!(
 		PolkadotXcm: pallet_xcm::{Pallet, Call, Event<T>, Origin, Config} = 31,
 		CumulusXcm: cumulus_pallet_xcm::{Pallet, Event<T>, Origin} = 32,
 		DmpQueue: cumulus_pallet_dmp_queue::{Pallet, Call, Storage, Event<T>} = 33,
-
-		// Consensus support.
-		ShiftSessionManager: pallet_shift_session_manager::{Pallet} = 40,
 
 		// Wococo bridge modules
 		BridgeWococoGrandpa: pallet_bridge_grandpa::<Instance1>::{Pallet, Call, Storage, Config<T>} = 41,


### PR DESCRIPTION
This pallet is used by our testnets for selecting different validators in each session (without staking and everything else). It shall not be used in production.

Nothing criminal - just extra code :)