### PR TITLE
Use correct runtime function name

### DIFF
--- a/client/relay-chain-rpc-interface/src/rpc_client.rs
+++ b/client/relay-chain-rpc-interface/src/rpc_client.rs
@@ -141,12 +141,9 @@ impl RelayChainRpcClient {
 		at: RelayHash,
 		index: SessionIndex,
 	) -> Result<Option<OldV1SessionInfo>, RelayChainError> {
-		self.call_remote_runtime_function(
-			"ParachainHost_session_info_before_version_2",
-			at,
-			Some(index),
-		)
-		.await
+		// The function in wasm never changes/gets augmented with a version
+		self.call_remote_runtime_function("ParachainHost_session_info", at, Some(index))
+			.await
 	}
 
 	/// Scrape dispute relevant from on-chain, backing votes and resolved disputes.


### PR DESCRIPTION
The runtime function name doesn't change on chain, especially not for old runtimes.