### PR TITLE
Collectives chain xcm filter

### DIFF
--- a/parachains/runtimes/collectives/collectives-polkadot/src/xcm_config.rs
+++ b/parachains/runtimes/collectives/collectives-polkadot/src/xcm_config.rs
@@ -155,6 +155,9 @@ impl Contains<RuntimeCall> for SafeCallFilter {
 			RuntimeCall::DmpQueue(..) |
 			RuntimeCall::Utility(pallet_utility::Call::as_derivative { .. }) |
 			RuntimeCall::Alliance(
+				// `init_members` accepts unbounded vecs as arguments,
+				// but the call can be initiated only by root origin.
+				pallet_alliance::Call::init_members { .. } |
 				pallet_alliance::Call::vote { .. } |
 				pallet_alliance::Call::close_old_weight { .. } |
 				pallet_alliance::Call::disband { .. } |
@@ -175,7 +178,8 @@ impl Contains<RuntimeCall> for SafeCallFilter {
 				pallet_collective::Call::close_old_weight { .. } |
 				pallet_collective::Call::disapprove_proposal { .. } |
 				pallet_collective::Call::close { .. },
-			) => true,
+			) |
+			RuntimeCall::PolkadotXcm(pallet_xcm::Call::force_xcm_version { .. }) => true,
 			_ => false,
 		}
 	}


### PR DESCRIPTION
Allow the executing of Alliance::init_member and XcmPallet::force_xcm_version via XCM Transact operation.

This is nice to have, both calls required for the integration tests https://github.com/paritytech/cumulus/pull/2221.