### PR TITLE
[Backport] Tests + backport fix for teleport_assets (ReceiveTeleportedAsset) (#2…

### DIFF
--- a/parachains/runtimes/assets/statemine/src/weights/xcm/mod.rs
+++ b/parachains/runtimes/assets/statemine/src/weights/xcm/mod.rs
@@ -17,7 +17,7 @@
 mod pallet_xcm_benchmarks_fungible;
 mod pallet_xcm_benchmarks_generic;
 
-use crate::Runtime;
+use crate::{xcm_config::MaxAssetsIntoHolding, Runtime};
 use frame_support::weights::Weight;
 use pallet_xcm_benchmarks_fungible::WeightInfo as XcmFungibleWeight;
 use pallet_xcm_benchmarks_generic::WeightInfo as XcmGeneric;
@@ -28,14 +28,25 @@ trait WeighMultiAssets {
 	fn weigh_multi_assets(&self, weight: Weight) -> Weight;
 }
 
-const MAX_ASSETS: u32 = 100;
+const MAX_ASSETS: u64 = 100;
 
 impl WeighMultiAssets for MultiAssetFilter {
 	fn weigh_multi_assets(&self, weight: Weight) -> Weight {
 		match self {
 			Self::Definite(assets) =>
 				weight.saturating_mul(assets.inner().into_iter().count() as u64),
-			Self::Wild(_) => weight.saturating_mul(MAX_ASSETS as u64),
+			Self::Wild(asset) => match asset {
+				All => weight.saturating_mul(MAX_ASSETS),
+				AllOf { fun, .. } => match fun {
+					WildFungibility::Fungible => weight,
+					// Magic number 2 has to do with the fact that we could have up to 2 times
+					// MaxAssetsIntoHolding in the worst-case scenario.
+					WildFungibility::NonFungible =>
+						weight.saturating_mul((MaxAssetsIntoHolding::get() * 2) as u64),
+				},
+				AllCounted(count) => weight.saturating_mul(MAX_ASSETS.min(*count as u64)),
+				AllOfCounted { count, .. } => weight.saturating_mul(MAX_ASSETS.min(*count as u64)),
+			},
 		}
 	}
 }
@@ -138,10 +149,7 @@ impl<Call> XcmWeightInfo<Call> for StatemineXcmWeight<Call> {
 		_dest: &MultiLocation,
 		_xcm: &Xcm<()>,
 	) -> Weight {
-		// Hardcoded till the XCM pallet is fixed
-		let hardcoded_weight = Weight::from_ref_time(200_000_000 as u64);
-		let weight = assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::initiate_teleport());
-		hardcoded_weight.min(weight)
+		assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::initiate_teleport())
 	}
 	fn report_holding(_response_info: &QueryResponseInfo, _assets: &MultiAssetFilter) -> Weight {
 		XcmGeneric::<Runtime>::report_holding()

--- a/parachains/runtimes/assets/statemine/tests/tests.rs
+++ b/parachains/runtimes/assets/statemine/tests/tests.rs
@@ -1,7 +1,8 @@
 use asset_test_utils::{ExtBuilder, RuntimeHelper};
+use codec::Encode;
 use cumulus_primitives_utility::ChargeWeightInFungibles;
 use frame_support::{
-	assert_noop, assert_ok,
+	assert_noop, assert_ok, sp_io,
 	traits::PalletInfo,
 	weights::{Weight, WeightToFee as WeightToFeeT},
 };
@@ -9,10 +10,10 @@ use parachains_common::{AccountId, AuraId};
 use statemine_runtime::xcm_config::AssetFeeAsExistentialDepositMultiplierFeeCharger;
 pub use statemine_runtime::{
 	constants::fee::WeightToFee, xcm_config::XcmConfig, Assets, Balances, ExistentialDeposit,
-	Runtime, SessionKeys, System,
+	ReservedDmpWeight, Runtime, SessionKeys, System,
 };
 use xcm::latest::prelude::*;
-use xcm_executor::traits::WeightTrader;
+use xcm_executor::{traits::WeightTrader, XcmExecutor};
 
 pub const ALICE: [u8; 32] = [1u8; 32];
 
@@ -387,4 +388,52 @@ fn test_asset_xcm_trader_not_possible_for_non_sufficient_assets() {
 			// We also need to ensure the total supply NOT increased
 			assert_eq!(Assets::total_supply(1), minimum_asset_balance);
 		});
