### PR TITLE
[Backport] of update polkadot dependecies (#2086)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4322,7 +4322,7 @@ checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 [[package]]
 name = "kusama-runtime"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -4419,7 +4419,7 @@ dependencies = [
 [[package]]
 name = "kusama-runtime-constants"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -6852,7 +6852,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6870,7 +6870,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-benchmarks"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7403,7 +7403,7 @@ dependencies = [
 [[package]]
 name = "polkadot-approval-distribution"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -7418,7 +7418,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "futures",
  "polkadot-node-network-protocol",
@@ -7432,7 +7432,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-distribution"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "derive_more",
  "fatality",
@@ -7455,7 +7455,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-recovery"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "fatality",
  "futures",
@@ -7476,7 +7476,7 @@ dependencies = [
 [[package]]
 name = "polkadot-cli"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "clap 4.0.32",
  "frame-benchmarking-cli",
@@ -7503,7 +7503,7 @@ dependencies = [
 [[package]]
 name = "polkadot-client"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -7546,7 +7546,7 @@ dependencies = [
 [[package]]
 name = "polkadot-collator-protocol"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "always-assert",
  "bitvec",
@@ -7568,7 +7568,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -7580,7 +7580,7 @@ dependencies = [
 [[package]]
 name = "polkadot-dispute-distribution"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "derive_more",
  "fatality",
@@ -7605,7 +7605,7 @@ dependencies = [
 [[package]]
 name = "polkadot-erasure-coding"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -7619,7 +7619,7 @@ dependencies = [
 [[package]]
 name = "polkadot-gossip-support"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "futures",
  "futures-timer",
@@ -7639,7 +7639,7 @@ dependencies = [
 [[package]]
 name = "polkadot-network-bridge"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "always-assert",
  "async-trait",
@@ -7663,7 +7663,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-collation-generation"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -7681,7 +7681,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "bitvec",
  "derive_more",
@@ -7710,7 +7710,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-av-store"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "bitvec",
  "futures",
@@ -7730,7 +7730,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-backing"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "bitvec",
  "fatality",
@@ -7749,7 +7749,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
@@ -7764,7 +7764,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-candidate-validation"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "async-trait",
  "futures",
@@ -7783,7 +7783,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-api"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -7798,7 +7798,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-selection"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "futures",
  "futures-timer",
@@ -7815,7 +7815,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "fatality",
  "futures",
@@ -7834,7 +7834,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "async-trait",
  "futures",
@@ -7851,7 +7851,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-provisioner"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "bitvec",
  "fatality",
@@ -7869,7 +7869,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "always-assert",
  "assert_matches",
@@ -7901,7 +7901,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-checker"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "futures",
  "polkadot-node-primitives",
@@ -7917,7 +7917,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-runtime-api"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "futures",
  "lru",
@@ -7932,7 +7932,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-jaeger"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "lazy_static",
  "log",
@@ -7950,7 +7950,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-metrics"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "bs58",
  "futures",
@@ -7969,7 +7969,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -7992,7 +7992,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "bounded-vec",
  "futures",
@@ -8014,7 +8014,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "polkadot-node-jaeger",
  "polkadot-node-subsystem-types",
@@ -8024,7 +8024,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-test-helpers"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "async-trait",
  "futures",
@@ -8042,7 +8042,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-types"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -8065,7 +8065,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-util"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -8098,7 +8098,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "async-trait",
  "futures",
@@ -8121,7 +8121,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "derive_more",
  "frame-support",
@@ -8218,7 +8218,7 @@ dependencies = [
 [[package]]
 name = "polkadot-performance-test"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "env_logger 0.9.0",
  "kusama-runtime",
@@ -8233,7 +8233,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "bitvec",
  "hex-literal",
@@ -8259,7 +8259,7 @@ dependencies = [
 [[package]]
 name = "polkadot-rpc"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "beefy-gadget",
  "beefy-gadget-rpc",
@@ -8291,7 +8291,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -8380,7 +8380,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-common"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -8428,7 +8428,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-constants"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -8442,7 +8442,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "bs58",
  "parity-scale-codec",
@@ -8454,7 +8454,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "bitflags",
  "bitvec",
@@ -8497,7 +8497,7 @@ dependencies = [
 [[package]]
 name = "polkadot-service"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "async-trait",
  "beefy-gadget",
@@ -8604,7 +8604,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-distribution"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "arrayvec 0.5.2",
  "fatality",
@@ -8625,7 +8625,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -8635,7 +8635,7 @@ dependencies = [
 [[package]]
 name = "polkadot-test-client"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-subsystem",
@@ -8660,7 +8660,7 @@ dependencies = [
 [[package]]
 name = "polkadot-test-runtime"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "bitvec",
  "frame-election-provider-support",
@@ -8721,7 +8721,7 @@ dependencies = [
 [[package]]
 name = "polkadot-test-service"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "frame-benchmarking",
  "frame-system",
@@ -9447,7 +9447,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "beefy-merkle-tree",
  "frame-benchmarking",
@@ -9533,7 +9533,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime-constants"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -11220,7 +11220,7 @@ checksum = "03b634d87b960ab1a38c4fe143b508576f075e7c978bfad18217645ebfdfa2ec"
 [[package]]
 name = "slot-range-helper"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -12560,7 +12560,7 @@ checksum = "13a4ec180a2de59b57434704ccfad967f789b12737738798fa08798cd5824c16"
 [[package]]
 name = "test-runtime-constants"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -12917,7 +12917,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "polkadot-node-jaeger",
  "polkadot-primitives",
@@ -12928,7 +12928,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "expander 0.0.6",
  "proc-macro-crate",
@@ -13968,7 +13968,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -14058,7 +14058,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime-constants"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -14449,7 +14449,7 @@ dependencies = [
 [[package]]
 name = "xcm"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "derivative",
  "impl-trait-for-tuples",
@@ -14463,7 +14463,7 @@ dependencies = [
 [[package]]
 name = "xcm-builder"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -14483,7 +14483,7 @@ dependencies = [
 [[package]]
 name = "xcm-executor"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -14501,7 +14501,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#b996c75499d82ec2c004d258c1912e4e80f0d532"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.37#645723987cf9662244be8faf4e9b63e8b9a1b3a3"
 dependencies = [
  "Inflector",
  "proc-macro2",


### PR DESCRIPTION
Thi PR backports polkadot dependencies update from runtime release branch `release-parachains-v9370` into to the client release branch `release-v0.9.370`