### PR TITLE
Remove the `RelaychainClient` trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1737,7 +1737,6 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-parachain",
  "polkadot-primitives",
- "polkadot-service",
  "polkadot-test-client",
  "portpicker",
  "sc-cli",

--- a/client/consensus/common/src/tests.rs
+++ b/client/consensus/common/src/tests.rs
@@ -19,20 +19,24 @@ use crate::*;
 use async_trait::async_trait;
 use codec::Encode;
 use cumulus_client_pov_recovery::RecoveryKind;
-use cumulus_relay_chain_interface::RelayChainResult;
+use cumulus_primitives_core::{InboundDownwardMessage, InboundHrmpMessage};
+use cumulus_relay_chain_interface::{
+	CommittedCandidateReceipt, OccupiedCoreAssumption, OverseerHandle, PHeader, ParaId,
+	RelayChainInterface, RelayChainResult, SessionIndex, StorageValue, ValidatorId,
+};
 use cumulus_test_client::{
 	runtime::{Block, Header},
 	Backend, Client, InitBlockBuilder, TestClientBuilder, TestClientBuilderExt,
 };
 use futures::{channel::mpsc, executor::block_on, select, FutureExt, Stream, StreamExt};
 use futures_timer::Delay;
-use polkadot_primitives::v2::Id as ParaId;
 use sc_client_api::{blockchain::Backend as _, Backend as _, UsageProvider};
 use sc_consensus::{BlockImport, BlockImportParams, ForkChoiceStrategy};
-use sp_blockchain::Error as ClientError;
 use sp_consensus::{BlockOrigin, BlockStatus};
 use sp_runtime::generic::BlockId;
 use std::{
+	collections::{BTreeMap, HashMap},
+	pin::Pin,
 	sync::{Arc, Mutex},
 	time::Duration,
 };
@@ -42,6 +46,7 @@ struct RelaychainInner {
 	finalized_heads: Option<mpsc::UnboundedReceiver<Header>>,
 	new_best_heads_sender: mpsc::UnboundedSender<Header>,
 	finalized_heads_sender: mpsc::UnboundedSender<Header>,
+	relay_chain_hash_to_header: HashMap<PHash, Header>,
 }
 
 impl RelaychainInner {
@@ -54,6 +59,7 @@ impl RelaychainInner {
 			finalized_heads_sender,
 			new_best_heads: Some(new_best_heads),
 			finalized_heads: Some(finalized_heads),
+			relay_chain_hash_to_header: Default::default(),
 		}
 	}
 }
@@ -70,37 +76,133 @@ impl Relaychain {
 }
 
 #[async_trait]