+}
+
+#[test]
+fn receive_teleported_asset_works() {
+	ExtBuilder::<Runtime>::default()
+		.with_collators(vec![AccountId::from(ALICE)])
+		.with_session_keys(vec![(
+			AccountId::from(ALICE),
+			AccountId::from(ALICE),
+			SessionKeys { aura: AuraId::from(sp_core::sr25519::Public::from_raw(ALICE)) },
+		)])
+		.build()
+		.execute_with(|| {
+			let xcm = Xcm(vec![
+				ReceiveTeleportedAsset(MultiAssets::from(vec![MultiAsset {
+					id: Concrete(MultiLocation { parents: 1, interior: Here }),
+					fun: Fungible(10000000000000),
+				}])),
+				ClearOrigin,
+				BuyExecution {
+					fees: MultiAsset {
+						id: Concrete(MultiLocation { parents: 1, interior: Here }),
+						fun: Fungible(10000000000000),
+					},
+					weight_limit: Limited(Weight::from_parts(303531000, 65536)),
+				},
+				DepositAsset {
+					assets: Wild(AllCounted(1)),
+					beneficiary: MultiLocation {
+						parents: 0,
+						interior: X1(AccountId32 {
+							network: None,
+							id: [
+								18, 153, 85, 112, 1, 245, 88, 21, 211, 252, 181, 60, 116, 70, 58,
+								203, 12, 246, 209, 77, 70, 57, 179, 64, 152, 44, 96, 135, 127, 56,
+								70, 9,
+							],
+						}),
+					},
+				},
+			]);
+			let hash = xcm.using_encoded(sp_io::hashing::blake2_256);
+
+			let weight_limit = ReservedDmpWeight::get();
+
+			let outcome = XcmExecutor::<XcmConfig>::execute_xcm(Parent, xcm, hash, weight_limit);
+			assert_eq!(outcome.ensure_complete(), Ok(()));
+		})
 }

--- a/parachains/runtimes/assets/statemint/src/weights/xcm/mod.rs
+++ b/parachains/runtimes/assets/statemint/src/weights/xcm/mod.rs
@@ -17,7 +17,7 @@
 mod pallet_xcm_benchmarks_fungible;
 mod pallet_xcm_benchmarks_generic;
 
-use crate::Runtime;
+use crate::{xcm_config::MaxAssetsIntoHolding, Runtime};
 use frame_support::weights::Weight;
 use pallet_xcm_benchmarks_fungible::WeightInfo as XcmFungibleWeight;
 use pallet_xcm_benchmarks_generic::WeightInfo as XcmGeneric;
@@ -28,14 +28,25 @@ trait WeighMultiAssets {
 	fn weigh_multi_assets(&self, weight: Weight) -> Weight;
 }
 
-const MAX_ASSETS: u32 = 100;
+const MAX_ASSETS: u64 = 100;
 
 impl WeighMultiAssets for MultiAssetFilter {
 	fn weigh_multi_assets(&self, weight: Weight) -> Weight {
 		match self {
 			Self::Definite(assets) =>
 				weight.saturating_mul(assets.inner().into_iter().count() as u64),
-			Self::Wild(_) => weight.saturating_mul(MAX_ASSETS as u64),
+			Self::Wild(asset) => match asset {
+				All => weight.saturating_mul(MAX_ASSETS),
+				AllOf { fun, .. } => match fun {
+					WildFungibility::Fungible => weight,
+					// Magic number 2 has to do with the fact that we could have up to 2 times
+					// MaxAssetsIntoHolding in the worst-case scenario.
+					WildFungibility::NonFungible =>
+						weight.saturating_mul((MaxAssetsIntoHolding::get() * 2) as u64),
+				},
+				AllCounted(count) => weight.saturating_mul(MAX_ASSETS.min(*count as u64)),
+				AllOfCounted { count, .. } => weight.saturating_mul(MAX_ASSETS.min(*count as u64)),
+			},
 		}
 	}
 }
