### PR TITLE
[backport] txn version bump and changelog fix

### DIFF
--- a/parachains/runtimes/assets/statemine/src/lib.rs
+++ b/parachains/runtimes/assets/statemine/src/lib.rs
@@ -92,7 +92,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_version: 9380,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
-	transaction_version: 11,
+	transaction_version: 12,
 	state_version: 1,
 };
 
@@ -105,7 +105,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_version: 9380,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
-	transaction_version: 11,
+	transaction_version: 12,
 	state_version: 0,
 };
 

--- a/parachains/runtimes/assets/statemint/src/lib.rs
+++ b/parachains/runtimes/assets/statemint/src/lib.rs
@@ -120,7 +120,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_version: 9380,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
-	transaction_version: 11,
+	transaction_version: 12,
 	state_version: 0,
 };
 

--- a/parachains/runtimes/assets/westmint/src/lib.rs
+++ b/parachains/runtimes/assets/westmint/src/lib.rs
@@ -90,7 +90,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_version: 9380,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
-	transaction_version: 11,
+	transaction_version: 12,
 	state_version: 0,
 };
 

--- a/parachains/runtimes/bridge-hubs/bridge-hub-kusama/src/lib.rs
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-kusama/src/lib.rs
@@ -130,7 +130,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_version: 9380,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
-	transaction_version: 1,
+	transaction_version: 2,
 	state_version: 1,
 };
 

--- a/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/lib.rs
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/lib.rs
@@ -159,7 +159,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_version: 9380,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
-	transaction_version: 1,
+	transaction_version: 2,
 	state_version: 1,
 };
 

--- a/parachains/runtimes/collectives/collectives-polkadot/src/lib.rs
+++ b/parachains/runtimes/collectives/collectives-polkadot/src/lib.rs
@@ -105,7 +105,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_version: 9380,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
-	transaction_version: 2,
+	transaction_version: 3,
 	state_version: 0,
 };
 

--- a/parachains/runtimes/contracts/contracts-rococo/src/lib.rs
+++ b/parachains/runtimes/contracts/contracts-rococo/src/lib.rs
@@ -123,7 +123,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_version: 9380,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
-	transaction_version: 4,
+	transaction_version: 5,
 	state_version: 1,
 };
 

--- a/parachains/runtimes/testing/rococo-parachain/src/lib.rs
+++ b/parachains/runtimes/testing/rococo-parachain/src/lib.rs
@@ -104,7 +104,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_version: 9380,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
-	transaction_version: 4,
+	transaction_version: 5,
 	state_version: 0,
 };
 

--- a/scripts/ci/changelog/bin/changelog
+++ b/scripts/ci/changelog/bin/changelog
@@ -119,6 +119,7 @@ else
       --slurpfile srtool_polkadot_collectives %s \
       --slurpfile srtool_bridge_hub_rococo %s \
       --slurpfile srtool_bridge_hub_kusama %s \
+      --slurpfile srtool_bridge_hub_polkadot %s \
       -n \'{
             cumulus: $cumulus[0],
             substrate: $substrate[0],


### PR DESCRIPTION
This PR backports `transaction_version` bump and fix for changelog from runtimes release brunch