-impl crate::parachain_consensus::RelaychainClient for Relaychain {
-	type Error = ClientError;
-
-	type HeadStream = Box<dyn Stream<Item = Vec<u8>> + Send + Unpin>;
-
-	async fn new_best_heads(&self, _: ParaId) -> RelayChainResult<Self::HeadStream> {
-		let stream = self
-			.inner
-			.lock()
-			.unwrap()
-			.new_best_heads
-			.take()
-			.expect("Should only be called once");
-
-		Ok(Box::new(stream.map(|v| v.encode())))
+impl RelayChainInterface for Relaychain {
+	async fn validators(&self, _: PHash) -> RelayChainResult<Vec<ValidatorId>> {
+		unimplemented!("Not needed for test")
 	}
 
-	async fn finalized_heads(&self, _: ParaId) -> RelayChainResult<Self::HeadStream> {
-		let stream = self
+	async fn best_block_hash(&self) -> RelayChainResult<PHash> {
+		unimplemented!("Not needed for test")
+	}
+
+	async fn retrieve_dmq_contents(
+		&self,
+		_: ParaId,
+		_: PHash,
+	) -> RelayChainResult<Vec<InboundDownwardMessage>> {
+		unimplemented!("Not needed for test")
+	}
+
+	async fn retrieve_all_inbound_hrmp_channel_contents(
+		&self,
+		_: ParaId,
+		_: PHash,
+	) -> RelayChainResult<BTreeMap<ParaId, Vec<InboundHrmpMessage>>> {
+		unimplemented!("Not needed for test")
+	}
+
+	async fn persisted_validation_data(
+		&self,
+		hash: PHash,
+		_: ParaId,
+		_: OccupiedCoreAssumption,
+	) -> RelayChainResult<Option<PersistedValidationData>> {
+		Ok(Some(PersistedValidationData {
+			parent_head: self
+				.inner
+				.lock()
+				.unwrap()
+				.relay_chain_hash_to_header
+				.get(&hash)
+				.unwrap()
+				.encode()
+				.into(),
+			..Default::default()
+		}))
+	}
+
+	async fn candidate_pending_availability(
+		&self,
+		_: PHash,
+		_: ParaId,
+	) -> RelayChainResult<Option<CommittedCandidateReceipt>> {
+		unimplemented!("Not needed for test")
+	}
+
+	async fn session_index_for_child(&self, _: PHash) -> RelayChainResult<SessionIndex> {
+		unimplemented!("Not needed for test")
+	}
+
+	async fn import_notification_stream(
+		&self,
+	) -> RelayChainResult<Pin<Box<dyn Stream<Item = PHeader> + Send>>> {
+		unimplemented!("Not needed for test")
+	}
+
+	async fn finality_notification_stream(
+		&self,
+	) -> RelayChainResult<Pin<Box<dyn Stream<Item = PHeader> + Send>>> {
+		let inner = self.inner.clone();
+		Ok(self
 			.inner
 			.lock()
 			.unwrap()
 			.finalized_heads
 			.take()
-			.expect("Should only be called once");
-
-		Ok(Box::new(stream.map(|v| v.encode())))
+			.unwrap()
+			.map(move |h| {
+				// Let's abuse the "parachain header" directly as relay chain header.
+				inner.lock().unwrap().relay_chain_hash_to_header.insert(h.hash(), h.clone());
+				h
+			})
+			.boxed())
 	}
 
-	async fn parachain_head_at(&self, _: PHash, _: ParaId) -> RelayChainResult<Option<Vec<u8>>> {
-		unimplemented!("Not required for tests")
+	async fn is_major_syncing(&self) -> RelayChainResult<bool> {
+		Ok(false)
+	}
+
+	fn overseer_handle(&self) -> RelayChainResult<OverseerHandle> {
+		unimplemented!("Not needed for test")
+	}
+
+	async fn get_storage_by_key(
+		&self,
+		_: PHash,
+		_: &[u8],
+	) -> RelayChainResult<Option<StorageValue>> {
+		unimplemented!("Not needed for test")
+	}
+
+	async fn prove_read(
+		&self,
+		_: PHash,
+		_: &Vec<Vec<u8>>,
+	) -> RelayChainResult<sc_client_api::StorageProof> {
+		unimplemented!("Not needed for test")
+	}
+
+	async fn wait_for_block(&self, hash: PHash) -> RelayChainResult<()> {
+		unimplemented!("Not needed for test")
+	}
+
+	async fn new_best_notification_stream(
+		&self,
+	) -> RelayChainResult<Pin<Box<dyn Stream<Item = PHeader> + Send>>> {
+		let inner = self.inner.clone();
+		Ok(self
+			.inner
+			.lock()
+			.unwrap()
+			.new_best_heads
+			.take()
+			.unwrap()
+			.map(move |h| {
+				// Let's abuse the "parachain header" directly as relay chain header.
+				inner.lock().unwrap().relay_chain_hash_to_header.insert(h.hash(), h.clone());
+				h
+			})
+			.boxed())
 	}
 }
 
@@ -121,7 +223,7 @@ fn build_block<B: InitBlockBuilder>(
 	let mut block = builder.build().unwrap().block;
 
 	// Simulate some form of post activity (like a Seal or Other generic things).
-	// This is mostly used to excercise the `LevelMonitor` correct behavior.
+	// This is mostly used to exercise the `LevelMonitor` correct behavior.
 	// (in practice we want that header post-hash != pre-hash)
 	block.header.digest.push(sp_runtime::DigestItem::Other(vec![1, 2, 3]));
 

--- a/client/consensus/common/src/tests.rs
+++ b/client/consensus/common/src/tests.rs
@@ -182,7 +182,7 @@ impl RelayChainInterface for Relaychain {
 		unimplemented!("Not needed for test")
 	}
 
-	async fn wait_for_block(&self, hash: PHash) -> RelayChainResult<()> {
+	async fn wait_for_block(&self, _: PHash) -> RelayChainResult<()> {
 		unimplemented!("Not needed for test")
 	}
 

--- a/client/network/Cargo.toml
+++ b/client/network/Cargo.toml
@@ -45,7 +45,6 @@ substrate-test-utils = { git = "https://github.com/paritytech/substrate", branch
 
 # Polkadot
 polkadot-client = { git = "https://github.com/paritytech/polkadot", branch = "master" }
-polkadot-service = { git = "https://github.com/paritytech/polkadot", branch = "master" }
 polkadot-test-client = { git = "https://github.com/paritytech/polkadot", branch = "master" }
 
 # Cumulus

--- a/client/network/src/tests.rs
+++ b/client/network/src/tests.rs
@@ -17,18 +17,18 @@
 use super::*;
 use async_trait::async_trait;
 use cumulus_relay_chain_inprocess_interface::{check_block_in_chain, BlockCheckStatus};
-use cumulus_relay_chain_interface::{RelayChainError, RelayChainResult};
+use cumulus_relay_chain_interface::{
+	OverseerHandle, PHeader, ParaId, RelayChainError, RelayChainResult,
+};
 use cumulus_test_service::runtime::{Block, Hash, Header};
 use futures::{executor::block_on, poll, task::Poll, FutureExt, Stream, StreamExt};
 use parking_lot::Mutex;
 use polkadot_node_primitives::{SignedFullStatement, Statement};
 use polkadot_primitives::v2::{
 	CandidateCommitments, CandidateDescriptor, CollatorPair, CommittedCandidateReceipt,
-	Hash as PHash, HeadData, Header as PHeader, Id as ParaId, InboundDownwardMessage,
-	InboundHrmpMessage, OccupiedCoreAssumption, PersistedValidationData, SessionIndex,
-	SigningContext, ValidationCodeHash, ValidatorId,
+	Hash as PHash, HeadData, InboundDownwardMessage, InboundHrmpMessage, OccupiedCoreAssumption,
+	PersistedValidationData, SessionIndex, SigningContext, ValidationCodeHash, ValidatorId,
 };
-use polkadot_service::Handle;
 use polkadot_test_client::{
 	Client as PClient, ClientBlockImportExt, DefaultTestClientBuilderExt, FullBackend as PBackend,
 	InitPolkadotBlockBuilder, TestClientBuilder, TestClientBuilderExt,
@@ -174,7 +174,7 @@ impl RelayChainInterface for DummyRelayChainInterface {
 		Ok(false)
 	}
 
-	fn overseer_handle(&self) -> RelayChainResult<Handle> {
+	fn overseer_handle(&self) -> RelayChainResult<OverseerHandle> {
 		unimplemented!("Not needed for test")
 	}
 

--- a/client/relay-chain-interface/src/lib.rs
+++ b/client/relay-chain-interface/src/lib.rs
@@ -16,14 +16,7 @@
 
 use std::{collections::BTreeMap, pin::Pin, sync::Arc};
 
-use cumulus_primitives_core::{
-	relay_chain::{
-		v2::{CommittedCandidateReceipt, OccupiedCoreAssumption, SessionIndex, ValidatorId},
-		Hash as PHash, Header as PHeader, InboundHrmpMessage,
-	},
-	InboundDownwardMessage, ParaId, PersistedValidationData,
-};
-use polkadot_overseer::{prometheus::PrometheusError, Handle as OverseerHandle};
+use polkadot_overseer::prometheus::PrometheusError;
 use polkadot_service::SubstrateServiceError;
 use sc_client_api::StorageProof;
 
@@ -33,7 +26,16 @@ use async_trait::async_trait;
 use jsonrpsee_core::Error as JsonRpcError;
 use parity_scale_codec::Error as CodecError;
 use sp_api::ApiError;
-use sp_state_machine::StorageValue;
+
+pub use cumulus_primitives_core::{
+	relay_chain::{
+		v2::{CommittedCandidateReceipt, OccupiedCoreAssumption, SessionIndex, ValidatorId},
+		Hash as PHash, Header as PHeader, InboundHrmpMessage,
+	},
+	InboundDownwardMessage, ParaId, PersistedValidationData,
+};
+pub use polkadot_overseer::Handle as OverseerHandle;
+pub use sp_state_machine::StorageValue;
 
 pub type RelayChainResult<T> = Result<T, RelayChainError>;
 


### PR DESCRIPTION
It was just some historical trait that isn't really required anymore. Besides that this pr re-exports types that are being used by the relay chain interface to make its usage easier.