@@ -138,10 +149,7 @@ impl<Call> XcmWeightInfo<Call> for StatemintXcmWeight<Call> {
 		_dest: &MultiLocation,
 		_xcm: &Xcm<()>,
 	) -> Weight {
-		// Hardcoded till the XCM pallet is fixed
-		let hardcoded_weight = Weight::from_ref_time(200_000_000 as u64);
-		let weight = assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::initiate_teleport());
-		hardcoded_weight.min(weight)
+		assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::initiate_teleport())
 	}
 	fn report_holding(_response_info: &QueryResponseInfo, _assets: &MultiAssetFilter) -> Weight {
 		XcmGeneric::<Runtime>::report_holding()

--- a/parachains/runtimes/assets/statemint/tests/tests.rs
+++ b/parachains/runtimes/assets/statemint/tests/tests.rs
@@ -1,7 +1,8 @@
 use asset_test_utils::{ExtBuilder, RuntimeHelper};
+use codec::Encode;
 use cumulus_primitives_utility::ChargeWeightInFungibles;
 use frame_support::{
-	assert_noop, assert_ok,
+	assert_noop, assert_ok, sp_io,
 	traits::PalletInfo,
 	weights::{Weight, WeightToFee as WeightToFeeT},
 };
@@ -9,10 +10,10 @@ use parachains_common::{AccountId, StatemintAuraId as AuraId};
 use statemint_runtime::xcm_config::AssetFeeAsExistentialDepositMultiplierFeeCharger;
 pub use statemint_runtime::{
 	constants::fee::WeightToFee, xcm_config::XcmConfig, Assets, Balances, ExistentialDeposit,
-	Runtime, SessionKeys, System,
+	ReservedDmpWeight, Runtime, SessionKeys, System,
 };
 use xcm::latest::prelude::*;
-use xcm_executor::traits::WeightTrader;
+use xcm_executor::{traits::WeightTrader, XcmExecutor};
 
 pub const ALICE: [u8; 32] = [1u8; 32];
 
@@ -399,4 +400,52 @@ fn test_asset_xcm_trader_not_possible_for_non_sufficient_assets() {
 			// We also need to ensure the total supply NOT increased
 			assert_eq!(Assets::total_supply(1), minimum_asset_balance);
 		});
+}
+
+#[test]
+fn receive_teleported_asset_works() {
+	ExtBuilder::<Runtime>::default()
+		.with_collators(vec![AccountId::from(ALICE)])
+		.with_session_keys(vec![(
+			AccountId::from(ALICE),
+			AccountId::from(ALICE),
+			SessionKeys { aura: AuraId::from(sp_core::ed25519::Public::from_raw(ALICE)) },
+		)])
+		.build()
+		.execute_with(|| {
+			let xcm = Xcm(vec![
+				ReceiveTeleportedAsset(MultiAssets::from(vec![MultiAsset {
+					id: Concrete(MultiLocation { parents: 1, interior: Here }),
+					fun: Fungible(10000000000000),
+				}])),
+				ClearOrigin,
+				BuyExecution {
+					fees: MultiAsset {
+						id: Concrete(MultiLocation { parents: 1, interior: Here }),
+						fun: Fungible(10000000000000),
+					},
+					weight_limit: Limited(Weight::from_parts(303531000, 65536)),
+				},
+				DepositAsset {
+					assets: Wild(AllCounted(1)),
+					beneficiary: MultiLocation {
+						parents: 0,
+						interior: X1(AccountId32 {
+							network: None,
+							id: [
+								18, 153, 85, 112, 1, 245, 88, 21, 211, 252, 181, 60, 116, 70, 58,
+								203, 12, 246, 209, 77, 70, 57, 179, 64, 152, 44, 96, 135, 127, 56,
+								70, 9,
+							],
+						}),
+					},
+				},
+			]);
+			let hash = xcm.using_encoded(sp_io::hashing::blake2_256);
+
+			let weight_limit = ReservedDmpWeight::get();
+
+			let outcome = XcmExecutor::<XcmConfig>::execute_xcm(Parent, xcm, hash, weight_limit);
+			assert_eq!(outcome.ensure_complete(), Ok(()));
+		})
 }

