### PR TITLE
bump `zombienet` version to v1.3.35

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,7 +30,7 @@ variables:
   CI_IMAGE:                        "paritytech/ci-linux:production"
   DOCKER_OS:                       "debian:stretch"
   ARCH:                            "x86_64"
-  ZOMBIENET_IMAGE:                 "docker.io/paritytech/zombienet:v1.3.34"
+  ZOMBIENET_IMAGE:                 "docker.io/paritytech/zombienet:v1.3.35"
 
 .collect-artifacts:
   artifacts:

--- a/zombienet/tests/0001-sync_blocks_from_tip_without_connected_collator.zndsl
+++ b/zombienet/tests/0001-sync_blocks_from_tip_without_connected_collator.zndsl
@@ -2,12 +2,6 @@ Description: Sync blocks from tip without connected collator test
 Network: ./0001-sync_blocks_from_tip_without_connected_collator.toml
 Creds: config
 
-
-alice: is up
-bob: is up
-charlie: is up
-dave: is up
-
 alice: parachain 2000 is registered within 225 seconds
 alice: parachain 2000 block height is at least 10 within 250 seconds
 

--- a/zombienet/tests/0002-pov_recovery.zndsl
+++ b/zombienet/tests/0002-pov_recovery.zndsl
@@ -2,18 +2,6 @@ Description: PoV recovery test
 Network: ./0002-pov_recovery.toml
 Creds: config
 
-
-validator-0: is up
-validator-1: is up
-validator-2: is up
-validator-3: is up
-alice: is up within 60 seconds
-bob: is up within 60 seconds
-charlie: is up within 60 seconds
-one: is up within 60 seconds
-two: is up within 60 seconds
-eve: is up within 60 seconds
-
 # wait 20 blocks and register parachain
 validator-3: reports block height is at least 20 within 250 seconds
 validator-0: js-script ./register-para.js with "2000" within 240 seconds

--- a/zombienet/tests/0003-full_node_catching_up.zndsl
+++ b/zombienet/tests/0003-full_node_catching_up.zndsl
@@ -2,11 +2,6 @@ Description: Full node catching up test
 Network: ./0003-full_node_catching_up.toml
 Creds: config
 
-alice: is up
-bob: is up
-charlie: is up
-dave: is up
-eve: is up
 alice: parachain 2000 is registered within 225 seconds
 dave: reports block height is at least 7 within 250 seconds
 eve: reports block height is at least 7 within 250 seconds

--- a/zombienet/tests/0004-runtime_upgrade.zndsl
+++ b/zombienet/tests/0004-runtime_upgrade.zndsl
@@ -2,10 +2,6 @@ Description: Runtime Upgrade test
 Network: ./0004-runtime_upgrade.toml
 Creds: config
 
-alice: is up
-bob: is up
-charlie: is up
-dave: is up
 alice: parachain 2000 is registered within 225 seconds
 charlie: reports block height is at least 5 within 250 seconds
 charlie: parachain 2000 perform upgrade with /tmp/wasm_binary_spec_version_incremented.rs.compact.compressed.wasm within 200 seconds

--- a/zombienet/tests/0005-migrate_solo_to_para.zndsl
+++ b/zombienet/tests/0005-migrate_solo_to_para.zndsl
@@ -2,10 +2,6 @@ Description: Migrate solo to para
 Network: ./0005-migrate_solo_to_para.toml
 Creds: config
 
-alice: is up
-bob: is up
-dave: is up
-eve: is up
 alice: parachain 2000 is registered within 225 seconds
 alice: reports block height is at least 10 within 250 seconds
 alice: parachain 2000 block height is at least 10 within 250 seconds

--- a/zombienet/tests/0006-rpc_collator_builds_blocks.zndsl
+++ b/zombienet/tests/0006-rpc_collator_builds_blocks.zndsl
@@ -2,15 +2,6 @@ Description: RPC collator should build blocks
 Network: ./0006-rpc_collator_builds_blocks.toml
 Creds: config
 
-alice: is up
-bob: is up
-charlie: is up
-one: is up
-two: is up
-three: is up
-dave: is up
-eve: is up
-
 alice: parachain 2000 is registered within 225 seconds
 alice: parachain 2000 block height is at least 10 within 250 seconds
 

--- a/zombienet/tests/0007-full_node_warp_sync.zndsl
+++ b/zombienet/tests/0007-full_node_warp_sync.zndsl
@@ -2,12 +2,6 @@ Description: Full node catching up using warp sync
 Network: ./0007-full_node_warp_sync.toml
 Creds: config
 
-alice: is up within 30 seconds
-bob: is up within 30 seconds
-charlie: is up within 30 seconds
-dave: is up within 30 seconds
-eve: is up within 30 seconds
-ferdie: is up within 30 seconds
 alice: parachain 2000 is registered within 225 seconds
 one: reports block height is at least 770 within 225 seconds
 two: reports block height is at least 770 within 225 seconds


### PR DESCRIPTION
Bump zombienet version and removing the is up assertions since that is now checked by zombienet before running the tests.

Thanks!