### PR TITLE
`BlockId` removal: `BlockBuilderProvider::new_block_at`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,7 +474,7 @@ dependencies = [
 [[package]]
 name = "beefy-gadget"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "array-bytes 4.2.0",
  "async-trait",
@@ -508,7 +508,7 @@ dependencies = [
 [[package]]
 name = "beefy-gadget-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "beefy-gadget",
  "futures",
@@ -527,7 +527,7 @@ dependencies = [
 [[package]]
 name = "binary-merkle-tree"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "hash-db",
  "log",
@@ -3229,7 +3229,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -3252,7 +3252,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 [[package]]
 name = "frame-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -3277,7 +3277,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "Inflector",
  "array-bytes 4.2.0",
@@ -3324,7 +3324,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -3335,7 +3335,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -3352,7 +3352,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3381,7 +3381,7 @@ dependencies = [
 [[package]]
 name = "frame-remote-externalities"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "futures",
  "log",
@@ -3397,7 +3397,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "bitflags",
  "frame-metadata",
@@ -3429,7 +3429,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -3444,7 +3444,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -3456,7 +3456,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3466,7 +3466,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "frame-support",
  "log",
@@ -3484,7 +3484,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3499,7 +3499,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -3508,7 +3508,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4441,7 +4441,7 @@ checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 [[package]]
 name = "kusama-runtime"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -4491,6 +4491,7 @@ dependencies = [
  "pallet-session-benchmarking",
  "pallet-society",
  "pallet-staking",
+ "pallet-staking-runtime-api",
  "pallet-timestamp",
  "pallet-tips",
  "pallet-transaction-payment",
@@ -4538,7 +4539,7 @@ dependencies = [
 [[package]]
 name = "kusama-runtime-constants"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -5375,7 +5376,7 @@ dependencies = [
 [[package]]
 name = "mmr-gadget"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "futures",
  "log",
@@ -5394,7 +5395,7 @@ dependencies = [
 [[package]]
 name = "mmr-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "anyhow",
  "jsonrpsee",
@@ -5892,7 +5893,7 @@ dependencies = [
 [[package]]
 name = "pallet-alliance"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "array-bytes 4.2.0",
  "frame-benchmarking",
@@ -5913,7 +5914,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-tx-payment"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5931,7 +5932,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5946,7 +5947,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5962,7 +5963,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5978,7 +5979,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5992,7 +5993,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6016,7 +6017,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6036,7 +6037,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6051,7 +6052,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6070,7 +6071,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "array-bytes 4.2.0",
  "binary-merkle-tree",
@@ -6094,7 +6095,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6112,7 +6113,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6156,7 +6157,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6173,7 +6174,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "bitflags",
  "frame-benchmarking",
@@ -6202,7 +6203,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-primitives"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "bitflags",
  "parity-scale-codec",
@@ -6215,7 +6216,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6225,7 +6226,7 @@ dependencies = [
 [[package]]
 name = "pallet-conviction-voting"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -6242,7 +6243,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6260,7 +6261,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6283,7 +6284,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6296,7 +6297,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "5.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6314,7 +6315,7 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6332,7 +6333,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6355,7 +6356,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -6371,7 +6372,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6391,7 +6392,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6408,7 +6409,7 @@ dependencies = [
 [[package]]
 name = "pallet-insecure-randomness-collective-flip"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6422,7 +6423,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6439,7 +6440,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6456,7 +6457,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6472,7 +6473,7 @@ dependencies = [
 [[package]]
 name = "pallet-nfts"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -6490,7 +6491,7 @@ dependencies = [
 [[package]]
 name = "pallet-nis"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6506,7 +6507,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6523,7 +6524,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6543,8 +6544,9 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
 version = "1.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
+ "pallet-nomination-pools",
  "parity-scale-codec",
  "sp-api",
  "sp-std",
@@ -6553,7 +6555,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6570,7 +6572,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6594,7 +6596,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6611,7 +6613,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6626,7 +6628,7 @@ dependencies = [
 [[package]]
 name = "pallet-ranked-collective"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6644,7 +6646,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6659,7 +6661,7 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -6678,7 +6680,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6695,7 +6697,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6716,7 +6718,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6732,7 +6734,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6746,7 +6748,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6769,7 +6771,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -6780,16 +6782,25 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "log",
  "sp-arithmetic",
 ]
 
 [[package]]
+name = "pallet-staking-runtime-api"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
+dependencies = [
+ "parity-scale-codec",
+ "sp-api",
+]
+
+[[package]]
 name = "pallet-state-trie-migration"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6806,7 +6817,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6835,7 +6846,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6853,7 +6864,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6872,7 +6883,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6888,7 +6899,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -6904,7 +6915,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -6916,7 +6927,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6933,7 +6944,7 @@ dependencies = [
 [[package]]
 name = "pallet-uniques"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6948,7 +6959,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6964,7 +6975,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6979,7 +6990,7 @@ dependencies = [
 [[package]]
 name = "pallet-whitelist"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6994,7 +7005,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "bounded-collections",
  "frame-benchmarking",
@@ -7015,7 +7026,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-benchmarks"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7551,7 +7562,7 @@ dependencies = [
 [[package]]
 name = "polkadot-approval-distribution"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -7566,7 +7577,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "futures",
  "polkadot-node-network-protocol",
@@ -7580,7 +7591,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-distribution"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "derive_more",
  "fatality",
@@ -7603,7 +7614,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-recovery"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "fatality",
  "futures",
@@ -7624,7 +7635,7 @@ dependencies = [
 [[package]]
 name = "polkadot-cli"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "clap 4.1.6",
  "frame-benchmarking-cli",
@@ -7652,7 +7663,7 @@ dependencies = [
 [[package]]
 name = "polkadot-client"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -7695,7 +7706,7 @@ dependencies = [
 [[package]]
 name = "polkadot-collator-protocol"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "always-assert",
  "bitvec",
@@ -7717,7 +7728,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -7729,7 +7740,7 @@ dependencies = [
 [[package]]
 name = "polkadot-dispute-distribution"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "derive_more",
  "fatality",
@@ -7754,7 +7765,7 @@ dependencies = [
 [[package]]
 name = "polkadot-erasure-coding"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -7768,7 +7779,7 @@ dependencies = [
 [[package]]
 name = "polkadot-gossip-support"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "futures",
  "futures-timer",
@@ -7788,7 +7799,7 @@ dependencies = [
 [[package]]
 name = "polkadot-network-bridge"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "always-assert",
  "async-trait",
@@ -7812,7 +7823,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-collation-generation"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -7830,7 +7841,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "bitvec",
  "derive_more",
@@ -7859,7 +7870,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-av-store"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "bitvec",
  "futures",
@@ -7880,7 +7891,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-backing"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "bitvec",
  "fatality",
@@ -7899,7 +7910,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
@@ -7914,7 +7925,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-candidate-validation"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "async-trait",
  "futures",
@@ -7934,7 +7945,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-api"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -7949,7 +7960,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-selection"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "futures",
  "futures-timer",
@@ -7966,7 +7977,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "fatality",
  "futures",
@@ -7985,7 +7996,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "async-trait",
  "futures",
@@ -8002,7 +8013,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-provisioner"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "bitvec",
  "fatality",
@@ -8020,7 +8031,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "always-assert",
  "assert_matches",
@@ -8056,7 +8067,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-checker"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "futures",
  "polkadot-node-primitives",
@@ -8072,7 +8083,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-runtime-api"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "futures",
  "lru 0.9.0",
@@ -8087,7 +8098,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-jaeger"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "lazy_static",
  "log",
@@ -8105,7 +8116,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-metrics"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "bs58",
  "futures",
@@ -8124,7 +8135,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -8147,7 +8158,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "bounded-vec",
  "futures",
@@ -8170,7 +8181,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "polkadot-node-jaeger",
  "polkadot-node-subsystem-types",
@@ -8180,7 +8191,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-test-helpers"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "async-trait",
  "futures",
@@ -8198,7 +8209,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-types"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -8221,7 +8232,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-util"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -8254,7 +8265,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "async-trait",
  "futures",
@@ -8277,7 +8288,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "bounded-collections",
  "derive_more",
@@ -8376,7 +8387,7 @@ dependencies = [
 [[package]]
 name = "polkadot-performance-test"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "env_logger 0.9.0",
  "kusama-runtime",
@@ -8392,7 +8403,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "bitvec",
  "hex-literal",
@@ -8418,7 +8429,7 @@ dependencies = [
 [[package]]
 name = "polkadot-rpc"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "beefy-gadget",
  "beefy-gadget-rpc",
@@ -8450,7 +8461,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -8494,6 +8505,7 @@ dependencies = [
  "pallet-session-benchmarking",
  "pallet-staking",
  "pallet-staking-reward-curve",
+ "pallet-staking-runtime-api",
  "pallet-timestamp",
  "pallet-tips",
  "pallet-transaction-payment",
@@ -8539,7 +8551,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-common"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -8587,7 +8599,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-constants"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -8601,7 +8613,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "bs58",
  "parity-scale-codec",
@@ -8613,7 +8625,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "bitflags",
  "bitvec",
@@ -8657,7 +8669,7 @@ dependencies = [
 [[package]]
 name = "polkadot-service"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "async-trait",
  "beefy-gadget",
@@ -8766,7 +8778,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-distribution"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "arrayvec 0.5.2",
  "fatality",
@@ -8787,7 +8799,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -8797,7 +8809,7 @@ dependencies = [
 [[package]]
 name = "polkadot-test-client"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-subsystem",
@@ -8822,7 +8834,7 @@ dependencies = [
 [[package]]
 name = "polkadot-test-runtime"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "bitvec",
  "frame-election-provider-support",
@@ -8883,7 +8895,7 @@ dependencies = [
 [[package]]
 name = "polkadot-test-service"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "frame-benchmarking",
  "frame-system",
@@ -9598,7 +9610,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "binary-merkle-tree",
  "frame-benchmarking",
@@ -9684,7 +9696,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime-constants"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -9903,7 +9915,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "4.1.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "log",
  "sp-core",
@@ -9914,7 +9926,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "async-trait",
  "futures",
@@ -9941,7 +9953,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "futures",
  "futures-timer",
@@ -9964,7 +9976,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -9980,7 +9992,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "memmap2",
  "sc-chain-spec-derive",
@@ -9995,7 +10007,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -10006,7 +10018,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "array-bytes 4.2.0",
  "chrono",
@@ -10046,7 +10058,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "fnv",
  "futures",
@@ -10072,7 +10084,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -10098,7 +10110,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "async-trait",
  "futures",
@@ -10123,7 +10135,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "async-trait",
  "futures",
@@ -10152,7 +10164,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -10191,7 +10203,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -10213,7 +10225,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -10226,7 +10238,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "async-trait",
  "futures",
@@ -10249,7 +10261,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "lru 0.8.1",
  "parity-scale-codec",
@@ -10273,7 +10285,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "sc-allocator",
  "sp-maybe-compressed-blob",
@@ -10286,7 +10298,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "log",
  "sc-allocator",
@@ -10299,7 +10311,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -10317,7 +10329,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "ahash 0.8.2",
  "array-bytes 4.2.0",
@@ -10357,7 +10369,7 @@ dependencies = [
 [[package]]
 name = "sc-finality-grandpa-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "finality-grandpa",
  "futures",
@@ -10377,7 +10389,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "ansi_term",
  "futures",
@@ -10392,7 +10404,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "array-bytes 4.2.0",
  "async-trait",
@@ -10407,7 +10419,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "array-bytes 4.2.0",
  "async-trait",
@@ -10450,7 +10462,7 @@ dependencies = [
 [[package]]
 name = "sc-network-bitswap"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "cid",
  "futures",
@@ -10469,7 +10481,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "async-trait",
  "bitflags",
@@ -10495,7 +10507,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "ahash 0.8.2",
  "futures",
@@ -10513,7 +10525,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "array-bytes 4.2.0",
  "futures",
@@ -10534,7 +10546,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "array-bytes 4.2.0",
  "async-trait",
@@ -10566,7 +10578,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "array-bytes 4.2.0",
  "futures",
@@ -10585,7 +10597,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "array-bytes 4.2.0",
  "bytes",
@@ -10615,7 +10627,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "futures",
  "libp2p",
@@ -10628,7 +10640,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -10637,7 +10649,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -10667,7 +10679,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -10686,7 +10698,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "http",
  "jsonrpsee",
@@ -10701,7 +10713,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "array-bytes 4.2.0",
  "futures",
@@ -10727,7 +10739,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "async-trait",
  "directories",
@@ -10793,7 +10805,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -10804,7 +10816,7 @@ dependencies = [
 [[package]]
 name = "sc-storage-monitor"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "clap 4.1.6",
  "futures",
@@ -10820,7 +10832,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -10839,7 +10851,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "6.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "futures",
  "libc",
@@ -10858,7 +10870,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "chrono",
  "futures",
@@ -10877,7 +10889,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "ansi_term",
  "atty",
@@ -10908,7 +10920,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -10919,7 +10931,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "async-trait",
  "futures",
@@ -10946,7 +10958,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "async-trait",
  "futures",
@@ -10960,7 +10972,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "backtrace",
  "futures",
@@ -11410,7 +11422,7 @@ checksum = "03b634d87b960ab1a38c4fe143b508576f075e7c978bfad18217645ebfdfa2ec"
 [[package]]
 name = "slot-range-helper"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -11487,7 +11499,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "hash-db",
  "log",
@@ -11505,7 +11517,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "blake2",
  "proc-macro-crate",
@@ -11517,7 +11529,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11530,7 +11542,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -11544,7 +11556,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11557,7 +11569,7 @@ dependencies = [
 [[package]]
 name = "sp-beefy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "lazy_static",
  "parity-scale-codec",
@@ -11576,7 +11588,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -11588,7 +11600,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "futures",
  "log",
@@ -11606,7 +11618,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "async-trait",
  "futures",
@@ -11624,7 +11636,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -11642,7 +11654,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "async-trait",
  "merlin",
@@ -11665,7 +11677,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11677,7 +11689,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11690,7 +11702,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "array-bytes 4.2.0",
  "base58",
@@ -11733,7 +11745,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "blake2",
  "byteorder",
@@ -11747,7 +11759,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11758,7 +11770,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.1",
@@ -11767,7 +11779,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11777,7 +11789,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.13.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -11788,7 +11800,7 @@ dependencies = [
 [[package]]
 name = "sp-finality-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -11806,7 +11818,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -11821,7 +11833,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "bytes",
  "ed25519",
@@ -11846,7 +11858,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -11857,7 +11869,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.13.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "async-trait",
  "futures",
@@ -11874,7 +11886,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "4.1.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "thiserror",
  "zstd",
@@ -11883,7 +11895,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "ckb-merkle-mountain-range",
  "log",
@@ -11901,7 +11913,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11915,7 +11927,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -11925,7 +11937,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -11935,7 +11947,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -11945,7 +11957,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -11967,7 +11979,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -11985,7 +11997,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -11997,7 +12009,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "serde",
  "serde_json",
@@ -12006,7 +12018,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12020,7 +12032,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12032,7 +12044,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.13.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "hash-db",
  "log",
@@ -12052,12 +12064,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 
 [[package]]
 name = "sp-storage"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -12070,7 +12082,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "async-trait",
  "futures-timer",
@@ -12085,7 +12097,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "parity-scale-codec",
  "sp-std",
@@ -12097,7 +12109,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -12106,7 +12118,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "async-trait",
  "log",
@@ -12122,7 +12134,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "ahash 0.8.2",
  "hash-db",
@@ -12145,7 +12157,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -12162,7 +12174,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -12173,7 +12185,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -12187,7 +12199,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12495,7 +12507,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "platforms",
 ]
@@ -12503,7 +12515,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures",
@@ -12522,7 +12534,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "hyper",
  "log",
@@ -12534,7 +12546,7 @@ dependencies = [
 [[package]]
 name = "substrate-rpc-client"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "async-trait",
  "jsonrpsee",
@@ -12547,7 +12559,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-trie-migration-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "jsonrpsee",
  "log",
@@ -12566,7 +12578,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "array-bytes 4.2.0",
  "async-trait",
@@ -12592,7 +12604,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-utils"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "futures",
  "substrate-test-utils-derive",
@@ -12602,7 +12614,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-utils-derive"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -12613,7 +12625,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "5.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "ansi_term",
  "build-helper",
@@ -12730,7 +12742,7 @@ checksum = "13a4ec180a2de59b57434704ccfad967f789b12737738798fa08798cd5824c16"
 [[package]]
 name = "test-runtime-constants"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -13138,7 +13150,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "polkadot-node-jaeger",
  "polkadot-primitives",
@@ -13149,7 +13161,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "expander 0.0.6",
  "proc-macro-crate",
@@ -13279,7 +13291,7 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 [[package]]
 name = "try-runtime-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#5b6519a7ff4a2d3cc424d78bc4830688f3b184c0"
+source = "git+https://github.com/paritytech/substrate?branch=master#e374a33fe1d99d59eb24a08981090bdb4503e81b"
 dependencies = [
  "async-trait",
  "clap 4.1.6",
@@ -14195,7 +14207,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -14239,6 +14251,7 @@ dependencies = [
  "pallet-society",
  "pallet-staking",
  "pallet-staking-reward-curve",
+ "pallet-staking-runtime-api",
  "pallet-state-trie-migration",
  "pallet-sudo",
  "pallet-timestamp",
@@ -14286,7 +14299,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime-constants"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -14687,7 +14700,7 @@ dependencies = [
 [[package]]
 name = "xcm"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "bounded-collections",
  "derivative",
@@ -14703,7 +14716,7 @@ dependencies = [
 [[package]]
 name = "xcm-builder"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -14724,7 +14737,7 @@ dependencies = [
 [[package]]
 name = "xcm-executor"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -14744,7 +14757,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#b5358e54679de9a1387559f882c0cfef444ed07c"
+source = "git+https://github.com/paritytech/polkadot?branch=master#89c3a38afdbff1f71d0b35710658615232d375a0"
 dependencies = [
  "Inflector",
  "proc-macro2",

--- a/test/client/src/block_builder.rs
+++ b/test/client/src/block_builder.rs
@@ -22,10 +22,7 @@ use cumulus_test_runtime::{Block, GetLastTimestamp, Hash, Header};
 use polkadot_primitives::{BlockNumber as PBlockNumber, Hash as PHash};
 use sc_block_builder::{BlockBuilder, BlockBuilderProvider};
 use sp_api::ProvideRuntimeApi;
-use sp_runtime::{
-	generic::BlockId,
-	traits::{Block as BlockT, Header as HeaderT},
-};
+use sp_runtime::traits::{Block as BlockT, Header as HeaderT};
 
 /// An extension for the Cumulus test client to init a block builder.
 pub trait InitBlockBuilder {
@@ -45,7 +42,7 @@ pub trait InitBlockBuilder {
 	/// Init a specific block builder at a specific block that works for the test runtime.
 	///
 	/// Same as [`InitBlockBuilder::init_block_builder`] besides that it takes a
-	/// [`BlockId`] to say which should be the parent block of the block that is being build.
+	/// [`Hash`] to say which should be the parent block of the block that is being build.
 	fn init_block_builder_at(
 		&self,
 		at: Hash,
@@ -56,7 +53,7 @@ pub trait InitBlockBuilder {
 	/// Init a specific block builder that works for the test runtime.
 	///
 	/// Same as [`InitBlockBuilder::init_block_builder`] besides that it takes a
-	/// [`BlockId`] to say which should be the parent block of the block that is being build and
+	/// [`Hash`] to say which should be the parent block of the block that is being build and
 	/// it will use the given `timestamp` as input for the timestamp inherent.
 	fn init_block_builder_with_timestamp(
 		&self,
@@ -75,7 +72,7 @@ fn init_block_builder<'a>(
 	timestamp: u64,
 ) -> BlockBuilder<'a, Block, Client, Backend> {
 	let mut block_builder = client
-		.new_block_at(&BlockId::Hash(at), Default::default(), true)
+		.new_block_at(at, Default::default(), true)
 		.expect("Creates new block builder for test runtime");
 
 	let mut inherent_data = sp_inherents::InherentData::new();

--- a/test/client/src/block_builder.rs
+++ b/test/client/src/block_builder.rs
@@ -42,7 +42,7 @@ pub trait InitBlockBuilder {
 	/// Init a specific block builder at a specific block that works for the test runtime.
 	///
 	/// Same as [`InitBlockBuilder::init_block_builder`] besides that it takes a
-	/// [`Hash`] to say which should be the parent block of the block that is being build.
+	/// [`type@Hash`] to say which should be the parent block of the block that is being build.
 	fn init_block_builder_at(
 		&self,
 		at: Hash,
@@ -53,7 +53,7 @@ pub trait InitBlockBuilder {
 	/// Init a specific block builder that works for the test runtime.
 	///
 	/// Same as [`InitBlockBuilder::init_block_builder`] besides that it takes a
-	/// [`Hash`] to say which should be the parent block of the block that is being build and
+	/// [`type@Hash`] to say which should be the parent block of the block that is being build and
 	/// it will use the given `timestamp` as input for the timestamp inherent.
 	fn init_block_builder_with_timestamp(
 		&self,


### PR DESCRIPTION
It changes the arguments of `BlockBuilderProvider::new_block_at` from:
`BlockId<Block>` to: `Block::Hash`

This PR is part of BlockId::Number refactoring analysis (https://github.com/paritytech/substrate/issues/11292)

Companion for: paritytech/substrate#13401