--- a/parachains/runtimes/assets/westmint/src/weights/xcm/mod.rs
+++ b/parachains/runtimes/assets/westmint/src/weights/xcm/mod.rs
@@ -17,7 +17,7 @@
 mod pallet_xcm_benchmarks_fungible;
 mod pallet_xcm_benchmarks_generic;
 
-use crate::Runtime;
+use crate::{xcm_config::MaxAssetsIntoHolding, Runtime};
 use frame_support::weights::Weight;
 use pallet_xcm_benchmarks_fungible::WeightInfo as XcmFungibleWeight;
 use pallet_xcm_benchmarks_generic::WeightInfo as XcmGeneric;
@@ -28,14 +28,25 @@ trait WeighMultiAssets {
 	fn weigh_multi_assets(&self, weight: Weight) -> Weight;
 }
 
-const MAX_ASSETS: u32 = 100;
+const MAX_ASSETS: u64 = 100;
 
 impl WeighMultiAssets for MultiAssetFilter {
 	fn weigh_multi_assets(&self, weight: Weight) -> Weight {
 		match self {
 			Self::Definite(assets) =>
 				weight.saturating_mul(assets.inner().into_iter().count() as u64),
-			Self::Wild(_) => weight.saturating_mul(MAX_ASSETS as u64),
+			Self::Wild(asset) => match asset {
+				All => weight.saturating_mul(MAX_ASSETS),
+				AllOf { fun, .. } => match fun {
+					WildFungibility::Fungible => weight,
+					// Magic number 2 has to do with the fact that we could have up to 2 times
+					// MaxAssetsIntoHolding in the worst-case scenario.
+					WildFungibility::NonFungible =>
+						weight.saturating_mul((MaxAssetsIntoHolding::get() * 2) as u64),
+				},
+				AllCounted(count) => weight.saturating_mul(MAX_ASSETS.min(*count as u64)),
+				AllOfCounted { count, .. } => weight.saturating_mul(MAX_ASSETS.min(*count as u64)),
+			},
 		}
 	}
 }
@@ -138,10 +149,7 @@ impl<Call> XcmWeightInfo<Call> for WestmintXcmWeight<Call> {
 		_dest: &MultiLocation,
 		_xcm: &Xcm<()>,
 	) -> Weight {
-		// Hardcoded till the XCM pallet is fixed
-		let hardcoded_weight = Weight::from_ref_time(200_000_000 as u64);
-		let weight = assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::initiate_teleport());
-		hardcoded_weight.min(weight)
+		assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::initiate_teleport())
 	}
 	fn report_holding(_response_info: &QueryResponseInfo, _assets: &MultiAssetFilter) -> Weight {
 		XcmGeneric::<Runtime>::report_holding()

--- a/parachains/runtimes/assets/westmint/tests/tests.rs
+++ b/parachains/runtimes/assets/westmint/tests/tests.rs
@@ -1,18 +1,19 @@
 use asset_test_utils::{ExtBuilder, RuntimeHelper};
+use codec::{DecodeLimit, Encode};
 use cumulus_primitives_utility::ChargeWeightInFungibles;
 use frame_support::{
-	assert_noop, assert_ok,
+	assert_noop, assert_ok, sp_io,
 	traits::PalletInfo,
 	weights::{Weight, WeightToFee as WeightToFeeT},
 };
 use parachains_common::{AccountId, AuraId};
-use westmint_runtime::xcm_config::AssetFeeAsExistentialDepositMultiplierFeeCharger;
 pub use westmint_runtime::{
 	constants::fee::WeightToFee, xcm_config::XcmConfig, Assets, Balances, ExistentialDeposit,
-	Runtime, SessionKeys, System,
+	ReservedDmpWeight, Runtime, SessionKeys, System,
 };
-use xcm::latest::prelude::*;
-use xcm_executor::traits::WeightTrader;
+use westmint_runtime::{xcm_config::AssetFeeAsExistentialDepositMultiplierFeeCharger, RuntimeCall};
+use xcm::{latest::prelude::*, VersionedXcm, MAX_XCM_DECODE_DEPTH};
+use xcm_executor::{traits::WeightTrader, XcmExecutor};
 
 pub const ALICE: [u8; 32] = [1u8; 32];
 
@@ -385,4 +386,80 @@ fn test_asset_xcm_trader_not_possible_for_non_sufficient_assets() {
 			// We also need to ensure the total supply NOT increased
 			assert_eq!(Assets::total_supply(1), minimum_asset_balance);
 		});
