### PR TITLE
[backport] Update polkadot dependencies (#2183) to node release branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4425,7 +4425,7 @@ checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 [[package]]
 name = "kusama-runtime"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -4522,7 +4522,7 @@ dependencies = [
 [[package]]
 name = "kusama-runtime-constants"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -6982,7 +6982,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7002,7 +7002,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-benchmarks"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7538,7 +7538,7 @@ dependencies = [
 [[package]]
 name = "polkadot-approval-distribution"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -7553,7 +7553,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "futures",
  "polkadot-node-network-protocol",
@@ -7567,7 +7567,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-distribution"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "derive_more",
  "fatality",
@@ -7590,7 +7590,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-recovery"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "fatality",
  "futures",
@@ -7611,7 +7611,7 @@ dependencies = [
 [[package]]
 name = "polkadot-cli"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "clap 4.1.4",
  "frame-benchmarking-cli",
@@ -7639,7 +7639,7 @@ dependencies = [
 [[package]]
 name = "polkadot-client"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -7682,7 +7682,7 @@ dependencies = [
 [[package]]
 name = "polkadot-collator-protocol"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "always-assert",
  "bitvec",
@@ -7704,7 +7704,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -7716,7 +7716,7 @@ dependencies = [
 [[package]]
 name = "polkadot-dispute-distribution"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "derive_more",
  "fatality",
@@ -7741,7 +7741,7 @@ dependencies = [
 [[package]]
 name = "polkadot-erasure-coding"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -7755,7 +7755,7 @@ dependencies = [
 [[package]]
 name = "polkadot-gossip-support"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "futures",
  "futures-timer",
@@ -7775,7 +7775,7 @@ dependencies = [
 [[package]]
 name = "polkadot-network-bridge"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "always-assert",
  "async-trait",
@@ -7799,7 +7799,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-collation-generation"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -7817,7 +7817,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "bitvec",
  "derive_more",
@@ -7846,7 +7846,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-av-store"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "bitvec",
  "futures",
@@ -7866,7 +7866,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-backing"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "bitvec",
  "fatality",
@@ -7885,7 +7885,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
@@ -7900,7 +7900,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-candidate-validation"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "async-trait",
  "futures",
@@ -7919,7 +7919,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-api"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -7934,7 +7934,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-selection"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "futures",
  "futures-timer",
@@ -7951,7 +7951,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "fatality",
  "futures",
@@ -7970,7 +7970,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "async-trait",
  "futures",
@@ -7987,7 +7987,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-provisioner"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "bitvec",
  "fatality",
@@ -8005,7 +8005,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "always-assert",
  "assert_matches",
@@ -8037,7 +8037,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-checker"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "futures",
  "polkadot-node-primitives",
@@ -8053,7 +8053,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-runtime-api"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "futures",
  "lru 0.9.0",
@@ -8068,7 +8068,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-jaeger"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "lazy_static",
  "log",
@@ -8086,7 +8086,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-metrics"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "bs58",
  "futures",
@@ -8105,7 +8105,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -8128,7 +8128,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "bounded-vec",
  "futures",
@@ -8150,7 +8150,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "polkadot-node-jaeger",
  "polkadot-node-subsystem-types",
@@ -8160,7 +8160,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-test-helpers"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "async-trait",
  "futures",
@@ -8178,7 +8178,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-types"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -8201,7 +8201,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-util"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -8234,7 +8234,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "async-trait",
  "futures",
@@ -8257,7 +8257,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "derive_more",
  "frame-support",
@@ -8355,7 +8355,7 @@ dependencies = [
 [[package]]
 name = "polkadot-performance-test"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "env_logger 0.9.0",
  "kusama-runtime",
@@ -8370,7 +8370,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "bitvec",
  "hex-literal",
@@ -8396,7 +8396,7 @@ dependencies = [
 [[package]]
 name = "polkadot-rpc"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "beefy-gadget",
  "beefy-gadget-rpc",
@@ -8428,7 +8428,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -8517,7 +8517,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-common"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -8566,7 +8566,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-constants"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -8580,7 +8580,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "bs58",
  "parity-scale-codec",
@@ -8592,7 +8592,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "bitflags",
  "bitvec",
@@ -8635,7 +8635,7 @@ dependencies = [
 [[package]]
 name = "polkadot-service"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "async-trait",
  "beefy-gadget",
@@ -8744,7 +8744,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-distribution"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "arrayvec 0.5.2",
  "fatality",
@@ -8765,7 +8765,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -8775,7 +8775,7 @@ dependencies = [
 [[package]]
 name = "polkadot-test-client"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-subsystem",
@@ -8800,7 +8800,7 @@ dependencies = [
 [[package]]
 name = "polkadot-test-runtime"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "bitvec",
  "frame-election-provider-support",
@@ -8861,7 +8861,7 @@ dependencies = [
 [[package]]
 name = "polkadot-test-service"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "frame-benchmarking",
  "frame-system",
@@ -9586,7 +9586,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "beefy-merkle-tree",
  "frame-benchmarking",
@@ -9672,7 +9672,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime-constants"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -11399,7 +11399,7 @@ checksum = "03b634d87b960ab1a38c4fe143b508576f075e7c978bfad18217645ebfdfa2ec"
 [[package]]
 name = "slot-range-helper"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -12727,7 +12727,7 @@ checksum = "13a4ec180a2de59b57434704ccfad967f789b12737738798fa08798cd5824c16"
 [[package]]
 name = "test-runtime-constants"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -13118,7 +13118,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "polkadot-node-jaeger",
  "polkadot-primitives",
@@ -13129,7 +13129,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "expander 0.0.6",
  "proc-macro-crate",
@@ -14169,7 +14169,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -14260,7 +14260,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime-constants"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -14651,7 +14651,7 @@ dependencies = [
 [[package]]
 name = "xcm"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "derivative",
  "impl-trait-for-tuples",
@@ -14667,7 +14667,7 @@ dependencies = [
 [[package]]
 name = "xcm-builder"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -14688,7 +14688,7 @@ dependencies = [
 [[package]]
 name = "xcm-executor"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -14708,7 +14708,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "0.9.38"
-source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#5421daf3473e77010f6c812f29c1a6403046407d"
+source = "git+https://github.com/paritytech/polkadot?branch=release-v0.9.38#909567fe6da7af8a6b99ae86e293698cb9b4bae3"
 dependencies = [
  "Inflector",
  "proc-macro2",


### PR DESCRIPTION
This PR backports polkadot deps update from runtime release branch to the node release branch