+}
+
+#[test]
+fn receive_teleported_asset_works() {
+	ExtBuilder::<Runtime>::default()
+		.with_collators(vec![AccountId::from(ALICE)])
+		.with_session_keys(vec![(
+			AccountId::from(ALICE),
+			AccountId::from(ALICE),
+			SessionKeys { aura: AuraId::from(sp_core::sr25519::Public::from_raw(ALICE)) },
+		)])
+		.build()
+		.execute_with(|| {
+			let xcm = Xcm(vec![
+				ReceiveTeleportedAsset(MultiAssets::from(vec![MultiAsset {
+					id: Concrete(MultiLocation { parents: 1, interior: Here }),
+					fun: Fungible(10000000000000),
+				}])),
+				ClearOrigin,
+				BuyExecution {
+					fees: MultiAsset {
+						id: Concrete(MultiLocation { parents: 1, interior: Here }),
+						fun: Fungible(10000000000000),
+					},
+					weight_limit: Limited(Weight::from_parts(303531000, 65536)),
+				},
+				DepositAsset {
+					assets: Wild(AllCounted(1)),
+					beneficiary: MultiLocation {
+						parents: 0,
+						interior: X1(AccountId32 {
+							network: None,
+							id: [
+								18, 153, 85, 112, 1, 245, 88, 21, 211, 252, 181, 60, 116, 70, 58,
+								203, 12, 246, 209, 77, 70, 57, 179, 64, 152, 44, 96, 135, 127, 56,
+								70, 9,
+							],
+						}),
+					},
+				},
+			]);
+			let hash = xcm.using_encoded(sp_io::hashing::blake2_256);
+
+			let weight_limit = ReservedDmpWeight::get();
+
+			let outcome = XcmExecutor::<XcmConfig>::execute_xcm(Parent, xcm, hash, weight_limit);
+			assert_eq!(outcome.ensure_complete(), Ok(()));
+		})
+}
+
+#[test]
+fn plain_receive_teleported_asset_works() {
+	ExtBuilder::<Runtime>::default()
+		.with_collators(vec![AccountId::from(ALICE)])
+		.with_session_keys(vec![(
+			AccountId::from(ALICE),
+			AccountId::from(ALICE),
+			SessionKeys { aura: AuraId::from(sp_core::sr25519::Public::from_raw(ALICE)) },
+		)])
+		.build()
+		.execute_with(|| {
+			let data = hex_literal::hex!("02100204000100000b00a0724e18090a13000100000b00a0724e180901e20f5e480d010004000101001299557001f55815d3fcb53c74463acb0cf6d14d4639b340982c60877f384609").to_vec();
+			let message_id = sp_io::hashing::blake2_256(&data);
+
+			let maybe_msg = VersionedXcm::<RuntimeCall>::decode_all_with_depth_limit(
+				MAX_XCM_DECODE_DEPTH,
+				&mut data.as_ref(),
+			)
+				.map(xcm::v3::Xcm::<RuntimeCall>::try_from).expect("failed").expect("failed");
+
+			let weight_limit = ReservedDmpWeight::get();
+
+			let outcome =
+				XcmExecutor::<XcmConfig>::execute_xcm(Parent, maybe_msg, message_id, weight_limit);
+			assert_eq!(outcome.ensure_complete(), Ok(()));
+		})
 }

--- a/parachains/runtimes/bridge-hubs/bridge-hub-kusama/src/weights/xcm/mod.rs
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-kusama/src/weights/xcm/mod.rs
@@ -17,7 +17,7 @@
 mod pallet_xcm_benchmarks_fungible;
 mod pallet_xcm_benchmarks_generic;
 
-use crate::Runtime;
+use crate::{xcm_config::MaxAssetsIntoHolding, Runtime};
 use frame_support::weights::Weight;
 use pallet_xcm_benchmarks_fungible::WeightInfo as XcmFungibleWeight;
 use pallet_xcm_benchmarks_generic::WeightInfo as XcmGeneric;
@@ -28,14 +28,25 @@ trait WeighMultiAssets {
 	fn weigh_multi_assets(&self, weight: Weight) -> Weight;
 }
 
-const MAX_ASSETS: u32 = 100;
+const MAX_ASSETS: u64 = 100;
 
 impl WeighMultiAssets for MultiAssetFilter {
 	fn weigh_multi_assets(&self, weight: Weight) -> Weight {
 		match self {
 			Self::Definite(assets) =>
 				weight.saturating_mul(assets.inner().into_iter().count() as u64),
-			Self::Wild(_) => weight.saturating_mul(MAX_ASSETS as u64),
+			Self::Wild(asset) => match asset {
+				All => weight.saturating_mul(MAX_ASSETS),
+				AllOf { fun, .. } => match fun {
+					WildFungibility::Fungible => weight,
+					// Magic number 2 has to do with the fact that we could have up to 2 times
+					// MaxAssetsIntoHolding in the worst-case scenario.
+					WildFungibility::NonFungible =>
+						weight.saturating_mul((MaxAssetsIntoHolding::get() * 2) as u64),
+				},
+				AllCounted(count) => weight.saturating_mul(MAX_ASSETS.min(*count as u64)),
+				AllOfCounted { count, .. } => weight.saturating_mul(MAX_ASSETS.min(*count as u64)),
+			},
 		}
 	}
 }
@@ -138,10 +149,7 @@ impl<Call> XcmWeightInfo<Call> for BridgeHubKusamaXcmWeight<Call> {
 		_dest: &MultiLocation,
 		_xcm: &Xcm<()>,
 	) -> Weight {
-		// Hardcoded till the XCM pallet is fixed
-		let hardcoded_weight = Weight::from_ref_time(200_000_000 as u64);
-		let weight = assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::initiate_teleport());
-		hardcoded_weight.min(weight)
+		assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::initiate_teleport())
 	}
 	fn report_holding(_response_info: &QueryResponseInfo, _assets: &MultiAssetFilter) -> Weight {
 		XcmGeneric::<Runtime>::report_holding()

--- a/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/src/weights/xcm/mod.rs
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/src/weights/xcm/mod.rs
@@ -17,7 +17,7 @@
 mod pallet_xcm_benchmarks_fungible;
 mod pallet_xcm_benchmarks_generic;
 
-use crate::Runtime;
+use crate::{xcm_config::MaxAssetsIntoHolding, Runtime};
 use frame_support::weights::Weight;
 use pallet_xcm_benchmarks_fungible::WeightInfo as XcmFungibleWeight;
 use pallet_xcm_benchmarks_generic::WeightInfo as XcmGeneric;
@@ -28,14 +28,25 @@ trait WeighMultiAssets {
 	fn weigh_multi_assets(&self, weight: Weight) -> Weight;
 }
 
-const MAX_ASSETS: u32 = 100;
+const MAX_ASSETS: u64 = 100;
 
 impl WeighMultiAssets for MultiAssetFilter {
 	fn weigh_multi_assets(&self, weight: Weight) -> Weight {
 		match self {
 			Self::Definite(assets) =>
 				weight.saturating_mul(assets.inner().into_iter().count() as u64),
-			Self::Wild(_) => weight.saturating_mul(MAX_ASSETS as u64),
+			Self::Wild(asset) => match asset {
+				All => weight.saturating_mul(MAX_ASSETS),
+				AllOf { fun, .. } => match fun {
+					WildFungibility::Fungible => weight,
+					// Magic number 2 has to do with the fact that we could have up to 2 times
+					// MaxAssetsIntoHolding in the worst-case scenario.
+					WildFungibility::NonFungible =>
+						weight.saturating_mul((MaxAssetsIntoHolding::get() * 2) as u64),
+				},
+				AllCounted(count) => weight.saturating_mul(MAX_ASSETS.min(*count as u64)),
+				AllOfCounted { count, .. } => weight.saturating_mul(MAX_ASSETS.min(*count as u64)),
+			},
 		}
 	}
 }

--- a/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/weights/xcm/mod.rs
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/weights/xcm/mod.rs
@@ -17,7 +17,7 @@
 mod pallet_xcm_benchmarks_fungible;
 mod pallet_xcm_benchmarks_generic;
 
-use crate::Runtime;
+use crate::{xcm_config::MaxAssetsIntoHolding, Runtime};
 use frame_support::weights::Weight;
 use pallet_xcm_benchmarks_fungible::WeightInfo as XcmFungibleWeight;
 use pallet_xcm_benchmarks_generic::WeightInfo as XcmGeneric;
@@ -28,14 +28,25 @@ trait WeighMultiAssets {
 	fn weigh_multi_assets(&self, weight: Weight) -> Weight;
 }
 
-const MAX_ASSETS: u32 = 100;
+const MAX_ASSETS: u64 = 100;
 
 impl WeighMultiAssets for MultiAssetFilter {
 	fn weigh_multi_assets(&self, weight: Weight) -> Weight {
 		match self {
 			Self::Definite(assets) =>
 				weight.saturating_mul(assets.inner().into_iter().count() as u64),
-			Self::Wild(_) => weight.saturating_mul(MAX_ASSETS as u64),
+			Self::Wild(asset) => match asset {
+				All => weight.saturating_mul(MAX_ASSETS),
+				AllOf { fun, .. } => match fun {
+					WildFungibility::Fungible => weight,
+					// Magic number 2 has to do with the fact that we could have up to 2 times
+					// MaxAssetsIntoHolding in the worst-case scenario.
+					WildFungibility::NonFungible =>
+						weight.saturating_mul((MaxAssetsIntoHolding::get() * 2) as u64),
+				},
+				AllCounted(count) => weight.saturating_mul(MAX_ASSETS.min(*count as u64)),
+				AllOfCounted { count, .. } => weight.saturating_mul(MAX_ASSETS.min(*count as u64)),
+			},
 		}
 	}
 }
@@ -138,10 +149,7 @@ impl<Call> XcmWeightInfo<Call> for BridgeHubRococoXcmWeight<Call> {
 		_dest: &MultiLocation,
 		_xcm: &Xcm<()>,
 	) -> Weight {
-		// Hardcoded till the XCM pallet is fixed
-		let hardcoded_weight = Weight::from_ref_time(200_000_000 as u64);
-		let weight = assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::initiate_teleport());
-		hardcoded_weight.min(weight)
+		assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::initiate_teleport())
 	}
 	fn report_holding(_response_info: &QueryResponseInfo, _assets: &MultiAssetFilter) -> Weight {
 		XcmGeneric::<Runtime>::report_holding()


### PR DESCRIPTION
…235)

* Wwstmint test for ReceiveTeleportedAsset

* Missing fix for `weigh_multi_assets`

* Added tests for statemine/statemint

* [Enhancement] Use XCM V3 for initiate_teleport weight calc (#2102)

* [Enhancement] Use XCM V3 for initiate_teleport weight calc

* deref

* replicate in all the runtimes

* fmt

* better handling for AllOf

* fmt

* small type fix

* replicate the fix for all runtimes

---------

Co-authored-by: parity-processbot <>

* removed `frame_support::sp_tracing::try_init_simple();`

* Review fixes

* Removed `as u64`

---------