### PR TITLE
Migrate to `Weight::from_parts`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5907,7 +5907,7 @@ dependencies = [
 [[package]]
 name = "pallet-alliance"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "array-bytes 4.2.0",
  "frame-benchmarking",
@@ -5928,7 +5928,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-tx-payment"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5946,7 +5946,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5961,7 +5961,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6188,7 +6188,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "bitflags",
  "frame-benchmarking",
@@ -6217,7 +6217,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-primitives"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "bitflags",
  "parity-scale-codec",
@@ -6230,7 +6230,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6423,7 +6423,7 @@ dependencies = [
 [[package]]
 name = "pallet-insecure-randomness-collective-flip"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6487,7 +6487,7 @@ dependencies = [
 [[package]]
 name = "pallet-nfts"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -6505,7 +6505,7 @@ dependencies = [
 [[package]]
 name = "pallet-nfts-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-support",
  "pallet-nfts",
@@ -6969,7 +6969,7 @@ dependencies = [
 [[package]]
 name = "pallet-uniques"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10187,7 +10187,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "async-trait",
  "futures",
@@ -12111,7 +12111,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "serde",
  "serde_json",
@@ -12708,7 +12708,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-utils"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "futures",
  "substrate-test-utils-derive",
@@ -12718,7 +12718,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-utils-derive"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,7 +500,7 @@ dependencies = [
 [[package]]
 name = "binary-merkle-tree"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "hash-db",
  "log",
@@ -3219,7 +3219,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -3242,7 +3242,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 [[package]]
 name = "frame-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -3267,7 +3267,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "Inflector",
  "array-bytes 4.2.0",
@@ -3314,7 +3314,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -3325,7 +3325,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -3342,7 +3342,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3371,7 +3371,7 @@ dependencies = [
 [[package]]
 name = "frame-remote-externalities"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "futures",
  "log",
@@ -3387,7 +3387,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "bitflags",
  "environmental",
@@ -3420,7 +3420,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -3435,7 +3435,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -3447,7 +3447,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3457,7 +3457,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "frame-support",
  "log",
@@ -3475,7 +3475,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3490,7 +3490,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -3499,7 +3499,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4449,7 +4449,7 @@ checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 [[package]]
 name = "kusama-runtime"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -4547,7 +4547,7 @@ dependencies = [
 [[package]]
 name = "kusama-runtime-constants"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -5390,7 +5390,7 @@ dependencies = [
 [[package]]
 name = "mmr-gadget"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "futures",
  "log",
@@ -5409,7 +5409,7 @@ dependencies = [
 [[package]]
 name = "mmr-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "anyhow",
  "jsonrpsee",
@@ -5907,7 +5907,7 @@ dependencies = [
 [[package]]
 name = "pallet-alliance"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "array-bytes 4.2.0",
  "frame-benchmarking",
@@ -5928,7 +5928,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-tx-payment"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5946,7 +5946,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5961,7 +5961,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5977,7 +5977,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5993,7 +5993,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6007,7 +6007,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6031,7 +6031,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6051,7 +6051,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6066,7 +6066,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6085,7 +6085,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "array-bytes 4.2.0",
  "binary-merkle-tree",
@@ -6109,7 +6109,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6127,7 +6127,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6171,7 +6171,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6188,7 +6188,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "bitflags",
  "frame-benchmarking",
@@ -6217,7 +6217,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-primitives"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "bitflags",
  "parity-scale-codec",
@@ -6230,7 +6230,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6240,7 +6240,7 @@ dependencies = [
 [[package]]
 name = "pallet-conviction-voting"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -6257,7 +6257,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6275,7 +6275,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6298,7 +6298,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6311,7 +6311,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "5.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6329,7 +6329,7 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6347,7 +6347,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6370,7 +6370,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -6386,7 +6386,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6406,7 +6406,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6423,7 +6423,7 @@ dependencies = [
 [[package]]
 name = "pallet-insecure-randomness-collective-flip"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6437,7 +6437,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6454,7 +6454,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6471,7 +6471,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6487,7 +6487,7 @@ dependencies = [
 [[package]]
 name = "pallet-nfts"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -6505,7 +6505,7 @@ dependencies = [
 [[package]]
 name = "pallet-nfts-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "frame-support",
  "pallet-nfts",
@@ -6516,7 +6516,7 @@ dependencies = [
 [[package]]
 name = "pallet-nis"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6532,7 +6532,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6549,7 +6549,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6569,7 +6569,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
 version = "1.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
@@ -6580,7 +6580,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6597,7 +6597,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6621,7 +6621,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6638,7 +6638,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6653,7 +6653,7 @@ dependencies = [
 [[package]]
 name = "pallet-ranked-collective"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6671,7 +6671,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6686,7 +6686,7 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -6705,7 +6705,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6722,7 +6722,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6743,7 +6743,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6759,7 +6759,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6773,7 +6773,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6796,7 +6796,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -6807,7 +6807,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -6816,7 +6816,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6825,7 +6825,7 @@ dependencies = [
 [[package]]
 name = "pallet-state-trie-migration"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6842,7 +6842,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6871,7 +6871,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6889,7 +6889,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6908,7 +6908,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6924,7 +6924,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -6940,7 +6940,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -6952,7 +6952,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6969,7 +6969,7 @@ dependencies = [
 [[package]]
 name = "pallet-uniques"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6984,7 +6984,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7000,7 +7000,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7015,7 +7015,7 @@ dependencies = [
 [[package]]
 name = "pallet-whitelist"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7030,7 +7030,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "bounded-collections",
  "frame-benchmarking",
@@ -7051,7 +7051,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-benchmarks"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7587,7 +7587,7 @@ dependencies = [
 [[package]]
 name = "polkadot-approval-distribution"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -7602,7 +7602,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "futures",
  "polkadot-node-network-protocol",
@@ -7616,7 +7616,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-distribution"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "derive_more",
  "fatality",
@@ -7639,7 +7639,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-recovery"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "fatality",
  "futures",
@@ -7660,7 +7660,7 @@ dependencies = [
 [[package]]
 name = "polkadot-cli"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "clap 4.1.6",
  "frame-benchmarking-cli",
@@ -7688,7 +7688,7 @@ dependencies = [
 [[package]]
 name = "polkadot-client"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -7731,7 +7731,7 @@ dependencies = [
 [[package]]
 name = "polkadot-collator-protocol"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "always-assert",
  "bitvec",
@@ -7753,7 +7753,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -7765,7 +7765,7 @@ dependencies = [
 [[package]]
 name = "polkadot-dispute-distribution"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "derive_more",
  "fatality",
@@ -7790,7 +7790,7 @@ dependencies = [
 [[package]]
 name = "polkadot-erasure-coding"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -7804,7 +7804,7 @@ dependencies = [
 [[package]]
 name = "polkadot-gossip-support"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "futures",
  "futures-timer",
@@ -7824,7 +7824,7 @@ dependencies = [
 [[package]]
 name = "polkadot-network-bridge"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "always-assert",
  "async-trait",
@@ -7848,7 +7848,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-collation-generation"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -7866,7 +7866,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "bitvec",
  "derive_more",
@@ -7895,7 +7895,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-av-store"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "bitvec",
  "futures",
@@ -7916,7 +7916,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-backing"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "bitvec",
  "fatality",
@@ -7935,7 +7935,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
@@ -7950,7 +7950,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-candidate-validation"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "async-trait",
  "futures",
@@ -7970,7 +7970,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-api"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -7985,7 +7985,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-selection"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "futures",
  "futures-timer",
@@ -8002,7 +8002,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "fatality",
  "futures",
@@ -8021,7 +8021,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "async-trait",
  "futures",
@@ -8038,7 +8038,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-provisioner"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "bitvec",
  "fatality",
@@ -8056,7 +8056,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "always-assert",
  "assert_matches",
@@ -8092,7 +8092,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-checker"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "futures",
  "polkadot-node-primitives",
@@ -8108,7 +8108,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-runtime-api"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "futures",
  "lru 0.9.0",
@@ -8123,7 +8123,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-jaeger"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "lazy_static",
  "log",
@@ -8141,7 +8141,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-metrics"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "bs58",
  "futures",
@@ -8160,7 +8160,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -8183,7 +8183,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "bounded-vec",
  "futures",
@@ -8206,7 +8206,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "polkadot-node-jaeger",
  "polkadot-node-subsystem-types",
@@ -8216,7 +8216,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-test-helpers"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "async-trait",
  "futures",
@@ -8234,7 +8234,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-types"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -8257,7 +8257,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-util"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -8290,7 +8290,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "async-trait",
  "futures",
@@ -8313,7 +8313,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "bounded-collections",
  "derive_more",
@@ -8412,7 +8412,7 @@ dependencies = [
 [[package]]
 name = "polkadot-performance-test"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "env_logger 0.9.0",
  "kusama-runtime",
@@ -8428,7 +8428,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "bitvec",
  "hex-literal",
@@ -8454,7 +8454,7 @@ dependencies = [
 [[package]]
 name = "polkadot-rpc"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "jsonrpsee",
  "mmr-rpc",
@@ -8486,7 +8486,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -8576,7 +8576,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-common"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -8622,7 +8622,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-constants"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -8636,7 +8636,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "bs58",
  "parity-scale-codec",
@@ -8648,7 +8648,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "bitflags",
  "bitvec",
@@ -8692,7 +8692,7 @@ dependencies = [
 [[package]]
 name = "polkadot-service"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "async-trait",
  "frame-benchmarking-cli",
@@ -8801,7 +8801,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-distribution"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "arrayvec 0.5.2",
  "fatality",
@@ -8822,7 +8822,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -8832,7 +8832,7 @@ dependencies = [
 [[package]]
 name = "polkadot-test-client"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-subsystem",
@@ -8857,7 +8857,7 @@ dependencies = [
 [[package]]
 name = "polkadot-test-runtime"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "bitvec",
  "frame-election-provider-support",
@@ -8918,7 +8918,7 @@ dependencies = [
 [[package]]
 name = "polkadot-test-service"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "frame-benchmarking",
  "frame-system",
@@ -9645,7 +9645,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "binary-merkle-tree",
  "frame-benchmarking",
@@ -9731,7 +9731,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime-constants"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -9964,7 +9964,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "4.1.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "log",
  "sp-core",
@@ -9975,7 +9975,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "async-trait",
  "futures",
@@ -10002,7 +10002,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "futures",
  "futures-timer",
@@ -10025,7 +10025,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -10040,7 +10040,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "memmap2",
  "sc-chain-spec-derive",
@@ -10059,7 +10059,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -10070,7 +10070,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "array-bytes 4.2.0",
  "chrono",
@@ -10110,7 +10110,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "fnv",
  "futures",
@@ -10136,7 +10136,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -10162,7 +10162,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "async-trait",
  "futures",
@@ -10187,7 +10187,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "async-trait",
  "futures",
@@ -10216,7 +10216,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -10255,7 +10255,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -10277,7 +10277,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "array-bytes 4.2.0",
  "async-trait",
@@ -10311,7 +10311,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -10330,7 +10330,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -10343,7 +10343,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "ahash 0.8.2",
  "array-bytes 4.2.0",
@@ -10383,7 +10383,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "finality-grandpa",
  "futures",
@@ -10403,7 +10403,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "async-trait",
  "futures",
@@ -10426,7 +10426,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "lru 0.8.1",
  "parity-scale-codec",
@@ -10450,7 +10450,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "sc-allocator",
  "sp-maybe-compressed-blob",
@@ -10463,7 +10463,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "log",
  "sc-allocator",
@@ -10476,7 +10476,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -10494,7 +10494,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "ansi_term",
  "futures",
@@ -10509,7 +10509,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "array-bytes 4.2.0",
  "async-trait",
@@ -10524,7 +10524,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "array-bytes 4.2.0",
  "async-channel",
@@ -10567,7 +10567,7 @@ dependencies = [
 [[package]]
 name = "sc-network-bitswap"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "cid",
  "futures",
@@ -10586,7 +10586,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "async-trait",
  "bitflags",
@@ -10612,7 +10612,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "ahash 0.8.2",
  "futures",
@@ -10630,7 +10630,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "array-bytes 4.2.0",
  "futures",
@@ -10651,7 +10651,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "array-bytes 4.2.0",
  "async-trait",
@@ -10683,7 +10683,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "array-bytes 4.2.0",
  "futures",
@@ -10702,7 +10702,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "array-bytes 4.2.0",
  "bytes",
@@ -10732,7 +10732,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "futures",
  "libp2p",
@@ -10745,7 +10745,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -10754,7 +10754,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -10784,7 +10784,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -10803,7 +10803,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "http",
  "jsonrpsee",
@@ -10818,7 +10818,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "array-bytes 4.2.0",
  "futures",
@@ -10844,7 +10844,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "async-trait",
  "directories",
@@ -10910,7 +10910,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -10921,7 +10921,7 @@ dependencies = [
 [[package]]
 name = "sc-storage-monitor"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "clap 4.1.6",
  "fs4",
@@ -10937,7 +10937,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -10956,7 +10956,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "6.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "futures",
  "libc",
@@ -10975,7 +10975,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "chrono",
  "futures",
@@ -10994,7 +10994,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "ansi_term",
  "atty",
@@ -11025,7 +11025,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -11036,7 +11036,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "async-trait",
  "futures",
@@ -11063,7 +11063,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "async-trait",
  "futures",
@@ -11077,7 +11077,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "backtrace",
  "futures",
@@ -11527,7 +11527,7 @@ checksum = "03b634d87b960ab1a38c4fe143b508576f075e7c978bfad18217645ebfdfa2ec"
 [[package]]
 name = "slot-range-helper"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -11604,7 +11604,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "hash-db",
  "log",
@@ -11622,7 +11622,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "blake2",
  "proc-macro-crate",
@@ -11634,7 +11634,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11647,7 +11647,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -11661,7 +11661,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11674,7 +11674,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -11686,7 +11686,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "futures",
  "log",
@@ -11704,7 +11704,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "async-trait",
  "futures",
@@ -11719,7 +11719,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -11737,7 +11737,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "async-trait",
  "merlin",
@@ -11760,7 +11760,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-beefy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "lazy_static",
  "parity-scale-codec",
@@ -11779,7 +11779,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -11797,7 +11797,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11809,7 +11809,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11822,7 +11822,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "array-bytes 4.2.0",
  "base58",
@@ -11865,7 +11865,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "blake2",
  "byteorder",
@@ -11879,7 +11879,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11890,7 +11890,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.1",
@@ -11899,7 +11899,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11909,7 +11909,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.13.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -11920,7 +11920,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -11935,7 +11935,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "bytes",
  "ed25519",
@@ -11960,7 +11960,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -11971,7 +11971,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.13.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "async-trait",
  "futures",
@@ -11988,7 +11988,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "4.1.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "thiserror",
  "zstd",
@@ -11997,7 +11997,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "ckb-merkle-mountain-range",
  "log",
@@ -12015,7 +12015,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12029,7 +12029,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -12039,7 +12039,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -12049,7 +12049,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -12059,7 +12059,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -12081,7 +12081,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -12099,7 +12099,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -12111,7 +12111,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "serde",
  "serde_json",
@@ -12120,7 +12120,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12134,7 +12134,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12146,7 +12146,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.13.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "hash-db",
  "log",
@@ -12166,12 +12166,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 
 [[package]]
 name = "sp-storage"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -12184,7 +12184,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "async-trait",
  "futures-timer",
@@ -12199,7 +12199,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "parity-scale-codec",
  "sp-std",
@@ -12211,7 +12211,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -12220,7 +12220,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "async-trait",
  "log",
@@ -12236,7 +12236,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "ahash 0.8.2",
  "hash-db",
@@ -12259,7 +12259,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -12276,7 +12276,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -12287,7 +12287,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -12301,7 +12301,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12611,7 +12611,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "platforms",
 ]
@@ -12619,7 +12619,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures",
@@ -12638,7 +12638,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "hyper",
  "log",
@@ -12650,7 +12650,7 @@ dependencies = [
 [[package]]
 name = "substrate-rpc-client"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "async-trait",
  "jsonrpsee",
@@ -12663,7 +12663,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-trie-migration-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "jsonrpsee",
  "log",
@@ -12682,7 +12682,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "array-bytes 4.2.0",
  "async-trait",
@@ -12708,7 +12708,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-utils"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "futures",
  "substrate-test-utils-derive",
@@ -12718,7 +12718,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-utils-derive"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -12729,7 +12729,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "5.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "ansi_term",
  "build-helper",
@@ -12846,7 +12846,7 @@ checksum = "13a4ec180a2de59b57434704ccfad967f789b12737738798fa08798cd5824c16"
 [[package]]
 name = "test-runtime-constants"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -13237,7 +13237,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "polkadot-node-jaeger",
  "polkadot-primitives",
@@ -13248,7 +13248,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "expander 0.0.6",
  "proc-macro-crate",
@@ -13378,7 +13378,7 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 [[package]]
 name = "try-runtime-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
+source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
 dependencies = [
  "async-trait",
  "clap 4.1.6",
@@ -14305,7 +14305,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -14397,7 +14397,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime-constants"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -14800,7 +14800,7 @@ dependencies = [
 [[package]]
 name = "xcm"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "bounded-collections",
  "derivative",
@@ -14816,7 +14816,7 @@ dependencies = [
 [[package]]
 name = "xcm-builder"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -14837,7 +14837,7 @@ dependencies = [
 [[package]]
 name = "xcm-executor"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -14857,7 +14857,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
+source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
 dependencies = [
  "Inflector",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5907,7 +5907,7 @@ dependencies = [
 [[package]]
 name = "pallet-alliance"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "array-bytes 4.2.0",
  "frame-benchmarking",
@@ -5928,7 +5928,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-tx-payment"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5946,7 +5946,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5961,7 +5961,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6188,7 +6188,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "bitflags",
  "frame-benchmarking",
@@ -6217,7 +6217,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-primitives"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "bitflags",
  "parity-scale-codec",
@@ -6230,7 +6230,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6423,7 +6423,7 @@ dependencies = [
 [[package]]
 name = "pallet-insecure-randomness-collective-flip"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6487,7 +6487,7 @@ dependencies = [
 [[package]]
 name = "pallet-nfts"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -6505,7 +6505,7 @@ dependencies = [
 [[package]]
 name = "pallet-nfts-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "frame-support",
  "pallet-nfts",
@@ -6969,7 +6969,7 @@ dependencies = [
 [[package]]
 name = "pallet-uniques"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10187,7 +10187,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "async-trait",
  "futures",
@@ -12111,7 +12111,7 @@ dependencies = [
 [[package]]
 name = "sp-serializer"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "serde",
  "serde_json",
@@ -12708,7 +12708,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-utils"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "futures",
  "substrate-test-utils-derive",
@@ -12718,7 +12718,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-utils-derive"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,7 +500,7 @@ dependencies = [
 [[package]]
 name = "binary-merkle-tree"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "hash-db",
  "log",
@@ -3219,7 +3219,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -3242,7 +3242,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 [[package]]
 name = "frame-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -3267,7 +3267,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "Inflector",
  "array-bytes 4.2.0",
@@ -3314,7 +3314,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -3325,7 +3325,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -3342,7 +3342,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3371,7 +3371,7 @@ dependencies = [
 [[package]]
 name = "frame-remote-externalities"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "futures",
  "log",
@@ -3387,7 +3387,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "bitflags",
  "environmental",
@@ -3420,7 +3420,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -3435,7 +3435,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -3447,7 +3447,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3457,7 +3457,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-support",
  "log",
@@ -3475,7 +3475,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3490,7 +3490,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -3499,7 +3499,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4449,7 +4449,7 @@ checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 [[package]]
 name = "kusama-runtime"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -4547,7 +4547,7 @@ dependencies = [
 [[package]]
 name = "kusama-runtime-constants"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -5390,7 +5390,7 @@ dependencies = [
 [[package]]
 name = "mmr-gadget"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "futures",
  "log",
@@ -5409,7 +5409,7 @@ dependencies = [
 [[package]]
 name = "mmr-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "anyhow",
  "jsonrpsee",
@@ -5977,7 +5977,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5993,7 +5993,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6007,7 +6007,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6031,7 +6031,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6051,7 +6051,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6066,7 +6066,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6085,7 +6085,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "array-bytes 4.2.0",
  "binary-merkle-tree",
@@ -6109,7 +6109,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6127,7 +6127,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6171,7 +6171,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6240,7 +6240,7 @@ dependencies = [
 [[package]]
 name = "pallet-conviction-voting"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -6257,7 +6257,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6275,7 +6275,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6298,7 +6298,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6311,7 +6311,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "5.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6329,7 +6329,7 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6347,7 +6347,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6370,7 +6370,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -6386,7 +6386,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6406,7 +6406,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6437,7 +6437,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6454,7 +6454,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6471,7 +6471,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6516,7 +6516,7 @@ dependencies = [
 [[package]]
 name = "pallet-nis"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6532,7 +6532,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6549,7 +6549,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6569,7 +6569,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
 version = "1.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
@@ -6580,7 +6580,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6597,7 +6597,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6621,7 +6621,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6638,7 +6638,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6653,7 +6653,7 @@ dependencies = [
 [[package]]
 name = "pallet-ranked-collective"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6671,7 +6671,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6686,7 +6686,7 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -6705,7 +6705,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6722,7 +6722,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6743,7 +6743,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6759,7 +6759,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6773,7 +6773,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6796,7 +6796,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -6807,7 +6807,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -6816,7 +6816,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6825,7 +6825,7 @@ dependencies = [
 [[package]]
 name = "pallet-state-trie-migration"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6842,7 +6842,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6871,7 +6871,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6889,7 +6889,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6908,7 +6908,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6924,7 +6924,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -6940,7 +6940,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -6952,7 +6952,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6984,7 +6984,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7000,7 +7000,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7015,7 +7015,7 @@ dependencies = [
 [[package]]
 name = "pallet-whitelist"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7030,7 +7030,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "bounded-collections",
  "frame-benchmarking",
@@ -7051,7 +7051,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-benchmarks"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7587,7 +7587,7 @@ dependencies = [
 [[package]]
 name = "polkadot-approval-distribution"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -7602,7 +7602,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "futures",
  "polkadot-node-network-protocol",
@@ -7616,7 +7616,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-distribution"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "derive_more",
  "fatality",
@@ -7639,7 +7639,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-recovery"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "fatality",
  "futures",
@@ -7660,7 +7660,7 @@ dependencies = [
 [[package]]
 name = "polkadot-cli"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "clap 4.1.6",
  "frame-benchmarking-cli",
@@ -7688,7 +7688,7 @@ dependencies = [
 [[package]]
 name = "polkadot-client"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -7731,7 +7731,7 @@ dependencies = [
 [[package]]
 name = "polkadot-collator-protocol"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "always-assert",
  "bitvec",
@@ -7753,7 +7753,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -7765,7 +7765,7 @@ dependencies = [
 [[package]]
 name = "polkadot-dispute-distribution"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "derive_more",
  "fatality",
@@ -7790,7 +7790,7 @@ dependencies = [
 [[package]]
 name = "polkadot-erasure-coding"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -7804,7 +7804,7 @@ dependencies = [
 [[package]]
 name = "polkadot-gossip-support"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "futures",
  "futures-timer",
@@ -7824,7 +7824,7 @@ dependencies = [
 [[package]]
 name = "polkadot-network-bridge"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "always-assert",
  "async-trait",
@@ -7848,7 +7848,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-collation-generation"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -7866,7 +7866,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "bitvec",
  "derive_more",
@@ -7895,7 +7895,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-av-store"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "bitvec",
  "futures",
@@ -7916,7 +7916,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-backing"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "bitvec",
  "fatality",
@@ -7935,7 +7935,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
@@ -7950,7 +7950,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-candidate-validation"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "async-trait",
  "futures",
@@ -7970,7 +7970,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-api"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -7985,7 +7985,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-selection"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "futures",
  "futures-timer",
@@ -8002,7 +8002,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "fatality",
  "futures",
@@ -8021,7 +8021,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "async-trait",
  "futures",
@@ -8038,7 +8038,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-provisioner"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "bitvec",
  "fatality",
@@ -8056,7 +8056,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "always-assert",
  "assert_matches",
@@ -8092,7 +8092,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-checker"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "futures",
  "polkadot-node-primitives",
@@ -8108,7 +8108,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-runtime-api"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "futures",
  "lru 0.9.0",
@@ -8123,7 +8123,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-jaeger"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "lazy_static",
  "log",
@@ -8141,7 +8141,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-metrics"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "bs58",
  "futures",
@@ -8160,7 +8160,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -8183,7 +8183,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "bounded-vec",
  "futures",
@@ -8206,7 +8206,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "polkadot-node-jaeger",
  "polkadot-node-subsystem-types",
@@ -8216,7 +8216,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-test-helpers"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "async-trait",
  "futures",
@@ -8234,7 +8234,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-types"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -8257,7 +8257,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-util"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -8290,7 +8290,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "async-trait",
  "futures",
@@ -8313,7 +8313,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "bounded-collections",
  "derive_more",
@@ -8412,7 +8412,7 @@ dependencies = [
 [[package]]
 name = "polkadot-performance-test"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "env_logger 0.9.0",
  "kusama-runtime",
@@ -8428,7 +8428,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "bitvec",
  "hex-literal",
@@ -8454,7 +8454,7 @@ dependencies = [
 [[package]]
 name = "polkadot-rpc"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "jsonrpsee",
  "mmr-rpc",
@@ -8486,7 +8486,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -8576,7 +8576,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-common"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -8622,7 +8622,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-constants"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -8636,7 +8636,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "bs58",
  "parity-scale-codec",
@@ -8648,7 +8648,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "bitflags",
  "bitvec",
@@ -8692,7 +8692,7 @@ dependencies = [
 [[package]]
 name = "polkadot-service"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "async-trait",
  "frame-benchmarking-cli",
@@ -8801,7 +8801,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-distribution"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "arrayvec 0.5.2",
  "fatality",
@@ -8822,7 +8822,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -8832,7 +8832,7 @@ dependencies = [
 [[package]]
 name = "polkadot-test-client"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-subsystem",
@@ -8857,7 +8857,7 @@ dependencies = [
 [[package]]
 name = "polkadot-test-runtime"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "bitvec",
  "frame-election-provider-support",
@@ -8918,7 +8918,7 @@ dependencies = [
 [[package]]
 name = "polkadot-test-service"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "frame-benchmarking",
  "frame-system",
@@ -9645,7 +9645,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "binary-merkle-tree",
  "frame-benchmarking",
@@ -9731,7 +9731,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime-constants"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -9964,7 +9964,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "4.1.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "log",
  "sp-core",
@@ -9975,7 +9975,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "async-trait",
  "futures",
@@ -10002,7 +10002,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "futures",
  "futures-timer",
@@ -10025,7 +10025,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -10040,7 +10040,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "memmap2",
  "sc-chain-spec-derive",
@@ -10059,7 +10059,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -10070,7 +10070,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "array-bytes 4.2.0",
  "chrono",
@@ -10110,7 +10110,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "fnv",
  "futures",
@@ -10136,7 +10136,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -10162,7 +10162,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "async-trait",
  "futures",
@@ -10216,7 +10216,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -10255,7 +10255,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -10277,7 +10277,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "array-bytes 4.2.0",
  "async-trait",
@@ -10311,7 +10311,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -10330,7 +10330,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -10343,7 +10343,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "ahash 0.8.2",
  "array-bytes 4.2.0",
@@ -10383,7 +10383,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "finality-grandpa",
  "futures",
@@ -10403,7 +10403,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "async-trait",
  "futures",
@@ -10426,7 +10426,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "lru 0.8.1",
  "parity-scale-codec",
@@ -10450,7 +10450,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "sc-allocator",
  "sp-maybe-compressed-blob",
@@ -10463,7 +10463,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "log",
  "sc-allocator",
@@ -10476,7 +10476,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -10494,7 +10494,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "ansi_term",
  "futures",
@@ -10509,7 +10509,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "array-bytes 4.2.0",
  "async-trait",
@@ -10524,7 +10524,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "array-bytes 4.2.0",
  "async-channel",
@@ -10567,7 +10567,7 @@ dependencies = [
 [[package]]
 name = "sc-network-bitswap"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "cid",
  "futures",
@@ -10586,7 +10586,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "async-trait",
  "bitflags",
@@ -10612,7 +10612,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "ahash 0.8.2",
  "futures",
@@ -10630,7 +10630,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "array-bytes 4.2.0",
  "futures",
@@ -10651,7 +10651,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "array-bytes 4.2.0",
  "async-trait",
@@ -10683,7 +10683,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "array-bytes 4.2.0",
  "futures",
@@ -10702,7 +10702,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "array-bytes 4.2.0",
  "bytes",
@@ -10732,7 +10732,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "futures",
  "libp2p",
@@ -10745,7 +10745,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -10754,7 +10754,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -10784,7 +10784,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -10803,7 +10803,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "http",
  "jsonrpsee",
@@ -10818,7 +10818,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "array-bytes 4.2.0",
  "futures",
@@ -10844,7 +10844,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "async-trait",
  "directories",
@@ -10910,7 +10910,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -10921,7 +10921,7 @@ dependencies = [
 [[package]]
 name = "sc-storage-monitor"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "clap 4.1.6",
  "fs4",
@@ -10937,7 +10937,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -10956,7 +10956,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "6.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "futures",
  "libc",
@@ -10975,7 +10975,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "chrono",
  "futures",
@@ -10994,7 +10994,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "ansi_term",
  "atty",
@@ -11025,7 +11025,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -11036,7 +11036,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "async-trait",
  "futures",
@@ -11063,7 +11063,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "async-trait",
  "futures",
@@ -11077,7 +11077,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "backtrace",
  "futures",
@@ -11527,7 +11527,7 @@ checksum = "03b634d87b960ab1a38c4fe143b508576f075e7c978bfad18217645ebfdfa2ec"
 [[package]]
 name = "slot-range-helper"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -11604,7 +11604,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "hash-db",
  "log",
@@ -11622,7 +11622,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "blake2",
  "proc-macro-crate",
@@ -11634,7 +11634,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11647,7 +11647,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -11661,7 +11661,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11674,7 +11674,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -11686,7 +11686,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "futures",
  "log",
@@ -11704,7 +11704,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "async-trait",
  "futures",
@@ -11719,7 +11719,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -11737,7 +11737,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "async-trait",
  "merlin",
@@ -11760,7 +11760,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-beefy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "lazy_static",
  "parity-scale-codec",
@@ -11779,7 +11779,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -11797,7 +11797,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11809,7 +11809,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11822,7 +11822,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "array-bytes 4.2.0",
  "base58",
@@ -11865,7 +11865,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "blake2",
  "byteorder",
@@ -11879,7 +11879,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11890,7 +11890,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.1",
@@ -11899,7 +11899,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11909,7 +11909,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.13.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -11920,7 +11920,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -11935,7 +11935,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "bytes",
  "ed25519",
@@ -11960,7 +11960,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -11971,7 +11971,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.13.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "async-trait",
  "futures",
@@ -11988,7 +11988,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "4.1.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "thiserror",
  "zstd",
@@ -11997,7 +11997,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "ckb-merkle-mountain-range",
  "log",
@@ -12015,7 +12015,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12029,7 +12029,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -12039,7 +12039,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -12049,7 +12049,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -12059,7 +12059,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -12081,7 +12081,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -12099,7 +12099,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -12120,7 +12120,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12134,7 +12134,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12146,7 +12146,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.13.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "hash-db",
  "log",
@@ -12166,12 +12166,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 
 [[package]]
 name = "sp-storage"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -12184,7 +12184,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "async-trait",
  "futures-timer",
@@ -12199,7 +12199,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "parity-scale-codec",
  "sp-std",
@@ -12211,7 +12211,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -12220,7 +12220,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "async-trait",
  "log",
@@ -12236,7 +12236,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "ahash 0.8.2",
  "hash-db",
@@ -12259,7 +12259,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -12276,7 +12276,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -12287,7 +12287,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -12301,7 +12301,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12611,7 +12611,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "platforms",
 ]
@@ -12619,7 +12619,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures",
@@ -12638,7 +12638,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "hyper",
  "log",
@@ -12650,7 +12650,7 @@ dependencies = [
 [[package]]
 name = "substrate-rpc-client"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "async-trait",
  "jsonrpsee",
@@ -12663,7 +12663,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-trie-migration-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "jsonrpsee",
  "log",
@@ -12682,7 +12682,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "array-bytes 4.2.0",
  "async-trait",
@@ -12729,7 +12729,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "5.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "ansi_term",
  "build-helper",
@@ -12846,7 +12846,7 @@ checksum = "13a4ec180a2de59b57434704ccfad967f789b12737738798fa08798cd5824c16"
 [[package]]
 name = "test-runtime-constants"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -13237,7 +13237,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "polkadot-node-jaeger",
  "polkadot-primitives",
@@ -13248,7 +13248,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "expander 0.0.6",
  "proc-macro-crate",
@@ -13378,7 +13378,7 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 [[package]]
 name = "try-runtime-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6f923eedcac0fba4fd6b73e8792520f69722e527"
 dependencies = [
  "async-trait",
  "clap 4.1.6",
@@ -14305,7 +14305,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -14397,7 +14397,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime-constants"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -14800,7 +14800,7 @@ dependencies = [
 [[package]]
 name = "xcm"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "bounded-collections",
  "derivative",
@@ -14816,7 +14816,7 @@ dependencies = [
 [[package]]
 name = "xcm-builder"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -14837,7 +14837,7 @@ dependencies = [
 [[package]]
 name = "xcm-executor"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -14857,7 +14857,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#3dd8331414c92f5d01d6a470eae43049099d7aa9"
+source = "git+https://github.com/paritytech/polkadot?branch=master#c10b52e8ba17a2d766e6be627612180bf4693e21"
 dependencies = [
  "Inflector",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,7 +500,7 @@ dependencies = [
 [[package]]
 name = "binary-merkle-tree"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "hash-db",
  "log",
@@ -3219,7 +3219,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -3242,7 +3242,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 [[package]]
 name = "frame-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -3267,7 +3267,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "Inflector",
  "array-bytes 4.2.0",
@@ -3314,7 +3314,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -3325,7 +3325,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -3342,7 +3342,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3371,7 +3371,7 @@ dependencies = [
 [[package]]
 name = "frame-remote-externalities"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "futures",
  "log",
@@ -3387,7 +3387,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "bitflags",
  "environmental",
@@ -3420,7 +3420,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -3435,7 +3435,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -3447,7 +3447,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3457,7 +3457,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "frame-support",
  "log",
@@ -3475,7 +3475,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3490,7 +3490,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -3499,7 +3499,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4449,7 +4449,7 @@ checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 [[package]]
 name = "kusama-runtime"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -4547,7 +4547,7 @@ dependencies = [
 [[package]]
 name = "kusama-runtime-constants"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -5390,7 +5390,7 @@ dependencies = [
 [[package]]
 name = "mmr-gadget"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "futures",
  "log",
@@ -5409,7 +5409,7 @@ dependencies = [
 [[package]]
 name = "mmr-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "anyhow",
  "jsonrpsee",
@@ -5977,7 +5977,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5993,7 +5993,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6007,7 +6007,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6031,7 +6031,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6051,7 +6051,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6066,7 +6066,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6085,7 +6085,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "array-bytes 4.2.0",
  "binary-merkle-tree",
@@ -6109,7 +6109,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6127,7 +6127,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6171,7 +6171,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6240,7 +6240,7 @@ dependencies = [
 [[package]]
 name = "pallet-conviction-voting"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -6257,7 +6257,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6275,7 +6275,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6298,7 +6298,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6311,7 +6311,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "5.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6329,7 +6329,7 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6347,7 +6347,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6370,7 +6370,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -6386,7 +6386,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6406,7 +6406,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6437,7 +6437,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6454,7 +6454,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6471,7 +6471,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6516,7 +6516,7 @@ dependencies = [
 [[package]]
 name = "pallet-nis"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6532,7 +6532,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6549,7 +6549,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6569,7 +6569,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
 version = "1.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
@@ -6580,7 +6580,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6597,7 +6597,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6621,7 +6621,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6638,7 +6638,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6653,7 +6653,7 @@ dependencies = [
 [[package]]
 name = "pallet-ranked-collective"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6671,7 +6671,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6686,7 +6686,7 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -6705,7 +6705,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6722,7 +6722,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6743,7 +6743,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6759,7 +6759,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6773,7 +6773,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6796,7 +6796,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -6807,7 +6807,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -6816,7 +6816,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -6825,7 +6825,7 @@ dependencies = [
 [[package]]
 name = "pallet-state-trie-migration"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6842,7 +6842,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6871,7 +6871,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6889,7 +6889,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6908,7 +6908,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6924,7 +6924,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -6940,7 +6940,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -6952,7 +6952,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6984,7 +6984,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7000,7 +7000,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7015,7 +7015,7 @@ dependencies = [
 [[package]]
 name = "pallet-whitelist"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7030,7 +7030,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "bounded-collections",
  "frame-benchmarking",
@@ -7051,7 +7051,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-benchmarks"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7587,7 +7587,7 @@ dependencies = [
 [[package]]
 name = "polkadot-approval-distribution"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -7602,7 +7602,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "futures",
  "polkadot-node-network-protocol",
@@ -7616,7 +7616,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-distribution"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "derive_more",
  "fatality",
@@ -7639,7 +7639,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-recovery"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "fatality",
  "futures",
@@ -7660,7 +7660,7 @@ dependencies = [
 [[package]]
 name = "polkadot-cli"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "clap 4.1.6",
  "frame-benchmarking-cli",
@@ -7688,7 +7688,7 @@ dependencies = [
 [[package]]
 name = "polkadot-client"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -7731,7 +7731,7 @@ dependencies = [
 [[package]]
 name = "polkadot-collator-protocol"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "always-assert",
  "bitvec",
@@ -7753,7 +7753,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -7765,7 +7765,7 @@ dependencies = [
 [[package]]
 name = "polkadot-dispute-distribution"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "derive_more",
  "fatality",
@@ -7790,7 +7790,7 @@ dependencies = [
 [[package]]
 name = "polkadot-erasure-coding"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -7804,7 +7804,7 @@ dependencies = [
 [[package]]
 name = "polkadot-gossip-support"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "futures",
  "futures-timer",
@@ -7824,7 +7824,7 @@ dependencies = [
 [[package]]
 name = "polkadot-network-bridge"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "always-assert",
  "async-trait",
@@ -7848,7 +7848,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-collation-generation"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -7866,7 +7866,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "bitvec",
  "derive_more",
@@ -7895,7 +7895,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-av-store"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "bitvec",
  "futures",
@@ -7916,7 +7916,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-backing"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "bitvec",
  "fatality",
@@ -7935,7 +7935,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
@@ -7950,7 +7950,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-candidate-validation"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "async-trait",
  "futures",
@@ -7970,7 +7970,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-api"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -7985,7 +7985,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-selection"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "futures",
  "futures-timer",
@@ -8002,7 +8002,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "fatality",
  "futures",
@@ -8021,7 +8021,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "async-trait",
  "futures",
@@ -8038,7 +8038,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-provisioner"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "bitvec",
  "fatality",
@@ -8056,7 +8056,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "always-assert",
  "assert_matches",
@@ -8092,7 +8092,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-checker"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "futures",
  "polkadot-node-primitives",
@@ -8108,7 +8108,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-runtime-api"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "futures",
  "lru 0.9.0",
@@ -8123,7 +8123,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-jaeger"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "lazy_static",
  "log",
@@ -8141,7 +8141,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-metrics"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "bs58",
  "futures",
@@ -8160,7 +8160,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -8183,7 +8183,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "bounded-vec",
  "futures",
@@ -8206,7 +8206,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "polkadot-node-jaeger",
  "polkadot-node-subsystem-types",
@@ -8216,7 +8216,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-test-helpers"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "async-trait",
  "futures",
@@ -8234,7 +8234,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-types"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -8257,7 +8257,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-util"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -8290,7 +8290,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "async-trait",
  "futures",
@@ -8313,7 +8313,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "bounded-collections",
  "derive_more",
@@ -8412,7 +8412,7 @@ dependencies = [
 [[package]]
 name = "polkadot-performance-test"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "env_logger 0.9.0",
  "kusama-runtime",
@@ -8428,7 +8428,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "bitvec",
  "hex-literal",
@@ -8454,7 +8454,7 @@ dependencies = [
 [[package]]
 name = "polkadot-rpc"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "jsonrpsee",
  "mmr-rpc",
@@ -8486,7 +8486,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -8576,7 +8576,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-common"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -8622,7 +8622,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-constants"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -8636,7 +8636,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "bs58",
  "parity-scale-codec",
@@ -8648,7 +8648,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "bitflags",
  "bitvec",
@@ -8692,7 +8692,7 @@ dependencies = [
 [[package]]
 name = "polkadot-service"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "async-trait",
  "frame-benchmarking-cli",
@@ -8801,7 +8801,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-distribution"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "arrayvec 0.5.2",
  "fatality",
@@ -8822,7 +8822,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -8832,7 +8832,7 @@ dependencies = [
 [[package]]
 name = "polkadot-test-client"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-subsystem",
@@ -8857,7 +8857,7 @@ dependencies = [
 [[package]]
 name = "polkadot-test-runtime"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "bitvec",
  "frame-election-provider-support",
@@ -8918,7 +8918,7 @@ dependencies = [
 [[package]]
 name = "polkadot-test-service"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "frame-benchmarking",
  "frame-system",
@@ -9645,7 +9645,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "binary-merkle-tree",
  "frame-benchmarking",
@@ -9731,7 +9731,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime-constants"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -9964,7 +9964,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "4.1.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "log",
  "sp-core",
@@ -9975,7 +9975,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "async-trait",
  "futures",
@@ -10002,7 +10002,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "futures",
  "futures-timer",
@@ -10025,7 +10025,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -10040,7 +10040,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "memmap2",
  "sc-chain-spec-derive",
@@ -10059,7 +10059,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -10070,7 +10070,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "array-bytes 4.2.0",
  "chrono",
@@ -10110,7 +10110,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "fnv",
  "futures",
@@ -10136,7 +10136,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -10162,7 +10162,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "async-trait",
  "futures",
@@ -10216,7 +10216,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -10255,7 +10255,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -10277,7 +10277,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "array-bytes 4.2.0",
  "async-trait",
@@ -10311,7 +10311,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -10330,7 +10330,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -10343,7 +10343,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "ahash 0.8.2",
  "array-bytes 4.2.0",
@@ -10383,7 +10383,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "finality-grandpa",
  "futures",
@@ -10403,7 +10403,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "async-trait",
  "futures",
@@ -10426,7 +10426,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "lru 0.8.1",
  "parity-scale-codec",
@@ -10450,7 +10450,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "sc-allocator",
  "sp-maybe-compressed-blob",
@@ -10463,7 +10463,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "log",
  "sc-allocator",
@@ -10476,7 +10476,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -10494,7 +10494,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "ansi_term",
  "futures",
@@ -10509,7 +10509,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "array-bytes 4.2.0",
  "async-trait",
@@ -10524,7 +10524,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "array-bytes 4.2.0",
  "async-channel",
@@ -10567,7 +10567,7 @@ dependencies = [
 [[package]]
 name = "sc-network-bitswap"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "cid",
  "futures",
@@ -10586,7 +10586,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "async-trait",
  "bitflags",
@@ -10612,7 +10612,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "ahash 0.8.2",
  "futures",
@@ -10630,7 +10630,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "array-bytes 4.2.0",
  "futures",
@@ -10651,7 +10651,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "array-bytes 4.2.0",
  "async-trait",
@@ -10683,7 +10683,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "array-bytes 4.2.0",
  "futures",
@@ -10702,7 +10702,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "array-bytes 4.2.0",
  "bytes",
@@ -10732,7 +10732,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "futures",
  "libp2p",
@@ -10745,7 +10745,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -10754,7 +10754,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -10784,7 +10784,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -10803,7 +10803,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "http",
  "jsonrpsee",
@@ -10818,7 +10818,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "array-bytes 4.2.0",
  "futures",
@@ -10844,7 +10844,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "async-trait",
  "directories",
@@ -10910,7 +10910,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -10921,7 +10921,7 @@ dependencies = [
 [[package]]
 name = "sc-storage-monitor"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "clap 4.1.6",
  "fs4",
@@ -10937,7 +10937,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -10956,7 +10956,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "6.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "futures",
  "libc",
@@ -10975,7 +10975,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "chrono",
  "futures",
@@ -10994,7 +10994,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "ansi_term",
  "atty",
@@ -11025,7 +11025,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -11036,7 +11036,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "async-trait",
  "futures",
@@ -11063,7 +11063,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "async-trait",
  "futures",
@@ -11077,7 +11077,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "backtrace",
  "futures",
@@ -11527,7 +11527,7 @@ checksum = "03b634d87b960ab1a38c4fe143b508576f075e7c978bfad18217645ebfdfa2ec"
 [[package]]
 name = "slot-range-helper"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -11604,7 +11604,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "hash-db",
  "log",
@@ -11622,7 +11622,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "blake2",
  "proc-macro-crate",
@@ -11634,7 +11634,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11647,7 +11647,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -11661,7 +11661,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11674,7 +11674,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -11686,7 +11686,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "futures",
  "log",
@@ -11704,7 +11704,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "async-trait",
  "futures",
@@ -11719,7 +11719,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -11737,7 +11737,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "async-trait",
  "merlin",
@@ -11760,7 +11760,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-beefy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "lazy_static",
  "parity-scale-codec",
@@ -11779,7 +11779,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -11797,7 +11797,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11809,7 +11809,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11822,7 +11822,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "array-bytes 4.2.0",
  "base58",
@@ -11865,7 +11865,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "blake2",
  "byteorder",
@@ -11879,7 +11879,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11890,7 +11890,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.1",
@@ -11899,7 +11899,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11909,7 +11909,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.13.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -11920,7 +11920,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -11935,7 +11935,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "bytes",
  "ed25519",
@@ -11960,7 +11960,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -11971,7 +11971,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.13.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "async-trait",
  "futures",
@@ -11988,7 +11988,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "4.1.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "thiserror",
  "zstd",
@@ -11997,7 +11997,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "ckb-merkle-mountain-range",
  "log",
@@ -12015,7 +12015,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12029,7 +12029,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -12039,7 +12039,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -12049,7 +12049,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -12059,7 +12059,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -12081,7 +12081,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -12099,7 +12099,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -12120,7 +12120,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12134,7 +12134,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12146,7 +12146,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.13.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "hash-db",
  "log",
@@ -12166,12 +12166,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 
 [[package]]
 name = "sp-storage"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -12184,7 +12184,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "async-trait",
  "futures-timer",
@@ -12199,7 +12199,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "parity-scale-codec",
  "sp-std",
@@ -12211,7 +12211,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -12220,7 +12220,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "async-trait",
  "log",
@@ -12236,7 +12236,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "ahash 0.8.2",
  "hash-db",
@@ -12259,7 +12259,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -12276,7 +12276,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -12287,7 +12287,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -12301,7 +12301,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12611,7 +12611,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "platforms",
 ]
@@ -12619,7 +12619,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures",
@@ -12638,7 +12638,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "hyper",
  "log",
@@ -12650,7 +12650,7 @@ dependencies = [
 [[package]]
 name = "substrate-rpc-client"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "async-trait",
  "jsonrpsee",
@@ -12663,7 +12663,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-trie-migration-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "jsonrpsee",
  "log",
@@ -12682,7 +12682,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "array-bytes 4.2.0",
  "async-trait",
@@ -12729,7 +12729,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "5.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "ansi_term",
  "build-helper",
@@ -12846,7 +12846,7 @@ checksum = "13a4ec180a2de59b57434704ccfad967f789b12737738798fa08798cd5824c16"
 [[package]]
 name = "test-runtime-constants"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -13237,7 +13237,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "polkadot-node-jaeger",
  "polkadot-primitives",
@@ -13248,7 +13248,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "expander 0.0.6",
  "proc-macro-crate",
@@ -13378,7 +13378,7 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 [[package]]
 name = "try-runtime-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#d1d67cddf577ef275a2ca339312805c6d25ef9e5"
+source = "git+https://github.com/paritytech/substrate?branch=master#6e81199eac74ce9a7bf3b1c720989031dd9b18a1"
 dependencies = [
  "async-trait",
  "clap 4.1.6",
@@ -14305,7 +14305,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -14397,7 +14397,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime-constants"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -14800,7 +14800,7 @@ dependencies = [
 [[package]]
 name = "xcm"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "bounded-collections",
  "derivative",
@@ -14816,7 +14816,7 @@ dependencies = [
 [[package]]
 name = "xcm-builder"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -14837,7 +14837,7 @@ dependencies = [
 [[package]]
 name = "xcm-executor"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -14857,7 +14857,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "0.9.37"
-source = "git+https://github.com/paritytech/polkadot?branch=master#54bcee1d5615f53781d5172fcce6700dbf35dad2"
+source = "git+https://github.com/paritytech/polkadot?branch=master#6c026d53ea5567cffa2fba6cc4a49beeaea51c7f"
 dependencies = [
  "Inflector",
  "proc-macro2",

--- a/pallets/collator-selection/src/weights.rs
+++ b/pallets/collator-selection/src/weights.rs
@@ -39,42 +39,42 @@ pub trait WeightInfo {
 pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	fn set_invulnerables(b: u32) -> Weight {
-		Weight::from_ref_time(18_563_000 as u64)
+		Weight::from_parts(18_563_000 as u64, 0)
 			// Standard Error: 0
-			.saturating_add(Weight::from_ref_time(68_000 as u64).saturating_mul(b as u64))
+			.saturating_add(Weight::from_parts(68_000 as u64, 0).saturating_mul(b as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	fn set_desired_candidates() -> Weight {
-		Weight::from_ref_time(16_363_000 as u64).saturating_add(T::DbWeight::get().writes(1 as u64))
+		Weight::from_parts(16_363_000 as u64, 0).saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	fn set_candidacy_bond() -> Weight {
-		Weight::from_ref_time(16_840_000 as u64).saturating_add(T::DbWeight::get().writes(1 as u64))
+		Weight::from_parts(16_840_000 as u64, 0).saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	fn register_as_candidate(c: u32) -> Weight {
-		Weight::from_ref_time(71_196_000 as u64)
+		Weight::from_parts(71_196_000 as u64, 0)
 			// Standard Error: 0
-			.saturating_add(Weight::from_ref_time(198_000 as u64).saturating_mul(c as u64))
+			.saturating_add(Weight::from_parts(198_000 as u64, 0).saturating_mul(c as u64))
 			.saturating_add(T::DbWeight::get().reads(4 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	fn leave_intent(c: u32) -> Weight {
-		Weight::from_ref_time(55_336_000 as u64)
+		Weight::from_parts(55_336_000 as u64, 0)
 			// Standard Error: 0
-			.saturating_add(Weight::from_ref_time(151_000 as u64).saturating_mul(c as u64))
+			.saturating_add(Weight::from_parts(151_000 as u64, 0).saturating_mul(c as u64))
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	fn note_author() -> Weight {
-		Weight::from_ref_time(71_461_000 as u64)
+		Weight::from_parts(71_461_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(3 as u64))
 			.saturating_add(T::DbWeight::get().writes(4 as u64))
 	}
 	fn new_session(r: u32, c: u32) -> Weight {
-		Weight::from_ref_time(0 as u64)
+		Weight::from_parts(0 as u64, 0)
 			// Standard Error: 1_010_000
-			.saturating_add(Weight::from_ref_time(109_961_000 as u64).saturating_mul(r as u64))
+			.saturating_add(Weight::from_parts(109_961_000 as u64, 0).saturating_mul(r as u64))
 			// Standard Error: 1_010_000
-			.saturating_add(Weight::from_ref_time(151_952_000 as u64).saturating_mul(c as u64))
+			.saturating_add(Weight::from_parts(151_952_000 as u64, 0).saturating_mul(c as u64))
 			.saturating_add(T::DbWeight::get().reads((1 as u64).saturating_mul(r as u64)))
 			.saturating_add(T::DbWeight::get().reads((2 as u64).saturating_mul(c as u64)))
 			.saturating_add(T::DbWeight::get().writes((2 as u64).saturating_mul(r as u64)))
@@ -85,44 +85,44 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 // For backwards compatibility and tests
 impl WeightInfo for () {
 	fn set_invulnerables(b: u32) -> Weight {
-		Weight::from_ref_time(18_563_000 as u64)
+		Weight::from_parts(18_563_000 as u64, 0)
 			// Standard Error: 0
-			.saturating_add(Weight::from_ref_time(68_000 as u64).saturating_mul(b as u64))
+			.saturating_add(Weight::from_parts(68_000 as u64, 0).saturating_mul(b as u64))
 			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
 	fn set_desired_candidates() -> Weight {
-		Weight::from_ref_time(16_363_000 as u64)
+		Weight::from_parts(16_363_000 as u64, 0)
 			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
 	fn set_candidacy_bond() -> Weight {
-		Weight::from_ref_time(16_840_000 as u64)
+		Weight::from_parts(16_840_000 as u64, 0)
 			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
 	fn register_as_candidate(c: u32) -> Weight {
-		Weight::from_ref_time(71_196_000 as u64)
+		Weight::from_parts(71_196_000 as u64, 0)
 			// Standard Error: 0
-			.saturating_add(Weight::from_ref_time(198_000 as u64).saturating_mul(c as u64))
+			.saturating_add(Weight::from_parts(198_000 as u64, 0).saturating_mul(c as u64))
 			.saturating_add(RocksDbWeight::get().reads(4 as u64))
 			.saturating_add(RocksDbWeight::get().writes(2 as u64))
 	}
 	fn leave_intent(c: u32) -> Weight {
-		Weight::from_ref_time(55_336_000 as u64)
+		Weight::from_parts(55_336_000 as u64, 0)
 			// Standard Error: 0
-			.saturating_add(Weight::from_ref_time(151_000 as u64).saturating_mul(c as u64))
+			.saturating_add(Weight::from_parts(151_000 as u64, 0).saturating_mul(c as u64))
 			.saturating_add(RocksDbWeight::get().reads(1 as u64))
 			.saturating_add(RocksDbWeight::get().writes(2 as u64))
 	}
 	fn note_author() -> Weight {
-		Weight::from_ref_time(71_461_000 as u64)
+		Weight::from_parts(71_461_000 as u64, 0)
 			.saturating_add(RocksDbWeight::get().reads(3 as u64))
 			.saturating_add(RocksDbWeight::get().writes(4 as u64))
 	}
 	fn new_session(r: u32, c: u32) -> Weight {
-		Weight::from_ref_time(0 as u64)
+		Weight::from_parts(0 as u64, 0)
 			// Standard Error: 1_010_000
-			.saturating_add(Weight::from_ref_time(109_961_000 as u64).saturating_mul(r as u64))
+			.saturating_add(Weight::from_parts(109_961_000 as u64, 0).saturating_mul(r as u64))
 			// Standard Error: 1_010_000
-			.saturating_add(Weight::from_ref_time(151_952_000 as u64).saturating_mul(c as u64))
+			.saturating_add(Weight::from_parts(151_952_000 as u64, 0).saturating_mul(c as u64))
 			.saturating_add(RocksDbWeight::get().reads((1 as u64).saturating_mul(r as u64)))
 			.saturating_add(RocksDbWeight::get().reads((2 as u64).saturating_mul(c as u64)))
 			.saturating_add(RocksDbWeight::get().writes((2 as u64).saturating_mul(r as u64)))

--- a/pallets/dmp-queue/src/lib.rs
+++ b/pallets/dmp-queue/src/lib.rs
@@ -154,7 +154,7 @@ pub mod pallet {
 	impl<T: Config> Pallet<T> {
 		/// Service a single overweight message.
 		#[pallet::call_index(0)]
-		#[pallet::weight(weight_limit.saturating_add(Weight::from_ref_time(1_000_000)))]
+		#[pallet::weight(weight_limit.saturating_add(Weight::from_parts(1_000_000, 0)))]
 		pub fn service_overweight(
 			origin: OriginFor<T>,
 			index: OverweightIndex,
@@ -167,7 +167,7 @@ pub mod pallet {
 				.map_err(|_| Error::<T>::OverLimit)?;
 			Overweight::<T>::remove(index);
 			Self::deposit_event(Event::OverweightServiced { overweight_index: index, weight_used });
-			Ok(Some(weight_used.saturating_add(Weight::from_ref_time(1_000_000))).into())
+			Ok(Some(weight_used.saturating_add(Weight::from_parts(1_000_000, 0))).into())
 		}
 	}
 

--- a/pallets/xcmp-queue/src/benchmarking.rs
+++ b/pallets/xcmp-queue/src/benchmarking.rs
@@ -22,7 +22,7 @@ use frame_system::RawOrigin;
 
 benchmarks! {
 	set_config_with_u32 {}: update_resume_threshold(RawOrigin::Root, 100)
-	set_config_with_weight {}: update_weight_restrict_decay(RawOrigin::Root, Weight::from_ref_time(3_000_000))
+	set_config_with_weight {}: update_weight_restrict_decay(RawOrigin::Root, Weight::from_parts(3_000_000, 0))
 }
 
 impl_benchmark_test_suite!(Pallet, crate::mock::new_test_ext(), crate::mock::Test);

--- a/pallets/xcmp-queue/src/lib.rs
+++ b/pallets/xcmp-queue/src/lib.rs
@@ -142,7 +142,7 @@ pub mod pallet {
 		/// Events:
 		/// - `OverweightServiced`: On success.
 		#[pallet::call_index(0)]
-		#[pallet::weight((weight_limit.saturating_add(Weight::from_ref_time(1_000_000)), DispatchClass::Operational))]
+		#[pallet::weight((weight_limit.saturating_add(Weight::from_parts(1_000_000, 0)), DispatchClass::Operational))]
 		pub fn service_overweight(
 			origin: OriginFor<T>,
 			index: OverweightIndex,
@@ -161,7 +161,7 @@ pub mod pallet {
 				.map_err(|_| Error::<T>::WeightOverLimit)?;
 			Overweight::<T>::remove(index);
 			Self::deposit_event(Event::OverweightServiced { index, used });
-			Ok(Some(used.saturating_add(Weight::from_ref_time(1_000_000))).into())
+			Ok(Some(used.saturating_add(Weight::from_parts(1_000_000, 0))).into())
 		}
 
 		/// Suspends all XCM executions for the XCMP queue, regardless of the sender's origin.
@@ -467,8 +467,8 @@ impl Default for QueueConfigData {
 			suspend_threshold: 2,
 			drop_threshold: 5,
 			resume_threshold: 1,
-			threshold_weight: Weight::from_ref_time(100_000),
-			weight_restrict_decay: Weight::from_ref_time(2),
+			threshold_weight: Weight::from_parts(100_000, 0),
+			weight_restrict_decay: Weight::from_parts(2, 0),
 			xcmp_max_individual_weight: Weight::from_parts(
 				20u64 * WEIGHT_REF_TIME_PER_MILLIS,
 				DEFAULT_POV_SIZE,

--- a/pallets/xcmp-queue/src/migration.rs
+++ b/pallets/xcmp-queue/src/migration.rs
@@ -85,8 +85,8 @@ pub fn migrate_to_v2<T: Config>() -> Weight {
 			suspend_threshold: pre.suspend_threshold,
 			drop_threshold: pre.drop_threshold,
 			resume_threshold: pre.resume_threshold,
-			threshold_weight: Weight::from_ref_time(pre.threshold_weight),
-			weight_restrict_decay: Weight::from_ref_time(pre.weight_restrict_decay),
+			threshold_weight: Weight::from_parts(pre.threshold_weight, 0),
+			weight_restrict_decay: Weight::from_parts(pre.weight_restrict_decay, 0),
 			xcmp_max_individual_weight: Weight::from_parts(
 				pre.xcmp_max_individual_weight,
 				DEFAULT_POV_SIZE,

--- a/pallets/xcmp-queue/src/tests.rs
+++ b/pallets/xcmp-queue/src/tests.rs
@@ -47,8 +47,8 @@ fn bad_message_is_handled() {
 			1000.into(),
 			(1, format),
 			&mut 0,
-			Weight::from_ref_time(10_000_000_000),
-			Weight::from_ref_time(10_000_000_000),
+			Weight::from_parts(10_000_000_000, 0),
+			Weight::from_parts(10_000_000_000, 0),
 		);
 	});
 }
@@ -71,8 +71,8 @@ fn handle_blob_message() {
 			1000.into(),
 			(1, format),
 			&mut 0,
-			Weight::from_ref_time(10_000_000_000),
-			Weight::from_ref_time(10_000_000_000),
+			Weight::from_parts(10_000_000_000, 0),
+			Weight::from_parts(10_000_000_000, 0),
 		);
 	});
 }
@@ -89,8 +89,8 @@ fn handle_invalid_data() {
 			1000.into(),
 			(1, format),
 			&mut 0,
-			Weight::from_ref_time(10_000_000_000),
-			Weight::from_ref_time(10_000_000_000),
+			Weight::from_parts(10_000_000_000, 0),
+			Weight::from_parts(10_000_000_000, 0),
 		);
 	});
 }
@@ -189,21 +189,21 @@ fn update_resume_threshold_works() {
 fn update_threshold_weight_works() {
 	new_test_ext().execute_with(|| {
 		let data: QueueConfigData = <QueueConfig<Test>>::get();
-		assert_eq!(data.threshold_weight, Weight::from_ref_time(100_000));
+		assert_eq!(data.threshold_weight, Weight::from_parts(100_000, 0));
 		assert_ok!(XcmpQueue::update_threshold_weight(
 			RuntimeOrigin::root(),
-			Weight::from_ref_time(10_000)
+			Weight::from_parts(10_000, 0)
 		));
 		assert_noop!(
 			XcmpQueue::update_threshold_weight(
 				RuntimeOrigin::signed(5),
-				Weight::from_ref_time(10_000_000),
+				Weight::from_parts(10_000_000, 0),
 			),
 			BadOrigin
 		);
 		let data: QueueConfigData = <QueueConfig<Test>>::get();
 
-		assert_eq!(data.threshold_weight, Weight::from_ref_time(10_000));
+		assert_eq!(data.threshold_weight, Weight::from_parts(10_000, 0));
 	});
 }
 
@@ -211,21 +211,21 @@ fn update_threshold_weight_works() {
 fn update_weight_restrict_decay_works() {
 	new_test_ext().execute_with(|| {
 		let data: QueueConfigData = <QueueConfig<Test>>::get();
-		assert_eq!(data.weight_restrict_decay, Weight::from_ref_time(2));
+		assert_eq!(data.weight_restrict_decay, Weight::from_parts(2, 0));
 		assert_ok!(XcmpQueue::update_weight_restrict_decay(
 			RuntimeOrigin::root(),
-			Weight::from_ref_time(5)
+			Weight::from_parts(5, 0)
 		));
 		assert_noop!(
 			XcmpQueue::update_weight_restrict_decay(
 				RuntimeOrigin::signed(6),
-				Weight::from_ref_time(4),
+				Weight::from_parts(4, 0),
 			),
 			BadOrigin
 		);
 		let data: QueueConfigData = <QueueConfig<Test>>::get();
 
-		assert_eq!(data.weight_restrict_decay, Weight::from_ref_time(5));
+		assert_eq!(data.weight_restrict_decay, Weight::from_parts(5, 0));
 	});
 }
 
@@ -239,12 +239,12 @@ fn update_xcmp_max_individual_weight() {
 		);
 		assert_ok!(XcmpQueue::update_xcmp_max_individual_weight(
 			RuntimeOrigin::root(),
-			Weight::from_ref_time(30u64 * WEIGHT_REF_TIME_PER_MILLIS)
+			Weight::from_parts(30u64 * WEIGHT_REF_TIME_PER_MILLIS, 0)
 		));
 		assert_noop!(
 			XcmpQueue::update_xcmp_max_individual_weight(
 				RuntimeOrigin::signed(3),
-				Weight::from_ref_time(10u64 * WEIGHT_REF_TIME_PER_MILLIS)
+				Weight::from_parts(10u64 * WEIGHT_REF_TIME_PER_MILLIS, 0)
 			),
 			BadOrigin
 		);
@@ -252,7 +252,7 @@ fn update_xcmp_max_individual_weight() {
 
 		assert_eq!(
 			data.xcmp_max_individual_weight,
-			Weight::from_ref_time(30u64 * WEIGHT_REF_TIME_PER_MILLIS)
+			Weight::from_parts(30u64 * WEIGHT_REF_TIME_PER_MILLIS, 0)
 		);
 	});
 }

--- a/pallets/xcmp-queue/src/weights.rs
+++ b/pallets/xcmp-queue/src/weights.rs
@@ -18,14 +18,14 @@ pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: XcmpQueue QueueConfig (r:1 w:1)
 	fn set_config_with_u32() -> Weight {
-		Weight::from_ref_time(2_717_000 as u64)
+		Weight::from_parts(2_717_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 
 	// Storage: XcmpQueue QueueConfig (r:1 w:1)
 	fn set_config_with_weight() -> Weight {
-		Weight::from_ref_time(2_717_000 as u64)
+		Weight::from_parts(2_717_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
@@ -34,14 +34,14 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 impl WeightInfo for () {
 	// Storage: XcmpQueue QueueConfig (r:1 w:1)
 	fn set_config_with_u32() -> Weight {
-		Weight::from_ref_time(2_717_000 as u64)
+		Weight::from_parts(2_717_000 as u64, 0)
 			.saturating_add(RocksDbWeight::get().reads(1 as u64))
 			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}
 
 	// Storage: XcmpQueue QueueConfig (r:1 w:1)
 	fn set_config_with_weight() -> Weight {
-		Weight::from_ref_time(2_717_000 as u64)
+		Weight::from_parts(2_717_000 as u64, 0)
 			.saturating_add(RocksDbWeight::get().reads(1 as u64))
 			.saturating_add(RocksDbWeight::get().writes(1 as u64))
 	}

--- a/parachain-template/pallets/template/src/lib.rs
+++ b/parachain-template/pallets/template/src/lib.rs
@@ -68,7 +68,7 @@ pub mod pallet {
 		/// An example dispatchable that takes a singles value as a parameter, writes the value to
 		/// storage and emits an event. This function must be dispatched by a signed extrinsic.
 		#[pallet::call_index(0)]
-		#[pallet::weight(Weight::from_ref_time(10_000) + T::DbWeight::get().writes(1))]
+		#[pallet::weight(Weight::from_parts(10_000, 0) + T::DbWeight::get().writes(1))]
 		pub fn do_something(origin: OriginFor<T>, something: u32) -> DispatchResultWithPostInfo {
 			// Check that the extrinsic was signed and get the signer.
 			// This function will return an error if the extrinsic is not signed.
@@ -86,7 +86,7 @@ pub mod pallet {
 
 		/// An example dispatchable that may throw a custom error.
 		#[pallet::call_index(1)]
-		#[pallet::weight(Weight::from_ref_time(10_000) + T::DbWeight::get().reads_writes(1,1))]
+		#[pallet::weight(Weight::from_parts(10_000, 0) + T::DbWeight::get().reads_writes(1,1))]
 		pub fn cause_error(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
 			let _who = ensure_signed(origin)?;
 

--- a/parachain-template/runtime/src/weights/block_weights.rs
+++ b/parachain-template/runtime/src/weights/block_weights.rs
@@ -24,7 +24,7 @@ pub mod constants {
 	parameter_types! {
 		/// Importing a block with 0 Extrinsics.
 		pub const BlockExecutionWeight: Weight =
-			Weight::from_ref_time(constants::WEIGHT_REF_TIME_PER_NANOS.saturating_mul(5_000_000));
+			Weight::from_parts(constants::WEIGHT_REF_TIME_PER_NANOS.saturating_mul(5_000_000), 0);
 	}
 
 	#[cfg(test)]

--- a/parachain-template/runtime/src/weights/extrinsic_weights.rs
+++ b/parachain-template/runtime/src/weights/extrinsic_weights.rs
@@ -24,7 +24,7 @@ pub mod constants {
 	parameter_types! {
 		/// Executing a NO-OP `System::remarks` Extrinsic.
 		pub const ExtrinsicBaseWeight: Weight =
-			Weight::from_ref_time(constants::WEIGHT_REF_TIME_PER_NANOS.saturating_mul(125_000));
+			Weight::from_parts(constants::WEIGHT_REF_TIME_PER_NANOS.saturating_mul(125_000), 0);
 	}
 
 	#[cfg(test)]

--- a/parachains/runtimes/assets/statemine/src/weights/block_weights.rs
+++ b/parachains/runtimes/assets/statemine/src/weights/block_weights.rs
@@ -24,7 +24,7 @@ pub mod constants {
 	parameter_types! {
 		/// Importing a block with 0 Extrinsics.
 		pub const BlockExecutionWeight: Weight =
-			Weight::from_ref_time(constants::WEIGHT_REF_TIME_PER_NANOS.saturating_mul(5_000_000));
+			Weight::from_parts(constants::WEIGHT_REF_TIME_PER_NANOS.saturating_mul(5_000_000), 0);
 	}
 
 	#[cfg(test)]

--- a/parachains/runtimes/assets/statemine/src/weights/cumulus_pallet_xcmp_queue.rs
+++ b/parachains/runtimes/assets/statemine/src/weights/cumulus_pallet_xcmp_queue.rs
@@ -54,8 +54,8 @@ impl<T: frame_system::Config> cumulus_pallet_xcmp_queue::WeightInfo for WeightIn
 		//  Measured:  `76`
 		//  Estimated: `571`
 		// Minimum execution time: 4_956 nanoseconds.
-		Weight::from_ref_time(5_108_000)
-			.saturating_add(Weight::from_proof_size(571))
+		Weight::from_parts(5_108_000, 0)
+			.saturating_add(Weight::from_parts(0, 571))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -66,8 +66,8 @@ impl<T: frame_system::Config> cumulus_pallet_xcmp_queue::WeightInfo for WeightIn
 		//  Measured:  `76`
 		//  Estimated: `571`
 		// Minimum execution time: 4_945 nanoseconds.
-		Weight::from_ref_time(5_080_000)
-			.saturating_add(Weight::from_proof_size(571))
+		Weight::from_parts(5_080_000, 0)
+			.saturating_add(Weight::from_parts(0, 571))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}

--- a/parachains/runtimes/assets/statemine/src/weights/extrinsic_weights.rs
+++ b/parachains/runtimes/assets/statemine/src/weights/extrinsic_weights.rs
@@ -24,7 +24,7 @@ pub mod constants {
 	parameter_types! {
 		/// Executing a NO-OP `System::remarks` Extrinsic.
 		pub const ExtrinsicBaseWeight: Weight =
-			Weight::from_ref_time(constants::WEIGHT_REF_TIME_PER_NANOS.saturating_mul(125_000));
+			Weight::from_parts(constants::WEIGHT_REF_TIME_PER_NANOS.saturating_mul(125_000), 0);
 	}
 
 	#[cfg(test)]

--- a/parachains/runtimes/assets/statemine/src/weights/frame_system.rs
+++ b/parachains/runtimes/assets/statemine/src/weights/frame_system.rs
@@ -53,10 +53,10 @@ impl<T: frame_system::Config> frame_system::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 1_524 nanoseconds.
-		Weight::from_ref_time(1_612_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(1_612_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			// Standard Error: 0
-			.saturating_add(Weight::from_ref_time(413).saturating_mul(b.into()))
+			.saturating_add(Weight::from_parts(413, 0).saturating_mul(b.into()))
 	}
 	/// The range of component `b` is `[0, 3932160]`.
 	fn remark_with_event(b: u32, ) -> Weight {
@@ -64,10 +64,10 @@ impl<T: frame_system::Config> frame_system::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 6_865 nanoseconds.
-		Weight::from_ref_time(6_939_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(6_939_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			// Standard Error: 0
-			.saturating_add(Weight::from_ref_time(1_762).saturating_mul(b.into()))
+			.saturating_add(Weight::from_parts(1_762, 0).saturating_mul(b.into()))
 	}
 	/// Storage: System Digest (r:1 w:1)
 	/// Proof Skipped: System Digest (max_values: Some(1), max_size: None, mode: Measured)
@@ -78,8 +78,8 @@ impl<T: frame_system::Config> frame_system::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `495`
 		// Minimum execution time: 3_490 nanoseconds.
-		Weight::from_ref_time(3_688_000)
-			.saturating_add(Weight::from_proof_size(495))
+		Weight::from_parts(3_688_000, 0)
+			.saturating_add(Weight::from_parts(0, 495))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -91,10 +91,10 @@ impl<T: frame_system::Config> frame_system::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 1_683 nanoseconds.
-		Weight::from_ref_time(1_726_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(1_726_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			// Standard Error: 1_736
-			.saturating_add(Weight::from_ref_time(582_823).saturating_mul(i.into()))
+			.saturating_add(Weight::from_parts(582_823, 0).saturating_mul(i.into()))
 			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(i.into())))
 	}
 	/// Storage: Skipped Metadata (r:0 w:0)
@@ -105,10 +105,10 @@ impl<T: frame_system::Config> frame_system::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 1_711 nanoseconds.
-		Weight::from_ref_time(1_787_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(1_787_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			// Standard Error: 779
-			.saturating_add(Weight::from_ref_time(445_878).saturating_mul(i.into()))
+			.saturating_add(Weight::from_parts(445_878, 0).saturating_mul(i.into()))
 			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(i.into())))
 	}
 	/// Storage: Skipped Metadata (r:0 w:0)
@@ -119,11 +119,11 @@ impl<T: frame_system::Config> frame_system::WeightInfo for WeightInfo<T> {
 		//  Measured:  `81 + p * (69 ±0)`
 		//  Estimated: `72 + p * (70 ±0)`
 		// Minimum execution time: 3_428 nanoseconds.
-		Weight::from_ref_time(3_492_000)
-			.saturating_add(Weight::from_proof_size(72))
+		Weight::from_parts(3_492_000, 0)
+			.saturating_add(Weight::from_parts(0, 72))
 			// Standard Error: 991
-			.saturating_add(Weight::from_ref_time(953_258).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(953_258, 0).saturating_mul(p.into()))
 			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(p.into())))
-			.saturating_add(Weight::from_proof_size(70).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(0, 70).saturating_mul(p.into()))
 	}
 }

--- a/parachains/runtimes/assets/statemine/src/weights/pallet_assets.rs
+++ b/parachains/runtimes/assets/statemine/src/weights/pallet_assets.rs
@@ -56,8 +56,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `141`
 		//  Estimated: `5288`
 		// Minimum execution time: 21_487 nanoseconds.
-		Weight::from_ref_time(21_977_000)
-			.saturating_add(Weight::from_proof_size(5288))
+		Weight::from_parts(21_977_000, 0)
+			.saturating_add(Weight::from_parts(0, 5288))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -68,8 +68,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `6`
 		//  Estimated: `2685`
 		// Minimum execution time: 10_630 nanoseconds.
-		Weight::from_ref_time(10_963_000)
-			.saturating_add(Weight::from_proof_size(2685))
+		Weight::from_parts(10_963_000, 0)
+			.saturating_add(Weight::from_parts(0, 2685))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -80,8 +80,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `309`
 		//  Estimated: `2685`
 		// Minimum execution time: 13_627 nanoseconds.
-		Weight::from_ref_time(13_906_000)
-			.saturating_add(Weight::from_proof_size(2685))
+		Weight::from_parts(13_906_000, 0)
+			.saturating_add(Weight::from_parts(0, 2685))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -97,15 +97,15 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0 + c * (240 ±0)`
 		//  Estimated: `5262 + c * (5180 ±0)`
 		// Minimum execution time: 15_861 nanoseconds.
-		Weight::from_ref_time(16_079_000)
-			.saturating_add(Weight::from_proof_size(5262))
+		Weight::from_parts(16_079_000, 0)
+			.saturating_add(Weight::from_parts(0, 5262))
 			// Standard Error: 10_732
-			.saturating_add(Weight::from_ref_time(14_192_928).saturating_mul(c.into()))
+			.saturating_add(Weight::from_parts(14_192_928, 0).saturating_mul(c.into()))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().reads((2_u64).saturating_mul(c.into())))
 			.saturating_add(T::DbWeight::get().writes(1))
 			.saturating_add(T::DbWeight::get().writes((2_u64).saturating_mul(c.into())))
-			.saturating_add(Weight::from_proof_size(5180).saturating_mul(c.into()))
+			.saturating_add(Weight::from_parts(0, 5180).saturating_mul(c.into()))
 	}
 	/// Storage: Assets Asset (r:1 w:1)
 	/// Proof: Assets Asset (max_values: None, max_size: Some(210), added: 2685, mode: MaxEncodedLen)
@@ -117,15 +117,15 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `446 + a * (86 ±0)`
 		//  Estimated: `5308 + a * (2623 ±0)`
 		// Minimum execution time: 16_455 nanoseconds.
-		Weight::from_ref_time(16_720_000)
-			.saturating_add(Weight::from_proof_size(5308))
+		Weight::from_parts(16_720_000, 0)
+			.saturating_add(Weight::from_parts(0, 5308))
 			// Standard Error: 7_111
-			.saturating_add(Weight::from_ref_time(13_717_750).saturating_mul(a.into()))
+			.saturating_add(Weight::from_parts(13_717_750, 0).saturating_mul(a.into()))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().reads((1_u64).saturating_mul(a.into())))
 			.saturating_add(T::DbWeight::get().writes(1))
 			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(a.into())))
-			.saturating_add(Weight::from_proof_size(2623).saturating_mul(a.into()))
+			.saturating_add(Weight::from_parts(0, 2623).saturating_mul(a.into()))
 	}
 	/// Storage: Assets Asset (r:1 w:1)
 	/// Proof: Assets Asset (max_values: None, max_size: Some(210), added: 2685, mode: MaxEncodedLen)
@@ -136,8 +136,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `275`
 		//  Estimated: `5300`
 		// Minimum execution time: 12_819 nanoseconds.
-		Weight::from_ref_time(13_111_000)
-			.saturating_add(Weight::from_proof_size(5300))
+		Weight::from_parts(13_111_000, 0)
+			.saturating_add(Weight::from_parts(0, 5300))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -150,8 +150,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `275`
 		//  Estimated: `5262`
 		// Minimum execution time: 22_897 nanoseconds.
-		Weight::from_ref_time(23_386_000)
-			.saturating_add(Weight::from_proof_size(5262))
+		Weight::from_parts(23_386_000, 0)
+			.saturating_add(Weight::from_parts(0, 5262))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -164,8 +164,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `383`
 		//  Estimated: `5262`
 		// Minimum execution time: 28_432 nanoseconds.
-		Weight::from_ref_time(28_903_000)
-			.saturating_add(Weight::from_proof_size(5262))
+		Weight::from_parts(28_903_000, 0)
+			.saturating_add(Weight::from_parts(0, 5262))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -180,8 +180,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `383`
 		//  Estimated: `10442`
 		// Minimum execution time: 39_823 nanoseconds.
-		Weight::from_ref_time(40_380_000)
-			.saturating_add(Weight::from_proof_size(10442))
+		Weight::from_parts(40_380_000, 0)
+			.saturating_add(Weight::from_parts(0, 10442))
 			.saturating_add(T::DbWeight::get().reads(4))
 			.saturating_add(T::DbWeight::get().writes(4))
 	}
@@ -196,8 +196,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `383`
 		//  Estimated: `10442`
 		// Minimum execution time: 34_924 nanoseconds.
-		Weight::from_ref_time(35_584_000)
-			.saturating_add(Weight::from_proof_size(10442))
+		Weight::from_parts(35_584_000, 0)
+			.saturating_add(Weight::from_parts(0, 10442))
 			.saturating_add(T::DbWeight::get().reads(4))
 			.saturating_add(T::DbWeight::get().writes(4))
 	}
@@ -212,8 +212,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `383`
 		//  Estimated: `10442`
 		// Minimum execution time: 39_647 nanoseconds.
-		Weight::from_ref_time(40_611_000)
-			.saturating_add(Weight::from_proof_size(10442))
+		Weight::from_parts(40_611_000, 0)
+			.saturating_add(Weight::from_parts(0, 10442))
 			.saturating_add(T::DbWeight::get().reads(4))
 			.saturating_add(T::DbWeight::get().writes(4))
 	}
@@ -226,8 +226,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `383`
 		//  Estimated: `5262`
 		// Minimum execution time: 16_462 nanoseconds.
-		Weight::from_ref_time(16_821_000)
-			.saturating_add(Weight::from_proof_size(5262))
+		Weight::from_parts(16_821_000, 0)
+			.saturating_add(Weight::from_parts(0, 5262))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -240,8 +240,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `383`
 		//  Estimated: `5262`
 		// Minimum execution time: 16_416 nanoseconds.
-		Weight::from_ref_time(16_758_000)
-			.saturating_add(Weight::from_proof_size(5262))
+		Weight::from_parts(16_758_000, 0)
+			.saturating_add(Weight::from_parts(0, 5262))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -252,8 +252,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `309`
 		//  Estimated: `2685`
 		// Minimum execution time: 12_853 nanoseconds.
-		Weight::from_ref_time(13_257_000)
-			.saturating_add(Weight::from_proof_size(2685))
+		Weight::from_parts(13_257_000, 0)
+			.saturating_add(Weight::from_parts(0, 2685))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -264,8 +264,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `309`
 		//  Estimated: `2685`
 		// Minimum execution time: 12_422 nanoseconds.
-		Weight::from_ref_time(12_763_000)
-			.saturating_add(Weight::from_proof_size(2685))
+		Weight::from_parts(12_763_000, 0)
+			.saturating_add(Weight::from_parts(0, 2685))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -278,8 +278,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `275`
 		//  Estimated: `5300`
 		// Minimum execution time: 13_950 nanoseconds.
-		Weight::from_ref_time(14_242_000)
-			.saturating_add(Weight::from_proof_size(5300))
+		Weight::from_parts(14_242_000, 0)
+			.saturating_add(Weight::from_parts(0, 5300))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -290,8 +290,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `275`
 		//  Estimated: `2685`
 		// Minimum execution time: 12_726 nanoseconds.
-		Weight::from_ref_time(13_072_000)
-			.saturating_add(Weight::from_proof_size(2685))
+		Weight::from_parts(13_072_000, 0)
+			.saturating_add(Weight::from_parts(0, 2685))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -306,10 +306,10 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `275`
 		//  Estimated: `5300`
 		// Minimum execution time: 22_772 nanoseconds.
-		Weight::from_ref_time(24_026_274)
-			.saturating_add(Weight::from_proof_size(5300))
+		Weight::from_parts(24_026_274, 0)
+			.saturating_add(Weight::from_parts(0, 5300))
 			// Standard Error: 1_231
-			.saturating_add(Weight::from_ref_time(203).saturating_mul(s.into()))
+			.saturating_add(Weight::from_parts(203, 0).saturating_mul(s.into()))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -322,8 +322,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `471`
 		//  Estimated: `5300`
 		// Minimum execution time: 23_310 nanoseconds.
-		Weight::from_ref_time(23_724_000)
-			.saturating_add(Weight::from_proof_size(5300))
+		Weight::from_parts(23_724_000, 0)
+			.saturating_add(Weight::from_parts(0, 5300))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -338,12 +338,12 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `82`
 		//  Estimated: `5300`
 		// Minimum execution time: 12_379 nanoseconds.
-		Weight::from_ref_time(12_903_065)
-			.saturating_add(Weight::from_proof_size(5300))
+		Weight::from_parts(12_903_065, 0)
+			.saturating_add(Weight::from_parts(0, 5300))
 			// Standard Error: 330
-			.saturating_add(Weight::from_ref_time(667).saturating_mul(n.into()))
+			.saturating_add(Weight::from_parts(667, 0).saturating_mul(n.into()))
 			// Standard Error: 330
-			.saturating_add(Weight::from_ref_time(2_891).saturating_mul(s.into()))
+			.saturating_add(Weight::from_parts(2_891, 0).saturating_mul(s.into()))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -356,8 +356,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `471`
 		//  Estimated: `5300`
 		// Minimum execution time: 23_531 nanoseconds.
-		Weight::from_ref_time(23_845_000)
-			.saturating_add(Weight::from_proof_size(5300))
+		Weight::from_parts(23_845_000, 0)
+			.saturating_add(Weight::from_parts(0, 5300))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -368,8 +368,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `275`
 		//  Estimated: `2685`
 		// Minimum execution time: 12_426 nanoseconds.
-		Weight::from_ref_time(12_888_000)
-			.saturating_add(Weight::from_proof_size(2685))
+		Weight::from_parts(12_888_000, 0)
+			.saturating_add(Weight::from_parts(0, 2685))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -382,8 +382,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `309`
 		//  Estimated: `5308`
 		// Minimum execution time: 26_365 nanoseconds.
-		Weight::from_ref_time(26_700_000)
-			.saturating_add(Weight::from_proof_size(5308))
+		Weight::from_parts(26_700_000, 0)
+			.saturating_add(Weight::from_parts(0, 5308))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -400,8 +400,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `553`
 		//  Estimated: `13065`
 		// Minimum execution time: 53_167 nanoseconds.
-		Weight::from_ref_time(53_564_000)
-			.saturating_add(Weight::from_proof_size(13065))
+		Weight::from_parts(53_564_000, 0)
+			.saturating_add(Weight::from_parts(0, 13065))
 			.saturating_add(T::DbWeight::get().reads(5))
 			.saturating_add(T::DbWeight::get().writes(5))
 	}
@@ -414,8 +414,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `479`
 		//  Estimated: `5308`
 		// Minimum execution time: 28_120 nanoseconds.
-		Weight::from_ref_time(28_540_000)
-			.saturating_add(Weight::from_proof_size(5308))
+		Weight::from_parts(28_540_000, 0)
+			.saturating_add(Weight::from_parts(0, 5308))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -428,8 +428,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `479`
 		//  Estimated: `5308`
 		// Minimum execution time: 28_503 nanoseconds.
-		Weight::from_ref_time(28_988_000)
-			.saturating_add(Weight::from_proof_size(5308))
+		Weight::from_parts(28_988_000, 0)
+			.saturating_add(Weight::from_parts(0, 5308))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}

--- a/parachains/runtimes/assets/statemine/src/weights/pallet_assets.rs
+++ b/parachains/runtimes/assets/statemine/src/weights/pallet_assets.rs
@@ -440,8 +440,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `383`
 		//  Estimated: `3675`
 		// Minimum execution time: 16_213 nanoseconds.
-		Weight::from_ref_time(16_575_000)
-			.saturating_add(Weight::from_proof_size(3675))
+		Weight::from_parts(16_575_000, 0)
+			.saturating_add(Weight::from_parts(0, 3675))
 			.saturating_add(T::DbWeight::get().reads(1_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}

--- a/parachains/runtimes/assets/statemine/src/weights/pallet_balances.rs
+++ b/parachains/runtimes/assets/statemine/src/weights/pallet_balances.rs
@@ -54,8 +54,8 @@ impl<T: frame_system::Config> pallet_balances::WeightInfo for WeightInfo<T> {
 		//  Measured:  `1178`
 		//  Estimated: `2603`
 		// Minimum execution time: 46_493 nanoseconds.
-		Weight::from_ref_time(47_804_000)
-			.saturating_add(Weight::from_proof_size(2603))
+		Weight::from_parts(47_804_000, 0)
+			.saturating_add(Weight::from_parts(0, 2603))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -66,8 +66,8 @@ impl<T: frame_system::Config> pallet_balances::WeightInfo for WeightInfo<T> {
 		//  Measured:  `1062`
 		//  Estimated: `2603`
 		// Minimum execution time: 35_020 nanoseconds.
-		Weight::from_ref_time(35_462_000)
-			.saturating_add(Weight::from_proof_size(2603))
+		Weight::from_parts(35_462_000, 0)
+			.saturating_add(Weight::from_parts(0, 2603))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -78,8 +78,8 @@ impl<T: frame_system::Config> pallet_balances::WeightInfo for WeightInfo<T> {
 		//  Measured:  `1174`
 		//  Estimated: `2603`
 		// Minimum execution time: 26_282 nanoseconds.
-		Weight::from_ref_time(26_915_000)
-			.saturating_add(Weight::from_proof_size(2603))
+		Weight::from_parts(26_915_000, 0)
+			.saturating_add(Weight::from_parts(0, 2603))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -90,8 +90,8 @@ impl<T: frame_system::Config> pallet_balances::WeightInfo for WeightInfo<T> {
 		//  Measured:  `1174`
 		//  Estimated: `2603`
 		// Minimum execution time: 29_529 nanoseconds.
-		Weight::from_ref_time(30_135_000)
-			.saturating_add(Weight::from_proof_size(2603))
+		Weight::from_parts(30_135_000, 0)
+			.saturating_add(Weight::from_parts(0, 2603))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -102,8 +102,8 @@ impl<T: frame_system::Config> pallet_balances::WeightInfo for WeightInfo<T> {
 		//  Measured:  `1174`
 		//  Estimated: `5206`
 		// Minimum execution time: 46_969 nanoseconds.
-		Weight::from_ref_time(47_657_000)
-			.saturating_add(Weight::from_proof_size(5206))
+		Weight::from_parts(47_657_000, 0)
+			.saturating_add(Weight::from_parts(0, 5206))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -114,8 +114,8 @@ impl<T: frame_system::Config> pallet_balances::WeightInfo for WeightInfo<T> {
 		//  Measured:  `1062`
 		//  Estimated: `2603`
 		// Minimum execution time: 41_398 nanoseconds.
-		Weight::from_ref_time(42_012_000)
-			.saturating_add(Weight::from_proof_size(2603))
+		Weight::from_parts(42_012_000, 0)
+			.saturating_add(Weight::from_parts(0, 2603))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -126,8 +126,8 @@ impl<T: frame_system::Config> pallet_balances::WeightInfo for WeightInfo<T> {
 		//  Measured:  `1058`
 		//  Estimated: `2603`
 		// Minimum execution time: 22_969 nanoseconds.
-		Weight::from_ref_time(23_548_000)
-			.saturating_add(Weight::from_proof_size(2603))
+		Weight::from_parts(23_548_000, 0)
+			.saturating_add(Weight::from_parts(0, 2603))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}

--- a/parachains/runtimes/assets/statemine/src/weights/pallet_collator_selection.rs
+++ b/parachains/runtimes/assets/statemine/src/weights/pallet_collator_selection.rs
@@ -57,13 +57,13 @@ impl<T: frame_system::Config> pallet_collator_selection::WeightInfo for WeightIn
 		//  Measured:  `178 + b * (78 ±0)`
 		//  Estimated: `178 + b * (2554 ±0)`
 		// Minimum execution time: 14_234 nanoseconds.
-		Weight::from_ref_time(15_794_150)
-			.saturating_add(Weight::from_proof_size(178))
+		Weight::from_parts(15_794_150, 0)
+			.saturating_add(Weight::from_parts(0, 178))
 			// Standard Error: 4_000
-			.saturating_add(Weight::from_ref_time(2_477_800).saturating_mul(b.into()))
+			.saturating_add(Weight::from_parts(2_477_800, 0).saturating_mul(b.into()))
 			.saturating_add(T::DbWeight::get().reads((1_u64).saturating_mul(b.into())))
 			.saturating_add(T::DbWeight::get().writes(1))
-			.saturating_add(Weight::from_proof_size(2554).saturating_mul(b.into()))
+			.saturating_add(Weight::from_parts(0, 2554).saturating_mul(b.into()))
 	}
 	/// Storage: CollatorSelection DesiredCandidates (r:0 w:1)
 	/// Proof: CollatorSelection DesiredCandidates (max_values: Some(1), max_size: Some(4), added: 499, mode: MaxEncodedLen)
@@ -72,8 +72,8 @@ impl<T: frame_system::Config> pallet_collator_selection::WeightInfo for WeightIn
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 7_190 nanoseconds.
-		Weight::from_ref_time(7_441_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(7_441_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
 	/// Storage: CollatorSelection CandidacyBond (r:0 w:1)
@@ -83,8 +83,8 @@ impl<T: frame_system::Config> pallet_collator_selection::WeightInfo for WeightIn
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 7_495 nanoseconds.
-		Weight::from_ref_time(7_666_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(7_666_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
 	/// Storage: CollatorSelection Candidates (r:1 w:1)
@@ -105,13 +105,13 @@ impl<T: frame_system::Config> pallet_collator_selection::WeightInfo for WeightIn
 		//  Measured:  `1171 + c * (48 ±0)`
 		//  Estimated: `56784 + c * (49 ±0)`
 		// Minimum execution time: 35_713 nanoseconds.
-		Weight::from_ref_time(27_978_009)
-			.saturating_add(Weight::from_proof_size(56784))
+		Weight::from_parts(27_978_009, 0)
+			.saturating_add(Weight::from_parts(0, 56784))
 			// Standard Error: 1_293
-			.saturating_add(Weight::from_ref_time(111_881).saturating_mul(c.into()))
+			.saturating_add(Weight::from_parts(111_881, 0).saturating_mul(c.into()))
 			.saturating_add(T::DbWeight::get().reads(5))
 			.saturating_add(T::DbWeight::get().writes(2))
-			.saturating_add(Weight::from_proof_size(49).saturating_mul(c.into()))
+			.saturating_add(Weight::from_parts(0, 49).saturating_mul(c.into()))
 	}
 	/// Storage: CollatorSelection Candidates (r:1 w:1)
 	/// Proof: CollatorSelection Candidates (max_values: Some(1), max_size: Some(48002), added: 48497, mode: MaxEncodedLen)
@@ -123,10 +123,10 @@ impl<T: frame_system::Config> pallet_collator_selection::WeightInfo for WeightIn
 		//  Measured:  `536 + c * (48 ±0)`
 		//  Estimated: `48497`
 		// Minimum execution time: 27_164 nanoseconds.
-		Weight::from_ref_time(16_901_858)
-			.saturating_add(Weight::from_proof_size(48497))
+		Weight::from_parts(16_901_858, 0)
+			.saturating_add(Weight::from_parts(0, 48497))
 			// Standard Error: 1_312
-			.saturating_add(Weight::from_ref_time(108_799).saturating_mul(c.into()))
+			.saturating_add(Weight::from_parts(108_799, 0).saturating_mul(c.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -141,8 +141,8 @@ impl<T: frame_system::Config> pallet_collator_selection::WeightInfo for WeightIn
 		//  Measured:  `135`
 		//  Estimated: `5749`
 		// Minimum execution time: 26_007 nanoseconds.
-		Weight::from_ref_time(26_416_000)
-			.saturating_add(Weight::from_proof_size(5749))
+		Weight::from_parts(26_416_000, 0)
+			.saturating_add(Weight::from_parts(0, 5749))
 			.saturating_add(T::DbWeight::get().reads(3))
 			.saturating_add(T::DbWeight::get().writes(4))
 	}
@@ -163,15 +163,15 @@ impl<T: frame_system::Config> pallet_collator_selection::WeightInfo for WeightIn
 		//  Measured:  `22784 + r * (148 ±0) + c * (97 ±0)`
 		//  Estimated: `52737 + c * (2519 ±0) + r * (2602 ±0)`
 		// Minimum execution time: 16_056 nanoseconds.
-		Weight::from_ref_time(16_335_000)
-			.saturating_add(Weight::from_proof_size(52737))
+		Weight::from_parts(16_335_000, 0)
+			.saturating_add(Weight::from_parts(0, 52737))
 			// Standard Error: 806_799
-			.saturating_add(Weight::from_ref_time(29_195_677).saturating_mul(c.into()))
+			.saturating_add(Weight::from_parts(29_195_677, 0).saturating_mul(c.into()))
 			.saturating_add(T::DbWeight::get().reads(4))
 			.saturating_add(T::DbWeight::get().reads((1_u64).saturating_mul(c.into())))
 			.saturating_add(T::DbWeight::get().writes(1))
 			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(c.into())))
-			.saturating_add(Weight::from_proof_size(2519).saturating_mul(c.into()))
-			.saturating_add(Weight::from_proof_size(2602).saturating_mul(r.into()))
+			.saturating_add(Weight::from_parts(0, 2519).saturating_mul(c.into()))
+			.saturating_add(Weight::from_parts(0, 2602).saturating_mul(r.into()))
 	}
 }

--- a/parachains/runtimes/assets/statemine/src/weights/pallet_multisig.rs
+++ b/parachains/runtimes/assets/statemine/src/weights/pallet_multisig.rs
@@ -53,10 +53,10 @@ impl<T: frame_system::Config> pallet_multisig::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 12_185 nanoseconds.
-		Weight::from_ref_time(12_423_059)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(12_423_059, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			// Standard Error: 1
-			.saturating_add(Weight::from_ref_time(596).saturating_mul(z.into()))
+			.saturating_add(Weight::from_parts(596, 0).saturating_mul(z.into()))
 	}
 	/// Storage: Multisig Multisigs (r:1 w:1)
 	/// Proof: Multisig Multisigs (max_values: None, max_size: Some(3346), added: 5821, mode: MaxEncodedLen)
@@ -67,12 +67,12 @@ impl<T: frame_system::Config> pallet_multisig::WeightInfo for WeightInfo<T> {
 		//  Measured:  `311 + s * (2 ±0)`
 		//  Estimated: `5821`
 		// Minimum execution time: 35_394 nanoseconds.
-		Weight::from_ref_time(28_339_222)
-			.saturating_add(Weight::from_proof_size(5821))
+		Weight::from_parts(28_339_222, 0)
+			.saturating_add(Weight::from_parts(0, 5821))
 			// Standard Error: 525
-			.saturating_add(Weight::from_ref_time(76_810).saturating_mul(s.into()))
+			.saturating_add(Weight::from_parts(76_810, 0).saturating_mul(s.into()))
 			// Standard Error: 5
-			.saturating_add(Weight::from_ref_time(1_641).saturating_mul(z.into()))
+			.saturating_add(Weight::from_parts(1_641, 0).saturating_mul(z.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -85,12 +85,12 @@ impl<T: frame_system::Config> pallet_multisig::WeightInfo for WeightInfo<T> {
 		//  Measured:  `313`
 		//  Estimated: `5821`
 		// Minimum execution time: 26_605 nanoseconds.
-		Weight::from_ref_time(19_882_694)
-			.saturating_add(Weight::from_proof_size(5821))
+		Weight::from_parts(19_882_694, 0)
+			.saturating_add(Weight::from_parts(0, 5821))
 			// Standard Error: 486
-			.saturating_add(Weight::from_ref_time(73_686).saturating_mul(s.into()))
+			.saturating_add(Weight::from_parts(73_686, 0).saturating_mul(s.into()))
 			// Standard Error: 4
-			.saturating_add(Weight::from_ref_time(1_615).saturating_mul(z.into()))
+			.saturating_add(Weight::from_parts(1_615, 0).saturating_mul(z.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -105,12 +105,12 @@ impl<T: frame_system::Config> pallet_multisig::WeightInfo for WeightInfo<T> {
 		//  Measured:  `448 + s * (33 ±0)`
 		//  Estimated: `8424`
 		// Minimum execution time: 40_558 nanoseconds.
-		Weight::from_ref_time(31_782_538)
-			.saturating_add(Weight::from_proof_size(8424))
+		Weight::from_parts(31_782_538, 0)
+			.saturating_add(Weight::from_parts(0, 8424))
 			// Standard Error: 587
-			.saturating_add(Weight::from_ref_time(94_913).saturating_mul(s.into()))
+			.saturating_add(Weight::from_parts(94_913, 0).saturating_mul(s.into()))
 			// Standard Error: 5
-			.saturating_add(Weight::from_ref_time(1_647).saturating_mul(z.into()))
+			.saturating_add(Weight::from_parts(1_647, 0).saturating_mul(z.into()))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -122,10 +122,10 @@ impl<T: frame_system::Config> pallet_multisig::WeightInfo for WeightInfo<T> {
 		//  Measured:  `318 + s * (2 ±0)`
 		//  Estimated: `5821`
 		// Minimum execution time: 24_889 nanoseconds.
-		Weight::from_ref_time(27_183_432)
-			.saturating_add(Weight::from_proof_size(5821))
+		Weight::from_parts(27_183_432, 0)
+			.saturating_add(Weight::from_parts(0, 5821))
 			// Standard Error: 835
-			.saturating_add(Weight::from_ref_time(79_518).saturating_mul(s.into()))
+			.saturating_add(Weight::from_parts(79_518, 0).saturating_mul(s.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -137,10 +137,10 @@ impl<T: frame_system::Config> pallet_multisig::WeightInfo for WeightInfo<T> {
 		//  Measured:  `313`
 		//  Estimated: `5821`
 		// Minimum execution time: 17_143 nanoseconds.
-		Weight::from_ref_time(18_532_968)
-			.saturating_add(Weight::from_proof_size(5821))
+		Weight::from_parts(18_532_968, 0)
+			.saturating_add(Weight::from_parts(0, 5821))
 			// Standard Error: 632
-			.saturating_add(Weight::from_ref_time(75_565).saturating_mul(s.into()))
+			.saturating_add(Weight::from_parts(75_565, 0).saturating_mul(s.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -152,10 +152,10 @@ impl<T: frame_system::Config> pallet_multisig::WeightInfo for WeightInfo<T> {
 		//  Measured:  `517 + s * (1 ±0)`
 		//  Estimated: `5821`
 		// Minimum execution time: 26_917 nanoseconds.
-		Weight::from_ref_time(28_425_612)
-			.saturating_add(Weight::from_proof_size(5821))
+		Weight::from_parts(28_425_612, 0)
+			.saturating_add(Weight::from_parts(0, 5821))
 			// Standard Error: 685
-			.saturating_add(Weight::from_ref_time(81_581).saturating_mul(s.into()))
+			.saturating_add(Weight::from_parts(81_581, 0).saturating_mul(s.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}

--- a/parachains/runtimes/assets/statemine/src/weights/pallet_proxy.rs
+++ b/parachains/runtimes/assets/statemine/src/weights/pallet_proxy.rs
@@ -55,10 +55,10 @@ impl<T: frame_system::Config> pallet_proxy::WeightInfo for WeightInfo<T> {
 		//  Measured:  `159 + p * (37 ±0)`
 		//  Estimated: `3716`
 		// Minimum execution time: 15_168 nanoseconds.
-		Weight::from_ref_time(15_986_761)
-			.saturating_add(Weight::from_proof_size(3716))
+		Weight::from_parts(15_986_761, 0)
+			.saturating_add(Weight::from_parts(0, 3716))
 			// Standard Error: 2_885
-			.saturating_add(Weight::from_ref_time(12_185).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(12_185, 0).saturating_mul(p.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 	}
 	/// Storage: Proxy Proxies (r:1 w:0)
@@ -74,12 +74,12 @@ impl<T: frame_system::Config> pallet_proxy::WeightInfo for WeightInfo<T> {
 		//  Measured:  `550 + a * (68 ±0) + p * (37 ±0)`
 		//  Estimated: `11027`
 		// Minimum execution time: 32_310 nanoseconds.
-		Weight::from_ref_time(32_466_194)
-			.saturating_add(Weight::from_proof_size(11027))
+		Weight::from_parts(32_466_194, 0)
+			.saturating_add(Weight::from_parts(0, 11027))
 			// Standard Error: 1_813
-			.saturating_add(Weight::from_ref_time(120_725).saturating_mul(a.into()))
+			.saturating_add(Weight::from_parts(120_725, 0).saturating_mul(a.into()))
 			// Standard Error: 1_873
-			.saturating_add(Weight::from_ref_time(32_578).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(32_578, 0).saturating_mul(p.into()))
 			.saturating_add(T::DbWeight::get().reads(3))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -94,12 +94,12 @@ impl<T: frame_system::Config> pallet_proxy::WeightInfo for WeightInfo<T> {
 		//  Measured:  `433 + a * (68 ±0)`
 		//  Estimated: `7311`
 		// Minimum execution time: 20_363 nanoseconds.
-		Weight::from_ref_time(21_135_277)
-			.saturating_add(Weight::from_proof_size(7311))
+		Weight::from_parts(21_135_277, 0)
+			.saturating_add(Weight::from_parts(0, 7311))
 			// Standard Error: 1_404
-			.saturating_add(Weight::from_ref_time(120_045).saturating_mul(a.into()))
+			.saturating_add(Weight::from_parts(120_045, 0).saturating_mul(a.into()))
 			// Standard Error: 1_450
-			.saturating_add(Weight::from_ref_time(8_992).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(8_992, 0).saturating_mul(p.into()))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -114,12 +114,12 @@ impl<T: frame_system::Config> pallet_proxy::WeightInfo for WeightInfo<T> {
 		//  Measured:  `433 + a * (68 ±0)`
 		//  Estimated: `7311`
 		// Minimum execution time: 20_086 nanoseconds.
-		Weight::from_ref_time(21_145_287)
-			.saturating_add(Weight::from_proof_size(7311))
+		Weight::from_parts(21_145_287, 0)
+			.saturating_add(Weight::from_parts(0, 7311))
 			// Standard Error: 1_612
-			.saturating_add(Weight::from_ref_time(113_598).saturating_mul(a.into()))
+			.saturating_add(Weight::from_parts(113_598, 0).saturating_mul(a.into()))
 			// Standard Error: 1_666
-			.saturating_add(Weight::from_ref_time(11_520).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(11_520, 0).saturating_mul(p.into()))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -136,12 +136,12 @@ impl<T: frame_system::Config> pallet_proxy::WeightInfo for WeightInfo<T> {
 		//  Measured:  `482 + a * (68 ±0) + p * (37 ±0)`
 		//  Estimated: `11027`
 		// Minimum execution time: 27_819 nanoseconds.
-		Weight::from_ref_time(28_662_588)
-			.saturating_add(Weight::from_proof_size(11027))
+		Weight::from_parts(28_662_588, 0)
+			.saturating_add(Weight::from_parts(0, 11027))
 			// Standard Error: 2_297
-			.saturating_add(Weight::from_ref_time(128_485).saturating_mul(a.into()))
+			.saturating_add(Weight::from_parts(128_485, 0).saturating_mul(a.into()))
 			// Standard Error: 2_373
-			.saturating_add(Weight::from_ref_time(47_044).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(47_044, 0).saturating_mul(p.into()))
 			.saturating_add(T::DbWeight::get().reads(3))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -153,10 +153,10 @@ impl<T: frame_system::Config> pallet_proxy::WeightInfo for WeightInfo<T> {
 		//  Measured:  `159 + p * (37 ±0)`
 		//  Estimated: `3716`
 		// Minimum execution time: 21_187 nanoseconds.
-		Weight::from_ref_time(22_430_290)
-			.saturating_add(Weight::from_proof_size(3716))
+		Weight::from_parts(22_430_290, 0)
+			.saturating_add(Weight::from_parts(0, 3716))
 			// Standard Error: 6_530
-			.saturating_add(Weight::from_ref_time(43_133).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(43_133, 0).saturating_mul(p.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -168,10 +168,10 @@ impl<T: frame_system::Config> pallet_proxy::WeightInfo for WeightInfo<T> {
 		//  Measured:  `159 + p * (37 ±0)`
 		//  Estimated: `3716`
 		// Minimum execution time: 20_985 nanoseconds.
-		Weight::from_ref_time(21_852_273)
-			.saturating_add(Weight::from_proof_size(3716))
+		Weight::from_parts(21_852_273, 0)
+			.saturating_add(Weight::from_parts(0, 3716))
 			// Standard Error: 1_662
-			.saturating_add(Weight::from_ref_time(66_644).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(66_644, 0).saturating_mul(p.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -183,10 +183,10 @@ impl<T: frame_system::Config> pallet_proxy::WeightInfo for WeightInfo<T> {
 		//  Measured:  `159 + p * (37 ±0)`
 		//  Estimated: `3716`
 		// Minimum execution time: 16_958 nanoseconds.
-		Weight::from_ref_time(17_752_361)
-			.saturating_add(Weight::from_proof_size(3716))
+		Weight::from_parts(17_752_361, 0)
+			.saturating_add(Weight::from_parts(0, 3716))
 			// Standard Error: 1_173
-			.saturating_add(Weight::from_ref_time(25_691).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(25_691, 0).saturating_mul(p.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -198,10 +198,10 @@ impl<T: frame_system::Config> pallet_proxy::WeightInfo for WeightInfo<T> {
 		//  Measured:  `139`
 		//  Estimated: `3716`
 		// Minimum execution time: 23_055 nanoseconds.
-		Weight::from_ref_time(23_892_965)
-			.saturating_add(Weight::from_proof_size(3716))
+		Weight::from_parts(23_892_965, 0)
+			.saturating_add(Weight::from_parts(0, 3716))
 			// Standard Error: 1_390
-			.saturating_add(Weight::from_ref_time(16_195).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(16_195, 0).saturating_mul(p.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -213,8 +213,8 @@ impl<T: frame_system::Config> pallet_proxy::WeightInfo for WeightInfo<T> {
 		//  Measured:  `196 + p * (37 ±0)`
 		//  Estimated: `3716`
 		// Minimum execution time: 18_344 nanoseconds.
-		Weight::from_ref_time(20_533_110)
-			.saturating_add(Weight::from_proof_size(3716))
+		Weight::from_parts(20_533_110, 0)
+			.saturating_add(Weight::from_parts(0, 3716))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}

--- a/parachains/runtimes/assets/statemine/src/weights/pallet_session.rs
+++ b/parachains/runtimes/assets/statemine/src/weights/pallet_session.rs
@@ -56,8 +56,8 @@ impl<T: frame_system::Config> pallet_session::WeightInfo for WeightInfo<T> {
 		//  Measured:  `270`
 		//  Estimated: `5490`
 		// Minimum execution time: 15_187 nanoseconds.
-		Weight::from_ref_time(15_459_000)
-			.saturating_add(Weight::from_proof_size(5490))
+		Weight::from_parts(15_459_000, 0)
+			.saturating_add(Weight::from_parts(0, 5490))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -70,8 +70,8 @@ impl<T: frame_system::Config> pallet_session::WeightInfo for WeightInfo<T> {
 		//  Measured:  `242`
 		//  Estimated: `2959`
 		// Minimum execution time: 11_795 nanoseconds.
-		Weight::from_ref_time(11_994_000)
-			.saturating_add(Weight::from_proof_size(2959))
+		Weight::from_parts(11_994_000, 0)
+			.saturating_add(Weight::from_parts(0, 2959))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}

--- a/parachains/runtimes/assets/statemine/src/weights/pallet_timestamp.rs
+++ b/parachains/runtimes/assets/statemine/src/weights/pallet_timestamp.rs
@@ -56,8 +56,8 @@ impl<T: frame_system::Config> pallet_timestamp::WeightInfo for WeightInfo<T> {
 		//  Measured:  `86`
 		//  Estimated: `1006`
 		// Minimum execution time: 8_408 nanoseconds.
-		Weight::from_ref_time(8_706_000)
-			.saturating_add(Weight::from_proof_size(1006))
+		Weight::from_parts(8_706_000, 0)
+			.saturating_add(Weight::from_parts(0, 1006))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -66,7 +66,7 @@ impl<T: frame_system::Config> pallet_timestamp::WeightInfo for WeightInfo<T> {
 		//  Measured:  `57`
 		//  Estimated: `0`
 		// Minimum execution time: 3_185 nanoseconds.
-		Weight::from_ref_time(3_282_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(3_282_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 	}
 }

--- a/parachains/runtimes/assets/statemine/src/weights/pallet_uniques.rs
+++ b/parachains/runtimes/assets/statemine/src/weights/pallet_uniques.rs
@@ -56,8 +56,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `177`
 		//  Estimated: `2653`
 		// Minimum execution time: 24_517 nanoseconds.
-		Weight::from_ref_time(24_884_000)
-			.saturating_add(Weight::from_proof_size(2653))
+		Weight::from_parts(24_884_000, 0)
+			.saturating_add(Weight::from_parts(0, 2653))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -70,8 +70,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `42`
 		//  Estimated: `2653`
 		// Minimum execution time: 13_312 nanoseconds.
-		Weight::from_ref_time(13_652_000)
-			.saturating_add(Weight::from_proof_size(2653))
+		Weight::from_parts(13_652_000, 0)
+			.saturating_add(Weight::from_parts(0, 2653))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -99,21 +99,21 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `289 + n * (108 ±0) + m * (56 ±0) + a * (107 ±0)`
 		//  Estimated: `5250 + n * (2597 ±0)`
 		// Minimum execution time: 2_287_290 nanoseconds.
-		Weight::from_ref_time(2_319_526_000)
-			.saturating_add(Weight::from_proof_size(5250))
+		Weight::from_parts(2_319_526_000, 0)
+			.saturating_add(Weight::from_parts(0, 5250))
 			// Standard Error: 25_275
-			.saturating_add(Weight::from_ref_time(8_587_226).saturating_mul(n.into()))
+			.saturating_add(Weight::from_parts(8_587_226, 0).saturating_mul(n.into()))
 			// Standard Error: 25_275
-			.saturating_add(Weight::from_ref_time(193_381).saturating_mul(m.into()))
+			.saturating_add(Weight::from_parts(193_381, 0).saturating_mul(m.into()))
 			// Standard Error: 25_275
-			.saturating_add(Weight::from_ref_time(296_151).saturating_mul(a.into()))
+			.saturating_add(Weight::from_parts(296_151, 0).saturating_mul(a.into()))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().reads((1_u64).saturating_mul(n.into())))
 			.saturating_add(T::DbWeight::get().writes(4))
 			.saturating_add(T::DbWeight::get().writes((2_u64).saturating_mul(n.into())))
 			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(m.into())))
 			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(a.into())))
-			.saturating_add(Weight::from_proof_size(2597).saturating_mul(n.into()))
+			.saturating_add(Weight::from_parts(0, 2597).saturating_mul(n.into()))
 	}
 	/// Storage: Uniques Asset (r:1 w:1)
 	/// Proof: Uniques Asset (max_values: None, max_size: Some(122), added: 2597, mode: MaxEncodedLen)
@@ -128,8 +128,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `314`
 		//  Estimated: `7749`
 		// Minimum execution time: 29_225 nanoseconds.
-		Weight::from_ref_time(29_894_000)
-			.saturating_add(Weight::from_proof_size(7749))
+		Weight::from_parts(29_894_000, 0)
+			.saturating_add(Weight::from_parts(0, 7749))
 			.saturating_add(T::DbWeight::get().reads(3))
 			.saturating_add(T::DbWeight::get().writes(3))
 	}
@@ -146,8 +146,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `492`
 		//  Estimated: `5250`
 		// Minimum execution time: 30_673 nanoseconds.
-		Weight::from_ref_time(31_553_000)
-			.saturating_add(Weight::from_proof_size(5250))
+		Weight::from_parts(31_553_000, 0)
+			.saturating_add(Weight::from_parts(0, 5250))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(4))
 	}
@@ -164,8 +164,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `492`
 		//  Estimated: `5250`
 		// Minimum execution time: 24_944 nanoseconds.
-		Weight::from_ref_time(25_233_000)
-			.saturating_add(Weight::from_proof_size(5250))
+		Weight::from_parts(25_233_000, 0)
+			.saturating_add(Weight::from_parts(0, 5250))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(4))
 	}
@@ -179,15 +179,15 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `770 + i * (108 ±0)`
 		//  Estimated: `2653 + i * (2597 ±0)`
 		// Minimum execution time: 14_364 nanoseconds.
-		Weight::from_ref_time(14_520_000)
-			.saturating_add(Weight::from_proof_size(2653))
+		Weight::from_parts(14_520_000, 0)
+			.saturating_add(Weight::from_parts(0, 2653))
 			// Standard Error: 12_908
-			.saturating_add(Weight::from_ref_time(12_176_880).saturating_mul(i.into()))
+			.saturating_add(Weight::from_parts(12_176_880, 0).saturating_mul(i.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().reads((1_u64).saturating_mul(i.into())))
 			.saturating_add(T::DbWeight::get().writes(1))
 			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(i.into())))
-			.saturating_add(Weight::from_proof_size(2597).saturating_mul(i.into()))
+			.saturating_add(Weight::from_parts(0, 2597).saturating_mul(i.into()))
 	}
 	/// Storage: Uniques Asset (r:1 w:1)
 	/// Proof: Uniques Asset (max_values: None, max_size: Some(122), added: 2597, mode: MaxEncodedLen)
@@ -198,8 +198,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `492`
 		//  Estimated: `5250`
 		// Minimum execution time: 17_798 nanoseconds.
-		Weight::from_ref_time(18_009_000)
-			.saturating_add(Weight::from_proof_size(5250))
+		Weight::from_parts(18_009_000, 0)
+			.saturating_add(Weight::from_parts(0, 5250))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -212,8 +212,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `492`
 		//  Estimated: `5250`
 		// Minimum execution time: 17_924 nanoseconds.
-		Weight::from_ref_time(18_168_000)
-			.saturating_add(Weight::from_proof_size(5250))
+		Weight::from_parts(18_168_000, 0)
+			.saturating_add(Weight::from_parts(0, 5250))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -224,8 +224,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `314`
 		//  Estimated: `2653`
 		// Minimum execution time: 13_425 nanoseconds.
-		Weight::from_ref_time(13_846_000)
-			.saturating_add(Weight::from_proof_size(2653))
+		Weight::from_parts(13_846_000, 0)
+			.saturating_add(Weight::from_parts(0, 2653))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -236,8 +236,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `314`
 		//  Estimated: `2653`
 		// Minimum execution time: 13_484 nanoseconds.
-		Weight::from_ref_time(13_715_000)
-			.saturating_add(Weight::from_proof_size(2653))
+		Weight::from_parts(13_715_000, 0)
+			.saturating_add(Weight::from_parts(0, 2653))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -252,8 +252,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `388`
 		//  Estimated: `5180`
 		// Minimum execution time: 21_132 nanoseconds.
-		Weight::from_ref_time(21_421_000)
-			.saturating_add(Weight::from_proof_size(5180))
+		Weight::from_parts(21_421_000, 0)
+			.saturating_add(Weight::from_parts(0, 5180))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(4))
 	}
@@ -264,8 +264,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `314`
 		//  Estimated: `2653`
 		// Minimum execution time: 13_763 nanoseconds.
-		Weight::from_ref_time(14_136_000)
-			.saturating_add(Weight::from_proof_size(2653))
+		Weight::from_parts(14_136_000, 0)
+			.saturating_add(Weight::from_parts(0, 2653))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -278,8 +278,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `314`
 		//  Estimated: `2653`
 		// Minimum execution time: 16_125 nanoseconds.
-		Weight::from_ref_time(16_516_000)
-			.saturating_add(Weight::from_proof_size(2653))
+		Weight::from_parts(16_516_000, 0)
+			.saturating_add(Weight::from_parts(0, 2653))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -294,8 +294,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `623`
 		//  Estimated: `7962`
 		// Minimum execution time: 34_408 nanoseconds.
-		Weight::from_ref_time(34_820_000)
-			.saturating_add(Weight::from_proof_size(7962))
+		Weight::from_parts(34_820_000, 0)
+			.saturating_add(Weight::from_parts(0, 7962))
 			.saturating_add(T::DbWeight::get().reads(3))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -310,8 +310,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `851`
 		//  Estimated: `7962`
 		// Minimum execution time: 33_385 nanoseconds.
-		Weight::from_ref_time(34_088_000)
-			.saturating_add(Weight::from_proof_size(7962))
+		Weight::from_parts(34_088_000, 0)
+			.saturating_add(Weight::from_parts(0, 7962))
 			.saturating_add(T::DbWeight::get().reads(3))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -324,8 +324,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `380`
 		//  Estimated: `5315`
 		// Minimum execution time: 27_303 nanoseconds.
-		Weight::from_ref_time(27_692_000)
-			.saturating_add(Weight::from_proof_size(5315))
+		Weight::from_parts(27_692_000, 0)
+			.saturating_add(Weight::from_parts(0, 5315))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -338,8 +338,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `623`
 		//  Estimated: `5315`
 		// Minimum execution time: 27_530 nanoseconds.
-		Weight::from_ref_time(28_122_000)
-			.saturating_add(Weight::from_proof_size(5315))
+		Weight::from_parts(28_122_000, 0)
+			.saturating_add(Weight::from_parts(0, 5315))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -352,8 +352,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `314`
 		//  Estimated: `5295`
 		// Minimum execution time: 26_384 nanoseconds.
-		Weight::from_ref_time(27_285_000)
-			.saturating_add(Weight::from_proof_size(5295))
+		Weight::from_parts(27_285_000, 0)
+			.saturating_add(Weight::from_parts(0, 5295))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -366,8 +366,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `537`
 		//  Estimated: `5295`
 		// Minimum execution time: 24_599 nanoseconds.
-		Weight::from_ref_time(24_992_000)
-			.saturating_add(Weight::from_proof_size(5295))
+		Weight::from_parts(24_992_000, 0)
+			.saturating_add(Weight::from_parts(0, 5295))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -380,8 +380,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `492`
 		//  Estimated: `5250`
 		// Minimum execution time: 19_754 nanoseconds.
-		Weight::from_ref_time(20_071_000)
-			.saturating_add(Weight::from_proof_size(5250))
+		Weight::from_parts(20_071_000, 0)
+			.saturating_add(Weight::from_parts(0, 5250))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -394,8 +394,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `525`
 		//  Estimated: `5250`
 		// Minimum execution time: 19_376 nanoseconds.
-		Weight::from_ref_time(19_716_000)
-			.saturating_add(Weight::from_proof_size(5250))
+		Weight::from_parts(19_716_000, 0)
+			.saturating_add(Weight::from_parts(0, 5250))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -406,8 +406,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `42`
 		//  Estimated: `2527`
 		// Minimum execution time: 15_069 nanoseconds.
-		Weight::from_ref_time(15_273_000)
-			.saturating_add(Weight::from_proof_size(2527))
+		Weight::from_parts(15_273_000, 0)
+			.saturating_add(Weight::from_parts(0, 2527))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -420,8 +420,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `314`
 		//  Estimated: `5152`
 		// Minimum execution time: 15_900 nanoseconds.
-		Weight::from_ref_time(16_182_000)
-			.saturating_add(Weight::from_proof_size(5152))
+		Weight::from_parts(16_182_000, 0)
+			.saturating_add(Weight::from_parts(0, 5152))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -434,8 +434,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `291`
 		//  Estimated: `2597`
 		// Minimum execution time: 15_789 nanoseconds.
-		Weight::from_ref_time(16_115_000)
-			.saturating_add(Weight::from_proof_size(2597))
+		Weight::from_parts(16_115_000, 0)
+			.saturating_add(Weight::from_parts(0, 2597))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -452,8 +452,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `636`
 		//  Estimated: `7814`
 		// Minimum execution time: 34_557 nanoseconds.
-		Weight::from_ref_time(34_927_000)
-			.saturating_add(Weight::from_proof_size(7814))
+		Weight::from_parts(34_927_000, 0)
+			.saturating_add(Weight::from_parts(0, 7814))
 			.saturating_add(T::DbWeight::get().reads(3))
 			.saturating_add(T::DbWeight::get().writes(4))
 	}

--- a/parachains/runtimes/assets/statemine/src/weights/pallet_utility.rs
+++ b/parachains/runtimes/assets/statemine/src/weights/pallet_utility.rs
@@ -53,18 +53,18 @@ impl<T: frame_system::Config> pallet_utility::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 6_416 nanoseconds.
-		Weight::from_ref_time(18_983_305)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(18_983_305, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			// Standard Error: 2_082
-			.saturating_add(Weight::from_ref_time(4_175_368).saturating_mul(c.into()))
+			.saturating_add(Weight::from_parts(4_175_368, 0).saturating_mul(c.into()))
 	}
 	fn as_derivative() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 4_581 nanoseconds.
-		Weight::from_ref_time(4_767_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(4_767_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 	}
 	/// The range of component `c` is `[0, 1000]`.
 	fn batch_all(c: u32, ) -> Weight {
@@ -72,18 +72,18 @@ impl<T: frame_system::Config> pallet_utility::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 6_279 nanoseconds.
-		Weight::from_ref_time(21_320_216)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(21_320_216, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			// Standard Error: 1_995
-			.saturating_add(Weight::from_ref_time(4_376_040).saturating_mul(c.into()))
+			.saturating_add(Weight::from_parts(4_376_040, 0).saturating_mul(c.into()))
 	}
 	fn dispatch_as() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 8_298 nanoseconds.
-		Weight::from_ref_time(8_522_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(8_522_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 	}
 	/// The range of component `c` is `[0, 1000]`.
 	fn force_batch(c: u32, ) -> Weight {
@@ -91,9 +91,9 @@ impl<T: frame_system::Config> pallet_utility::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 6_311 nanoseconds.
-		Weight::from_ref_time(16_307_926)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(16_307_926, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			// Standard Error: 2_381
-			.saturating_add(Weight::from_ref_time(4_172_851).saturating_mul(c.into()))
+			.saturating_add(Weight::from_parts(4_172_851, 0).saturating_mul(c.into()))
 	}
 }

--- a/parachains/runtimes/assets/statemine/src/weights/pallet_xcm.rs
+++ b/parachains/runtimes/assets/statemine/src/weights/pallet_xcm.rs
@@ -62,8 +62,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `38`
 		//  Estimated: `4645`
 		// Minimum execution time: 25_244 nanoseconds.
-		Weight::from_ref_time(25_671_000)
-			.saturating_add(Weight::from_proof_size(4645))
+		Weight::from_parts(25_671_000, 0)
+			.saturating_add(Weight::from_parts(0, 4645))
 			.saturating_add(T::DbWeight::get().reads(5))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -74,8 +74,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `499`
 		// Minimum execution time: 25_183 nanoseconds.
-		Weight::from_ref_time(25_684_000)
-			.saturating_add(Weight::from_proof_size(499))
+		Weight::from_parts(25_684_000, 0)
+			.saturating_add(Weight::from_parts(0, 499))
 			.saturating_add(T::DbWeight::get().reads(1))
 	}
 	/// Storage: ParachainInfo ParachainId (r:1 w:0)
@@ -85,8 +85,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `499`
 		// Minimum execution time: 18_819 nanoseconds.
-		Weight::from_ref_time(19_048_000)
-			.saturating_add(Weight::from_proof_size(499))
+		Weight::from_parts(19_048_000, 0)
+			.saturating_add(Weight::from_parts(0, 499))
 			.saturating_add(T::DbWeight::get().reads(1))
 	}
 	/// Storage: Benchmark Override (r:0 w:0)
@@ -96,8 +96,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 18_446_744_073_709_551 nanoseconds.
-		Weight::from_ref_time(18_446_744_073_709_551_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(18_446_744_073_709_551_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 	}
 	/// Storage: PolkadotXcm SupportedVersion (r:0 w:1)
 	/// Proof Skipped: PolkadotXcm SupportedVersion (max_values: None, max_size: None, mode: Measured)
@@ -106,8 +106,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 8_636 nanoseconds.
-		Weight::from_ref_time(8_906_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(8_906_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
 	/// Storage: PolkadotXcm SafeXcmVersion (r:0 w:1)
@@ -117,8 +117,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 2_486 nanoseconds.
-		Weight::from_ref_time(2_652_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(2_652_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
 	/// Storage: PolkadotXcm VersionNotifiers (r:1 w:1)
@@ -142,8 +142,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `38`
 		//  Estimated: `7729`
 		// Minimum execution time: 29_811 nanoseconds.
-		Weight::from_ref_time(30_291_000)
-			.saturating_add(Weight::from_proof_size(7729))
+		Weight::from_parts(30_291_000, 0)
+			.saturating_add(Weight::from_parts(0, 7729))
 			.saturating_add(T::DbWeight::get().reads(7))
 			.saturating_add(T::DbWeight::get().writes(5))
 	}
@@ -166,8 +166,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `220`
 		//  Estimated: `8470`
 		// Minimum execution time: 31_884 nanoseconds.
-		Weight::from_ref_time(32_567_000)
-			.saturating_add(Weight::from_proof_size(8470))
+		Weight::from_parts(32_567_000, 0)
+			.saturating_add(Weight::from_parts(0, 8470))
 			.saturating_add(T::DbWeight::get().reads(6))
 			.saturating_add(T::DbWeight::get().writes(4))
 	}
@@ -178,8 +178,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `95`
 		//  Estimated: `9995`
 		// Minimum execution time: 14_098 nanoseconds.
-		Weight::from_ref_time(14_349_000)
-			.saturating_add(Weight::from_proof_size(9995))
+		Weight::from_parts(14_349_000, 0)
+			.saturating_add(Weight::from_parts(0, 9995))
 			.saturating_add(T::DbWeight::get().reads(4))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -190,8 +190,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `99`
 		//  Estimated: `9999`
 		// Minimum execution time: 14_117 nanoseconds.
-		Weight::from_ref_time(14_383_000)
-			.saturating_add(Weight::from_proof_size(9999))
+		Weight::from_parts(14_383_000, 0)
+			.saturating_add(Weight::from_parts(0, 9999))
 			.saturating_add(T::DbWeight::get().reads(4))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -202,8 +202,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `106`
 		//  Estimated: `12481`
 		// Minimum execution time: 15_353 nanoseconds.
-		Weight::from_ref_time(15_558_000)
-			.saturating_add(Weight::from_proof_size(12481))
+		Weight::from_parts(15_558_000, 0)
+			.saturating_add(Weight::from_parts(0, 12481))
 			.saturating_add(T::DbWeight::get().reads(5))
 	}
 	/// Storage: PolkadotXcm VersionNotifyTargets (r:2 w:1)
@@ -223,8 +223,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `106`
 		//  Estimated: `10041`
 		// Minimum execution time: 28_752 nanoseconds.
-		Weight::from_ref_time(29_435_000)
-			.saturating_add(Weight::from_proof_size(10041))
+		Weight::from_parts(29_435_000, 0)
+			.saturating_add(Weight::from_parts(0, 10041))
 			.saturating_add(T::DbWeight::get().reads(7))
 			.saturating_add(T::DbWeight::get().writes(3))
 	}
@@ -235,8 +235,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `136`
 		//  Estimated: `7561`
 		// Minimum execution time: 7_143 nanoseconds.
-		Weight::from_ref_time(7_368_000)
-			.saturating_add(Weight::from_proof_size(7561))
+		Weight::from_parts(7_368_000, 0)
+			.saturating_add(Weight::from_parts(0, 7561))
 			.saturating_add(T::DbWeight::get().reads(3))
 	}
 	/// Storage: PolkadotXcm VersionNotifyTargets (r:4 w:2)
@@ -246,8 +246,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `106`
 		//  Estimated: `10006`
 		// Minimum execution time: 14_381 nanoseconds.
-		Weight::from_ref_time(14_582_000)
-			.saturating_add(Weight::from_proof_size(10006))
+		Weight::from_parts(14_582_000, 0)
+			.saturating_add(Weight::from_parts(0, 10006))
 			.saturating_add(T::DbWeight::get().reads(4))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -268,8 +268,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `112`
 		//  Estimated: `15027`
 		// Minimum execution time: 34_190 nanoseconds.
-		Weight::from_ref_time(34_889_000)
-			.saturating_add(Weight::from_proof_size(15027))
+		Weight::from_parts(34_889_000, 0)
+			.saturating_add(Weight::from_parts(0, 15027))
 			.saturating_add(T::DbWeight::get().reads(9))
 			.saturating_add(T::DbWeight::get().writes(4))
 	}

--- a/parachains/runtimes/assets/statemine/src/weights/xcm/mod.rs
+++ b/parachains/runtimes/assets/statemine/src/weights/xcm/mod.rs
@@ -65,7 +65,7 @@ impl<Call> XcmWeightInfo<Call> for StatemineXcmWeight<Call> {
 	// Currently there is no trusted reserve
 	fn reserve_asset_deposited(_assets: &MultiAssets) -> Weight {
 		// TODO: hardcoded - fix https://github.com/paritytech/cumulus/issues/1974
-		Weight::from_ref_time(1_000_000_000 as u64)
+		Weight::from_parts(1_000_000_000 as u64, 0)
 	}
 	fn receive_teleported_asset(assets: &MultiAssets) -> Weight {
 		assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::receive_teleported_asset())
@@ -123,7 +123,7 @@ impl<Call> XcmWeightInfo<Call> for StatemineXcmWeight<Call> {
 
 	fn deposit_asset(assets: &MultiAssetFilter, _dest: &MultiLocation) -> Weight {
 		// Hardcoded till the XCM pallet is fixed
-		let hardcoded_weight = Weight::from_ref_time(1_000_000_000 as u64);
+		let hardcoded_weight = Weight::from_parts(1_000_000_000 as u64, 0);
 		let weight = assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::deposit_asset());
 		hardcoded_weight.min(weight)
 	}

--- a/parachains/runtimes/assets/statemine/src/weights/xcm/pallet_xcm_benchmarks_fungible.rs
+++ b/parachains/runtimes/assets/statemine/src/weights/xcm/pallet_xcm_benchmarks_fungible.rs
@@ -51,14 +51,14 @@ impl<T: frame_system::Config> WeightInfo<T> {
 	// Storage: System Account (r:1 w:1)
 	// Proof: System Account (max_values: None, max_size: Some(128), added: 2603, mode: MaxEncodedLen)
 	pub(crate) fn withdraw_asset() -> Weight {
-		Weight::from_ref_time(22_035_000 as u64)
+		Weight::from_parts(22_035_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: System Account (r:2 w:2)
 	// Proof: System Account (max_values: None, max_size: Some(128), added: 2603, mode: MaxEncodedLen)
 	pub(crate) fn transfer_asset() -> Weight {
-		Weight::from_ref_time(54_300_000 as u64)
+		Weight::from_parts(54_300_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
@@ -77,17 +77,17 @@ impl<T: frame_system::Config> WeightInfo<T> {
 	// Storage: ParachainSystem PendingUpwardMessages (r:1 w:1)
 	// Proof Skipped: ParachainSystem PendingUpwardMessages (max_values: Some(1), max_size: None, mode: Measured)
 	pub(crate) fn transfer_reserve_asset() -> Weight {
-		Weight::from_ref_time(78_569_000 as u64)
+		Weight::from_parts(78_569_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(8 as u64))
 			.saturating_add(T::DbWeight::get().writes(4 as u64))
 	}
 	pub(crate) fn receive_teleported_asset() -> Weight {
-		Weight::from_ref_time(4_652_000 as u64)
+		Weight::from_parts(4_652_000 as u64, 0)
 	}
 	// Storage: System Account (r:1 w:1)
 	// Proof: System Account (max_values: None, max_size: Some(128), added: 2603, mode: MaxEncodedLen)
 	pub(crate) fn deposit_asset() -> Weight {
-		Weight::from_ref_time(23_684_000 as u64)
+		Weight::from_parts(23_684_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
@@ -106,7 +106,7 @@ impl<T: frame_system::Config> WeightInfo<T> {
 	// Storage: ParachainSystem PendingUpwardMessages (r:1 w:1)
 	// Proof Skipped: ParachainSystem PendingUpwardMessages (max_values: Some(1), max_size: None, mode: Measured)
 	pub(crate) fn deposit_reserve_asset() -> Weight {
-		Weight::from_ref_time(45_884_000 as u64)
+		Weight::from_parts(45_884_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(7 as u64))
 			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
@@ -123,7 +123,7 @@ impl<T: frame_system::Config> WeightInfo<T> {
 	// Storage: ParachainSystem PendingUpwardMessages (r:1 w:1)
 	// Proof Skipped: ParachainSystem PendingUpwardMessages (max_values: Some(1), max_size: None, mode: Measured)
 	pub(crate) fn initiate_teleport() -> Weight {
-		Weight::from_ref_time(30_239_000 as u64)
+		Weight::from_parts(30_239_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(6 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}

--- a/parachains/runtimes/assets/statemine/src/weights/xcm/pallet_xcm_benchmarks_generic.rs
+++ b/parachains/runtimes/assets/statemine/src/weights/xcm/pallet_xcm_benchmarks_generic.rs
@@ -61,39 +61,39 @@ impl<T: frame_system::Config> WeightInfo<T> {
 	// Storage: ParachainSystem PendingUpwardMessages (r:1 w:1)
 	// Proof Skipped: ParachainSystem PendingUpwardMessages (max_values: Some(1), max_size: None, mode: Measured)
 	pub(crate) fn report_holding() -> Weight {
-		Weight::from_ref_time(450_021_000 as u64)
+		Weight::from_parts(450_021_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(6 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	pub(crate) fn buy_execution() -> Weight {
-		Weight::from_ref_time(4_086_000 as u64)
+		Weight::from_parts(4_086_000 as u64, 0)
 	}
 	// Storage: PolkadotXcm Queries (r:1 w:0)
 	// Proof Skipped: PolkadotXcm Queries (max_values: None, max_size: None, mode: Measured)
 	pub(crate) fn query_response() -> Weight {
-		Weight::from_ref_time(11_290_000 as u64)
+		Weight::from_parts(11_290_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 	}
 	pub(crate) fn transact() -> Weight {
-		Weight::from_ref_time(13_288_000 as u64)
+		Weight::from_parts(13_288_000 as u64, 0)
 	}
 	pub(crate) fn refund_surplus() -> Weight {
-		Weight::from_ref_time(4_270_000 as u64)
+		Weight::from_parts(4_270_000 as u64, 0)
 	}
 	pub(crate) fn set_error_handler() -> Weight {
-		Weight::from_ref_time(3_205_000 as u64)
+		Weight::from_parts(3_205_000 as u64, 0)
 	}
 	pub(crate) fn set_appendix() -> Weight {
-		Weight::from_ref_time(3_246_000 as u64)
+		Weight::from_parts(3_246_000 as u64, 0)
 	}
 	pub(crate) fn clear_error() -> Weight {
-		Weight::from_ref_time(3_189_000 as u64)
+		Weight::from_parts(3_189_000 as u64, 0)
 	}
 	pub(crate) fn descend_origin() -> Weight {
-		Weight::from_ref_time(4_222_000 as u64)
+		Weight::from_parts(4_222_000 as u64, 0)
 	}
 	pub(crate) fn clear_origin() -> Weight {
-		Weight::from_ref_time(3_178_000 as u64)
+		Weight::from_parts(3_178_000 as u64, 0)
 	}
 	// Storage: ParachainInfo ParachainId (r:1 w:0)
 	// Proof: ParachainInfo ParachainId (max_values: Some(1), max_size: Some(4), added: 499, mode: MaxEncodedLen)
@@ -108,19 +108,19 @@ impl<T: frame_system::Config> WeightInfo<T> {
 	// Storage: ParachainSystem PendingUpwardMessages (r:1 w:1)
 	// Proof Skipped: ParachainSystem PendingUpwardMessages (max_values: Some(1), max_size: None, mode: Measured)
 	pub(crate) fn report_error() -> Weight {
-		Weight::from_ref_time(24_770_000 as u64)
+		Weight::from_parts(24_770_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(6 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: PolkadotXcm AssetTraps (r:1 w:1)
 	// Proof Skipped: PolkadotXcm AssetTraps (max_values: None, max_size: None, mode: Measured)
 	pub(crate) fn claim_asset() -> Weight {
-		Weight::from_ref_time(14_967_000 as u64)
+		Weight::from_parts(14_967_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	pub(crate) fn trap() -> Weight {
-		Weight::from_ref_time(3_186_000 as u64)
+		Weight::from_parts(3_186_000 as u64, 0)
 	}
 	// Storage: PolkadotXcm VersionNotifyTargets (r:1 w:1)
 	// Proof Skipped: PolkadotXcm VersionNotifyTargets (max_values: None, max_size: None, mode: Measured)
@@ -135,14 +135,14 @@ impl<T: frame_system::Config> WeightInfo<T> {
 	// Storage: ParachainSystem PendingUpwardMessages (r:1 w:1)
 	// Proof Skipped: ParachainSystem PendingUpwardMessages (max_values: Some(1), max_size: None, mode: Measured)
 	pub(crate) fn subscribe_version() -> Weight {
-		Weight::from_ref_time(25_797_000 as u64)
+		Weight::from_parts(25_797_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(6 as u64))
 			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: PolkadotXcm VersionNotifyTargets (r:0 w:1)
 	// Proof Skipped: PolkadotXcm VersionNotifyTargets (max_values: None, max_size: None, mode: Measured)
 	pub(crate) fn unsubscribe_version() -> Weight {
-		Weight::from_ref_time(5_170_000 as u64)
+		Weight::from_parts(5_170_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: ParachainInfo ParachainId (r:1 w:0)
@@ -158,24 +158,24 @@ impl<T: frame_system::Config> WeightInfo<T> {
 	// Storage: ParachainSystem PendingUpwardMessages (r:1 w:1)
 	// Proof Skipped: ParachainSystem PendingUpwardMessages (max_values: Some(1), max_size: None, mode: Measured)
 	pub(crate) fn initiate_reserve_withdraw() -> Weight {
-		Weight::from_ref_time(508_189_000 as u64)
+		Weight::from_parts(508_189_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(6 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	pub(crate) fn burn_asset() -> Weight {
-		Weight::from_ref_time(156_147_000 as u64)
+		Weight::from_parts(156_147_000 as u64, 0)
 	}
 	pub(crate) fn expect_asset() -> Weight {
-		Weight::from_ref_time(14_507_000 as u64)
+		Weight::from_parts(14_507_000 as u64, 0)
 	}
 	pub(crate) fn expect_origin() -> Weight {
-		Weight::from_ref_time(3_329_000 as u64)
+		Weight::from_parts(3_329_000 as u64, 0)
 	}
 	pub(crate) fn expect_error() -> Weight {
-		Weight::from_ref_time(3_164_000 as u64)
+		Weight::from_parts(3_164_000 as u64, 0)
 	}
 	pub(crate) fn expect_transact_status() -> Weight {
-		Weight::from_ref_time(3_415_000 as u64)
+		Weight::from_parts(3_415_000 as u64, 0)
 	}
 	// Storage: ParachainInfo ParachainId (r:1 w:0)
 	// Proof: ParachainInfo ParachainId (max_values: Some(1), max_size: Some(4), added: 499, mode: MaxEncodedLen)
@@ -190,12 +190,12 @@ impl<T: frame_system::Config> WeightInfo<T> {
 	// Storage: ParachainSystem PendingUpwardMessages (r:1 w:1)
 	// Proof Skipped: ParachainSystem PendingUpwardMessages (max_values: Some(1), max_size: None, mode: Measured)
 	pub(crate) fn query_pallet() -> Weight {
-		Weight::from_ref_time(27_966_000 as u64)
+		Weight::from_parts(27_966_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(6 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	pub(crate) fn expect_pallet() -> Weight {
-		Weight::from_ref_time(5_019_000 as u64)
+		Weight::from_parts(5_019_000 as u64, 0)
 	}
 	// Storage: ParachainInfo ParachainId (r:1 w:0)
 	// Proof: ParachainInfo ParachainId (max_values: Some(1), max_size: Some(4), added: 499, mode: MaxEncodedLen)
@@ -210,23 +210,23 @@ impl<T: frame_system::Config> WeightInfo<T> {
 	// Storage: ParachainSystem PendingUpwardMessages (r:1 w:1)
 	// Proof Skipped: ParachainSystem PendingUpwardMessages (max_values: Some(1), max_size: None, mode: Measured)
 	pub(crate) fn report_transact_status() -> Weight {
-		Weight::from_ref_time(25_097_000 as u64)
+		Weight::from_parts(25_097_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(6 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	pub(crate) fn clear_transact_status() -> Weight {
-		Weight::from_ref_time(3_193_000 as u64)
+		Weight::from_parts(3_193_000 as u64, 0)
 	}
 	pub(crate) fn set_topic() -> Weight {
-		Weight::from_ref_time(3_146_000 as u64)
+		Weight::from_parts(3_146_000 as u64, 0)
 	}
 	pub(crate) fn clear_topic() -> Weight {
-		Weight::from_ref_time(3_178_000 as u64)
+		Weight::from_parts(3_178_000 as u64, 0)
 	}
 	pub(crate) fn set_fees_mode() -> Weight {
-		Weight::from_ref_time(3_134_000 as u64)
+		Weight::from_parts(3_134_000 as u64, 0)
 	}
 	pub(crate) fn unpaid_execution() -> Weight {
-		Weight::from_ref_time(3_282_000 as u64)
+		Weight::from_parts(3_282_000 as u64, 0)
 	}
 }

--- a/parachains/runtimes/assets/statemine/tests/tests.rs
+++ b/parachains/runtimes/assets/statemine/tests/tests.rs
@@ -63,7 +63,7 @@ fn test_asset_xcm_trader() {
 			RuntimeHelper::<Runtime>::run_to_block(2, Some(AccountId::from(ALICE)));
 
 			// We are going to buy 4e9 weight
-			let bought = Weight::from_ref_time(4_000_000_000u64);
+			let bought = Weight::from_parts(4_000_000_000u64, 0);
 
 			// Lets calculate amount needed
 			let asset_amount_needed =
@@ -139,7 +139,7 @@ fn test_asset_xcm_trader_with_refund() {
 			RuntimeHelper::<Runtime>::run_to_block(2, Some(AccountId::from(ALICE)));
 
 			// We are going to buy 4e9 weight
-			let bought = Weight::from_ref_time(4_000_000_000u64);
+			let bought = Weight::from_parts(4_000_000_000u64, 0);
 
 			let asset_multilocation = MultiLocation::new(
 				0,
@@ -217,7 +217,7 @@ fn test_asset_xcm_trader_refund_not_possible_since_amount_less_than_ed() {
 			RuntimeHelper::<Runtime>::run_to_block(2, Some(AccountId::from(ALICE)));
 
 			// We are going to buy small amount
-			let bought = Weight::from_ref_time(500_000_000u64);
+			let bought = Weight::from_parts(500_000_000u64, 0);
 
 			let asset_multilocation = MultiLocation::new(
 				0,
@@ -277,7 +277,7 @@ fn test_that_buying_ed_refund_does_not_refund() {
 			RuntimeHelper::<Runtime>::run_to_block(2, Some(AccountId::from(ALICE)));
 
 			// We are gonna buy ED
-			let bought = Weight::from_ref_time(ExistentialDeposit::get().try_into().unwrap());
+			let bought = Weight::from_parts(ExistentialDeposit::get().try_into().unwrap(), 0);
 
 			let asset_multilocation = MultiLocation::new(
 				0,
@@ -358,7 +358,7 @@ fn test_asset_xcm_trader_not_possible_for_non_sufficient_assets() {
 			RuntimeHelper::<Runtime>::run_to_block(2, Some(AccountId::from(ALICE)));
 
 			// We are going to buy 4e9 weight
-			let bought = Weight::from_ref_time(4_000_000_000u64);
+			let bought = Weight::from_parts(4_000_000_000u64, 0);
 
 			// lets calculate amount needed
 			let asset_amount_needed = WeightToFee::weight_to_fee(&bought);

--- a/parachains/runtimes/assets/statemint/src/weights/block_weights.rs
+++ b/parachains/runtimes/assets/statemint/src/weights/block_weights.rs
@@ -24,7 +24,7 @@ pub mod constants {
 	parameter_types! {
 		/// Importing a block with 0 Extrinsics.
 		pub const BlockExecutionWeight: Weight =
-			Weight::from_ref_time(constants::WEIGHT_REF_TIME_PER_NANOS.saturating_mul(5_000_000));
+			Weight::from_parts(constants::WEIGHT_REF_TIME_PER_NANOS.saturating_mul(5_000_000), 0);
 	}
 
 	#[cfg(test)]

--- a/parachains/runtimes/assets/statemint/src/weights/cumulus_pallet_xcmp_queue.rs
+++ b/parachains/runtimes/assets/statemint/src/weights/cumulus_pallet_xcmp_queue.rs
@@ -54,8 +54,8 @@ impl<T: frame_system::Config> cumulus_pallet_xcmp_queue::WeightInfo for WeightIn
 		//  Measured:  `76`
 		//  Estimated: `571`
 		// Minimum execution time: 4_717 nanoseconds.
-		Weight::from_ref_time(4_964_000)
-			.saturating_add(Weight::from_proof_size(571))
+		Weight::from_parts(4_964_000, 0)
+			.saturating_add(Weight::from_parts(0, 571))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -66,8 +66,8 @@ impl<T: frame_system::Config> cumulus_pallet_xcmp_queue::WeightInfo for WeightIn
 		//  Measured:  `76`
 		//  Estimated: `571`
 		// Minimum execution time: 4_840 nanoseconds.
-		Weight::from_ref_time(5_074_000)
-			.saturating_add(Weight::from_proof_size(571))
+		Weight::from_parts(5_074_000, 0)
+			.saturating_add(Weight::from_parts(0, 571))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}

--- a/parachains/runtimes/assets/statemint/src/weights/extrinsic_weights.rs
+++ b/parachains/runtimes/assets/statemint/src/weights/extrinsic_weights.rs
@@ -24,7 +24,7 @@ pub mod constants {
 	parameter_types! {
 		/// Executing a NO-OP `System::remarks` Extrinsic.
 		pub const ExtrinsicBaseWeight: Weight =
-			Weight::from_ref_time(constants::WEIGHT_REF_TIME_PER_NANOS.saturating_mul(125_000));
+			Weight::from_parts(constants::WEIGHT_REF_TIME_PER_NANOS.saturating_mul(125_000), 0);
 	}
 
 	#[cfg(test)]

--- a/parachains/runtimes/assets/statemint/src/weights/frame_system.rs
+++ b/parachains/runtimes/assets/statemint/src/weights/frame_system.rs
@@ -53,10 +53,10 @@ impl<T: frame_system::Config> frame_system::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 1_455 nanoseconds.
-		Weight::from_ref_time(1_553_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(1_553_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			// Standard Error: 0
-			.saturating_add(Weight::from_ref_time(368).saturating_mul(b.into()))
+			.saturating_add(Weight::from_parts(368, 0).saturating_mul(b.into()))
 	}
 	/// The range of component `b` is `[0, 3932160]`.
 	fn remark_with_event(b: u32, ) -> Weight {
@@ -64,10 +64,10 @@ impl<T: frame_system::Config> frame_system::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 6_602 nanoseconds.
-		Weight::from_ref_time(6_725_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(6_725_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			// Standard Error: 0
-			.saturating_add(Weight::from_ref_time(1_715).saturating_mul(b.into()))
+			.saturating_add(Weight::from_parts(1_715, 0).saturating_mul(b.into()))
 	}
 	/// Storage: System Digest (r:1 w:1)
 	/// Proof Skipped: System Digest (max_values: Some(1), max_size: None, mode: Measured)
@@ -78,8 +78,8 @@ impl<T: frame_system::Config> frame_system::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `495`
 		// Minimum execution time: 3_555 nanoseconds.
-		Weight::from_ref_time(3_745_000)
-			.saturating_add(Weight::from_proof_size(495))
+		Weight::from_parts(3_745_000, 0)
+			.saturating_add(Weight::from_parts(0, 495))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -91,10 +91,10 @@ impl<T: frame_system::Config> frame_system::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 1_690 nanoseconds.
-		Weight::from_ref_time(1_735_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(1_735_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			// Standard Error: 2_138
-			.saturating_add(Weight::from_ref_time(588_449).saturating_mul(i.into()))
+			.saturating_add(Weight::from_parts(588_449, 0).saturating_mul(i.into()))
 			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(i.into())))
 	}
 	/// Storage: Skipped Metadata (r:0 w:0)
@@ -105,10 +105,10 @@ impl<T: frame_system::Config> frame_system::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 1_695 nanoseconds.
-		Weight::from_ref_time(1_771_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(1_771_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			// Standard Error: 816
-			.saturating_add(Weight::from_ref_time(449_345).saturating_mul(i.into()))
+			.saturating_add(Weight::from_parts(449_345, 0).saturating_mul(i.into()))
 			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(i.into())))
 	}
 	/// Storage: Skipped Metadata (r:0 w:0)
@@ -119,11 +119,11 @@ impl<T: frame_system::Config> frame_system::WeightInfo for WeightInfo<T> {
 		//  Measured:  `81 + p * (69 ±0)`
 		//  Estimated: `72 + p * (70 ±0)`
 		// Minimum execution time: 3_289 nanoseconds.
-		Weight::from_ref_time(3_377_000)
-			.saturating_add(Weight::from_proof_size(72))
+		Weight::from_parts(3_377_000, 0)
+			.saturating_add(Weight::from_parts(0, 72))
 			// Standard Error: 922
-			.saturating_add(Weight::from_ref_time(969_103).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(969_103, 0).saturating_mul(p.into()))
 			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(p.into())))
-			.saturating_add(Weight::from_proof_size(70).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(0, 70).saturating_mul(p.into()))
 	}
 }

--- a/parachains/runtimes/assets/statemint/src/weights/pallet_assets.rs
+++ b/parachains/runtimes/assets/statemint/src/weights/pallet_assets.rs
@@ -56,8 +56,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `141`
 		//  Estimated: `5288`
 		// Minimum execution time: 21_786 nanoseconds.
-		Weight::from_ref_time(22_084_000)
-			.saturating_add(Weight::from_proof_size(5288))
+		Weight::from_parts(22_084_000, 0)
+			.saturating_add(Weight::from_parts(0, 5288))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -68,8 +68,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `6`
 		//  Estimated: `2685`
 		// Minimum execution time: 10_638 nanoseconds.
-		Weight::from_ref_time(10_889_000)
-			.saturating_add(Weight::from_proof_size(2685))
+		Weight::from_parts(10_889_000, 0)
+			.saturating_add(Weight::from_parts(0, 2685))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -80,8 +80,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `309`
 		//  Estimated: `2685`
 		// Minimum execution time: 13_146 nanoseconds.
-		Weight::from_ref_time(13_421_000)
-			.saturating_add(Weight::from_proof_size(2685))
+		Weight::from_parts(13_421_000, 0)
+			.saturating_add(Weight::from_parts(0, 2685))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -97,15 +97,15 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0 + c * (240 ±0)`
 		//  Estimated: `5262 + c * (5180 ±0)`
 		// Minimum execution time: 15_962 nanoseconds.
-		Weight::from_ref_time(16_041_000)
-			.saturating_add(Weight::from_proof_size(5262))
+		Weight::from_parts(16_041_000, 0)
+			.saturating_add(Weight::from_parts(0, 5262))
 			// Standard Error: 9_326
-			.saturating_add(Weight::from_ref_time(13_983_529).saturating_mul(c.into()))
+			.saturating_add(Weight::from_parts(13_983_529, 0).saturating_mul(c.into()))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().reads((2_u64).saturating_mul(c.into())))
 			.saturating_add(T::DbWeight::get().writes(1))
 			.saturating_add(T::DbWeight::get().writes((2_u64).saturating_mul(c.into())))
-			.saturating_add(Weight::from_proof_size(5180).saturating_mul(c.into()))
+			.saturating_add(Weight::from_parts(0, 5180).saturating_mul(c.into()))
 	}
 	/// Storage: Assets Asset (r:1 w:1)
 	/// Proof: Assets Asset (max_values: None, max_size: Some(210), added: 2685, mode: MaxEncodedLen)
@@ -117,15 +117,15 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `446 + a * (86 ±0)`
 		//  Estimated: `5308 + a * (2623 ±0)`
 		// Minimum execution time: 16_343 nanoseconds.
-		Weight::from_ref_time(16_490_000)
-			.saturating_add(Weight::from_proof_size(5308))
+		Weight::from_parts(16_490_000, 0)
+			.saturating_add(Weight::from_parts(0, 5308))
 			// Standard Error: 7_664
-			.saturating_add(Weight::from_ref_time(13_585_881).saturating_mul(a.into()))
+			.saturating_add(Weight::from_parts(13_585_881, 0).saturating_mul(a.into()))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().reads((1_u64).saturating_mul(a.into())))
 			.saturating_add(T::DbWeight::get().writes(1))
 			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(a.into())))
-			.saturating_add(Weight::from_proof_size(2623).saturating_mul(a.into()))
+			.saturating_add(Weight::from_parts(0, 2623).saturating_mul(a.into()))
 	}
 	/// Storage: Assets Asset (r:1 w:1)
 	/// Proof: Assets Asset (max_values: None, max_size: Some(210), added: 2685, mode: MaxEncodedLen)
@@ -136,8 +136,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `275`
 		//  Estimated: `5300`
 		// Minimum execution time: 12_531 nanoseconds.
-		Weight::from_ref_time(13_108_000)
-			.saturating_add(Weight::from_proof_size(5300))
+		Weight::from_parts(13_108_000, 0)
+			.saturating_add(Weight::from_parts(0, 5300))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -150,8 +150,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `275`
 		//  Estimated: `5262`
 		// Minimum execution time: 22_604 nanoseconds.
-		Weight::from_ref_time(22_970_000)
-			.saturating_add(Weight::from_proof_size(5262))
+		Weight::from_parts(22_970_000, 0)
+			.saturating_add(Weight::from_parts(0, 5262))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -164,8 +164,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `383`
 		//  Estimated: `5262`
 		// Minimum execution time: 28_407 nanoseconds.
-		Weight::from_ref_time(29_012_000)
-			.saturating_add(Weight::from_proof_size(5262))
+		Weight::from_parts(29_012_000, 0)
+			.saturating_add(Weight::from_parts(0, 5262))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -180,8 +180,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `383`
 		//  Estimated: `10442`
 		// Minimum execution time: 38_044 nanoseconds.
-		Weight::from_ref_time(38_562_000)
-			.saturating_add(Weight::from_proof_size(10442))
+		Weight::from_parts(38_562_000, 0)
+			.saturating_add(Weight::from_parts(0, 10442))
 			.saturating_add(T::DbWeight::get().reads(4))
 			.saturating_add(T::DbWeight::get().writes(4))
 	}
@@ -196,8 +196,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `383`
 		//  Estimated: `10442`
 		// Minimum execution time: 33_946 nanoseconds.
-		Weight::from_ref_time(34_532_000)
-			.saturating_add(Weight::from_proof_size(10442))
+		Weight::from_parts(34_532_000, 0)
+			.saturating_add(Weight::from_parts(0, 10442))
 			.saturating_add(T::DbWeight::get().reads(4))
 			.saturating_add(T::DbWeight::get().writes(4))
 	}
@@ -212,8 +212,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `383`
 		//  Estimated: `10442`
 		// Minimum execution time: 38_013 nanoseconds.
-		Weight::from_ref_time(38_818_000)
-			.saturating_add(Weight::from_proof_size(10442))
+		Weight::from_parts(38_818_000, 0)
+			.saturating_add(Weight::from_parts(0, 10442))
 			.saturating_add(T::DbWeight::get().reads(4))
 			.saturating_add(T::DbWeight::get().writes(4))
 	}
@@ -226,8 +226,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `383`
 		//  Estimated: `5262`
 		// Minimum execution time: 15_798 nanoseconds.
-		Weight::from_ref_time(16_178_000)
-			.saturating_add(Weight::from_proof_size(5262))
+		Weight::from_parts(16_178_000, 0)
+			.saturating_add(Weight::from_parts(0, 5262))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -240,8 +240,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `383`
 		//  Estimated: `5262`
 		// Minimum execution time: 16_196 nanoseconds.
-		Weight::from_ref_time(16_525_000)
-			.saturating_add(Weight::from_proof_size(5262))
+		Weight::from_parts(16_525_000, 0)
+			.saturating_add(Weight::from_parts(0, 5262))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -252,8 +252,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `309`
 		//  Estimated: `2685`
 		// Minimum execution time: 12_600 nanoseconds.
-		Weight::from_ref_time(13_038_000)
-			.saturating_add(Weight::from_proof_size(2685))
+		Weight::from_parts(13_038_000, 0)
+			.saturating_add(Weight::from_parts(0, 2685))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -264,8 +264,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `309`
 		//  Estimated: `2685`
 		// Minimum execution time: 12_433 nanoseconds.
-		Weight::from_ref_time(12_924_000)
-			.saturating_add(Weight::from_proof_size(2685))
+		Weight::from_parts(12_924_000, 0)
+			.saturating_add(Weight::from_parts(0, 2685))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -278,8 +278,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `275`
 		//  Estimated: `5300`
 		// Minimum execution time: 13_754 nanoseconds.
-		Weight::from_ref_time(14_069_000)
-			.saturating_add(Weight::from_proof_size(5300))
+		Weight::from_parts(14_069_000, 0)
+			.saturating_add(Weight::from_parts(0, 5300))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -290,8 +290,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `275`
 		//  Estimated: `2685`
 		// Minimum execution time: 12_640 nanoseconds.
-		Weight::from_ref_time(12_846_000)
-			.saturating_add(Weight::from_proof_size(2685))
+		Weight::from_parts(12_846_000, 0)
+			.saturating_add(Weight::from_parts(0, 2685))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -306,10 +306,10 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `275`
 		//  Estimated: `5300`
 		// Minimum execution time: 22_428 nanoseconds.
-		Weight::from_ref_time(23_549_955)
-			.saturating_add(Weight::from_proof_size(5300))
+		Weight::from_parts(23_549_955, 0)
+			.saturating_add(Weight::from_parts(0, 5300))
 			// Standard Error: 731
-			.saturating_add(Weight::from_ref_time(893).saturating_mul(s.into()))
+			.saturating_add(Weight::from_parts(893, 0).saturating_mul(s.into()))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -322,8 +322,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `471`
 		//  Estimated: `5300`
 		// Minimum execution time: 22_730 nanoseconds.
-		Weight::from_ref_time(23_336_000)
-			.saturating_add(Weight::from_proof_size(5300))
+		Weight::from_parts(23_336_000, 0)
+			.saturating_add(Weight::from_parts(0, 5300))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -338,10 +338,10 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `82`
 		//  Estimated: `5300`
 		// Minimum execution time: 12_289 nanoseconds.
-		Weight::from_ref_time(12_841_728)
-			.saturating_add(Weight::from_proof_size(5300))
+		Weight::from_parts(12_841_728, 0)
+			.saturating_add(Weight::from_parts(0, 5300))
 			// Standard Error: 304
-			.saturating_add(Weight::from_ref_time(1_964).saturating_mul(s.into()))
+			.saturating_add(Weight::from_parts(1_964, 0).saturating_mul(s.into()))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -354,8 +354,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `471`
 		//  Estimated: `5300`
 		// Minimum execution time: 23_203 nanoseconds.
-		Weight::from_ref_time(23_490_000)
-			.saturating_add(Weight::from_proof_size(5300))
+		Weight::from_parts(23_490_000, 0)
+			.saturating_add(Weight::from_parts(0, 5300))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -366,8 +366,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `275`
 		//  Estimated: `2685`
 		// Minimum execution time: 12_042 nanoseconds.
-		Weight::from_ref_time(12_246_000)
-			.saturating_add(Weight::from_proof_size(2685))
+		Weight::from_parts(12_246_000, 0)
+			.saturating_add(Weight::from_parts(0, 2685))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -380,8 +380,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `309`
 		//  Estimated: `5308`
 		// Minimum execution time: 25_898 nanoseconds.
-		Weight::from_ref_time(26_128_000)
-			.saturating_add(Weight::from_proof_size(5308))
+		Weight::from_parts(26_128_000, 0)
+			.saturating_add(Weight::from_parts(0, 5308))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -398,8 +398,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `553`
 		//  Estimated: `13065`
 		// Minimum execution time: 52_087 nanoseconds.
-		Weight::from_ref_time(52_630_000)
-			.saturating_add(Weight::from_proof_size(13065))
+		Weight::from_parts(52_630_000, 0)
+			.saturating_add(Weight::from_parts(0, 13065))
 			.saturating_add(T::DbWeight::get().reads(5))
 			.saturating_add(T::DbWeight::get().writes(5))
 	}
@@ -412,8 +412,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `479`
 		//  Estimated: `5308`
 		// Minimum execution time: 27_731 nanoseconds.
-		Weight::from_ref_time(28_129_000)
-			.saturating_add(Weight::from_proof_size(5308))
+		Weight::from_parts(28_129_000, 0)
+			.saturating_add(Weight::from_parts(0, 5308))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -426,8 +426,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `479`
 		//  Estimated: `5308`
 		// Minimum execution time: 27_921 nanoseconds.
-		Weight::from_ref_time(28_386_000)
-			.saturating_add(Weight::from_proof_size(5308))
+		Weight::from_parts(28_386_000, 0)
+			.saturating_add(Weight::from_parts(0, 5308))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}

--- a/parachains/runtimes/assets/statemint/src/weights/pallet_assets.rs
+++ b/parachains/runtimes/assets/statemint/src/weights/pallet_assets.rs
@@ -438,8 +438,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `383`
 		//  Estimated: `3675`
 		// Minimum execution time: 16_213 nanoseconds.
-		Weight::from_ref_time(16_575_000)
-			.saturating_add(Weight::from_proof_size(3675))
+		Weight::from_parts(16_575_000, 0)
+			.saturating_add(Weight::from_parts(0, 3675))
 			.saturating_add(T::DbWeight::get().reads(1_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}

--- a/parachains/runtimes/assets/statemint/src/weights/pallet_balances.rs
+++ b/parachains/runtimes/assets/statemint/src/weights/pallet_balances.rs
@@ -54,8 +54,8 @@ impl<T: frame_system::Config> pallet_balances::WeightInfo for WeightInfo<T> {
 		//  Measured:  `1178`
 		//  Estimated: `2603`
 		// Minimum execution time: 45_943 nanoseconds.
-		Weight::from_ref_time(46_894_000)
-			.saturating_add(Weight::from_proof_size(2603))
+		Weight::from_parts(46_894_000, 0)
+			.saturating_add(Weight::from_parts(0, 2603))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -66,8 +66,8 @@ impl<T: frame_system::Config> pallet_balances::WeightInfo for WeightInfo<T> {
 		//  Measured:  `1062`
 		//  Estimated: `2603`
 		// Minimum execution time: 35_842 nanoseconds.
-		Weight::from_ref_time(36_089_000)
-			.saturating_add(Weight::from_proof_size(2603))
+		Weight::from_parts(36_089_000, 0)
+			.saturating_add(Weight::from_parts(0, 2603))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -78,8 +78,8 @@ impl<T: frame_system::Config> pallet_balances::WeightInfo for WeightInfo<T> {
 		//  Measured:  `1174`
 		//  Estimated: `2603`
 		// Minimum execution time: 26_219 nanoseconds.
-		Weight::from_ref_time(26_783_000)
-			.saturating_add(Weight::from_proof_size(2603))
+		Weight::from_parts(26_783_000, 0)
+			.saturating_add(Weight::from_parts(0, 2603))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -90,8 +90,8 @@ impl<T: frame_system::Config> pallet_balances::WeightInfo for WeightInfo<T> {
 		//  Measured:  `1174`
 		//  Estimated: `2603`
 		// Minimum execution time: 29_939 nanoseconds.
-		Weight::from_ref_time(30_394_000)
-			.saturating_add(Weight::from_proof_size(2603))
+		Weight::from_parts(30_394_000, 0)
+			.saturating_add(Weight::from_parts(0, 2603))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -102,8 +102,8 @@ impl<T: frame_system::Config> pallet_balances::WeightInfo for WeightInfo<T> {
 		//  Measured:  `1174`
 		//  Estimated: `5206`
 		// Minimum execution time: 46_341 nanoseconds.
-		Weight::from_ref_time(47_111_000)
-			.saturating_add(Weight::from_proof_size(5206))
+		Weight::from_parts(47_111_000, 0)
+			.saturating_add(Weight::from_parts(0, 5206))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -114,8 +114,8 @@ impl<T: frame_system::Config> pallet_balances::WeightInfo for WeightInfo<T> {
 		//  Measured:  `1062`
 		//  Estimated: `2603`
 		// Minimum execution time: 41_093 nanoseconds.
-		Weight::from_ref_time(41_472_000)
-			.saturating_add(Weight::from_proof_size(2603))
+		Weight::from_parts(41_472_000, 0)
+			.saturating_add(Weight::from_parts(0, 2603))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -126,8 +126,8 @@ impl<T: frame_system::Config> pallet_balances::WeightInfo for WeightInfo<T> {
 		//  Measured:  `1058`
 		//  Estimated: `2603`
 		// Minimum execution time: 22_961 nanoseconds.
-		Weight::from_ref_time(23_413_000)
-			.saturating_add(Weight::from_proof_size(2603))
+		Weight::from_parts(23_413_000, 0)
+			.saturating_add(Weight::from_parts(0, 2603))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}

--- a/parachains/runtimes/assets/statemint/src/weights/pallet_collator_selection.rs
+++ b/parachains/runtimes/assets/statemint/src/weights/pallet_collator_selection.rs
@@ -57,13 +57,13 @@ impl<T: frame_system::Config> pallet_collator_selection::WeightInfo for WeightIn
 		//  Measured:  `178 + b * (78 ±0)`
 		//  Estimated: `178 + b * (2554 ±0)`
 		// Minimum execution time: 14_182 nanoseconds.
-		Weight::from_ref_time(16_174_028)
-			.saturating_add(Weight::from_proof_size(178))
+		Weight::from_parts(16_174_028, 0)
+			.saturating_add(Weight::from_parts(0, 178))
 			// Standard Error: 3_951
-			.saturating_add(Weight::from_ref_time(2_446_152).saturating_mul(b.into()))
+			.saturating_add(Weight::from_parts(2_446_152, 0).saturating_mul(b.into()))
 			.saturating_add(T::DbWeight::get().reads((1_u64).saturating_mul(b.into())))
 			.saturating_add(T::DbWeight::get().writes(1))
-			.saturating_add(Weight::from_proof_size(2554).saturating_mul(b.into()))
+			.saturating_add(Weight::from_parts(0, 2554).saturating_mul(b.into()))
 	}
 	/// Storage: CollatorSelection DesiredCandidates (r:0 w:1)
 	/// Proof: CollatorSelection DesiredCandidates (max_values: Some(1), max_size: Some(4), added: 499, mode: MaxEncodedLen)
@@ -72,8 +72,8 @@ impl<T: frame_system::Config> pallet_collator_selection::WeightInfo for WeightIn
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 6_843 nanoseconds.
-		Weight::from_ref_time(7_086_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(7_086_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
 	/// Storage: CollatorSelection CandidacyBond (r:0 w:1)
@@ -83,8 +83,8 @@ impl<T: frame_system::Config> pallet_collator_selection::WeightInfo for WeightIn
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 7_075 nanoseconds.
-		Weight::from_ref_time(7_294_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(7_294_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
 	/// Storage: CollatorSelection Candidates (r:1 w:1)
@@ -105,13 +105,13 @@ impl<T: frame_system::Config> pallet_collator_selection::WeightInfo for WeightIn
 		//  Measured:  `1171 + c * (48 ±0)`
 		//  Estimated: `56784 + c * (49 ±0)`
 		// Minimum execution time: 34_101 nanoseconds.
-		Weight::from_ref_time(27_254_778)
-			.saturating_add(Weight::from_proof_size(56784))
+		Weight::from_parts(27_254_778, 0)
+			.saturating_add(Weight::from_parts(0, 56784))
 			// Standard Error: 1_210
-			.saturating_add(Weight::from_ref_time(105_038).saturating_mul(c.into()))
+			.saturating_add(Weight::from_parts(105_038, 0).saturating_mul(c.into()))
 			.saturating_add(T::DbWeight::get().reads(5))
 			.saturating_add(T::DbWeight::get().writes(2))
-			.saturating_add(Weight::from_proof_size(49).saturating_mul(c.into()))
+			.saturating_add(Weight::from_parts(0, 49).saturating_mul(c.into()))
 	}
 	/// Storage: CollatorSelection Candidates (r:1 w:1)
 	/// Proof: CollatorSelection Candidates (max_values: Some(1), max_size: Some(48002), added: 48497, mode: MaxEncodedLen)
@@ -123,10 +123,10 @@ impl<T: frame_system::Config> pallet_collator_selection::WeightInfo for WeightIn
 		//  Measured:  `536 + c * (48 ±0)`
 		//  Estimated: `48497`
 		// Minimum execution time: 26_156 nanoseconds.
-		Weight::from_ref_time(16_543_802)
-			.saturating_add(Weight::from_proof_size(48497))
+		Weight::from_parts(16_543_802, 0)
+			.saturating_add(Weight::from_parts(0, 48497))
 			// Standard Error: 1_209
-			.saturating_add(Weight::from_ref_time(102_889).saturating_mul(c.into()))
+			.saturating_add(Weight::from_parts(102_889, 0).saturating_mul(c.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -141,8 +141,8 @@ impl<T: frame_system::Config> pallet_collator_selection::WeightInfo for WeightIn
 		//  Measured:  `135`
 		//  Estimated: `5749`
 		// Minimum execution time: 24_859 nanoseconds.
-		Weight::from_ref_time(25_423_000)
-			.saturating_add(Weight::from_proof_size(5749))
+		Weight::from_parts(25_423_000, 0)
+			.saturating_add(Weight::from_parts(0, 5749))
 			.saturating_add(T::DbWeight::get().reads(3))
 			.saturating_add(T::DbWeight::get().writes(4))
 	}
@@ -163,15 +163,15 @@ impl<T: frame_system::Config> pallet_collator_selection::WeightInfo for WeightIn
 		//  Measured:  `22784 + r * (148 ±0) + c * (97 ±0)`
 		//  Estimated: `52737 + c * (2519 ±0) + r * (2602 ±0)`
 		// Minimum execution time: 16_296 nanoseconds.
-		Weight::from_ref_time(16_532_000)
-			.saturating_add(Weight::from_proof_size(52737))
+		Weight::from_parts(16_532_000, 0)
+			.saturating_add(Weight::from_parts(0, 52737))
 			// Standard Error: 758_486
-			.saturating_add(Weight::from_ref_time(27_694_526).saturating_mul(c.into()))
+			.saturating_add(Weight::from_parts(27_694_526, 0).saturating_mul(c.into()))
 			.saturating_add(T::DbWeight::get().reads(4))
 			.saturating_add(T::DbWeight::get().reads((1_u64).saturating_mul(c.into())))
 			.saturating_add(T::DbWeight::get().writes(1))
 			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(c.into())))
-			.saturating_add(Weight::from_proof_size(2519).saturating_mul(c.into()))
-			.saturating_add(Weight::from_proof_size(2602).saturating_mul(r.into()))
+			.saturating_add(Weight::from_parts(0, 2519).saturating_mul(c.into()))
+			.saturating_add(Weight::from_parts(0, 2602).saturating_mul(r.into()))
 	}
 }

--- a/parachains/runtimes/assets/statemint/src/weights/pallet_multisig.rs
+++ b/parachains/runtimes/assets/statemint/src/weights/pallet_multisig.rs
@@ -53,10 +53,10 @@ impl<T: frame_system::Config> pallet_multisig::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 11_557 nanoseconds.
-		Weight::from_ref_time(12_087_731)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(12_087_731, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			// Standard Error: 1
-			.saturating_add(Weight::from_ref_time(493).saturating_mul(z.into()))
+			.saturating_add(Weight::from_parts(493, 0).saturating_mul(z.into()))
 	}
 	/// Storage: Multisig Multisigs (r:1 w:1)
 	/// Proof: Multisig Multisigs (max_values: None, max_size: Some(3346), added: 5821, mode: MaxEncodedLen)
@@ -67,12 +67,12 @@ impl<T: frame_system::Config> pallet_multisig::WeightInfo for WeightInfo<T> {
 		//  Measured:  `311 + s * (2 ±0)`
 		//  Estimated: `5821`
 		// Minimum execution time: 35_027 nanoseconds.
-		Weight::from_ref_time(28_254_579)
-			.saturating_add(Weight::from_proof_size(5821))
+		Weight::from_parts(28_254_579, 0)
+			.saturating_add(Weight::from_parts(0, 5821))
 			// Standard Error: 541
-			.saturating_add(Weight::from_ref_time(73_609).saturating_mul(s.into()))
+			.saturating_add(Weight::from_parts(73_609, 0).saturating_mul(s.into()))
 			// Standard Error: 5
-			.saturating_add(Weight::from_ref_time(1_530).saturating_mul(z.into()))
+			.saturating_add(Weight::from_parts(1_530, 0).saturating_mul(z.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -85,12 +85,12 @@ impl<T: frame_system::Config> pallet_multisig::WeightInfo for WeightInfo<T> {
 		//  Measured:  `313`
 		//  Estimated: `5821`
 		// Minimum execution time: 25_892 nanoseconds.
-		Weight::from_ref_time(19_974_491)
-			.saturating_add(Weight::from_proof_size(5821))
+		Weight::from_parts(19_974_491, 0)
+			.saturating_add(Weight::from_parts(0, 5821))
 			// Standard Error: 382
-			.saturating_add(Weight::from_ref_time(67_041).saturating_mul(s.into()))
+			.saturating_add(Weight::from_parts(67_041, 0).saturating_mul(s.into()))
 			// Standard Error: 3
-			.saturating_add(Weight::from_ref_time(1_516).saturating_mul(z.into()))
+			.saturating_add(Weight::from_parts(1_516, 0).saturating_mul(z.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -105,12 +105,12 @@ impl<T: frame_system::Config> pallet_multisig::WeightInfo for WeightInfo<T> {
 		//  Measured:  `448 + s * (33 ±0)`
 		//  Estimated: `8424`
 		// Minimum execution time: 39_799 nanoseconds.
-		Weight::from_ref_time(31_172_141)
-			.saturating_add(Weight::from_proof_size(8424))
+		Weight::from_parts(31_172_141, 0)
+			.saturating_add(Weight::from_parts(0, 8424))
 			// Standard Error: 523
-			.saturating_add(Weight::from_ref_time(91_287).saturating_mul(s.into()))
+			.saturating_add(Weight::from_parts(91_287, 0).saturating_mul(s.into()))
 			// Standard Error: 5
-			.saturating_add(Weight::from_ref_time(1_557).saturating_mul(z.into()))
+			.saturating_add(Weight::from_parts(1_557, 0).saturating_mul(z.into()))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -122,10 +122,10 @@ impl<T: frame_system::Config> pallet_multisig::WeightInfo for WeightInfo<T> {
 		//  Measured:  `318 + s * (2 ±0)`
 		//  Estimated: `5821`
 		// Minimum execution time: 24_614 nanoseconds.
-		Weight::from_ref_time(26_554_159)
-			.saturating_add(Weight::from_proof_size(5821))
+		Weight::from_parts(26_554_159, 0)
+			.saturating_add(Weight::from_parts(0, 5821))
 			// Standard Error: 754
-			.saturating_add(Weight::from_ref_time(81_278).saturating_mul(s.into()))
+			.saturating_add(Weight::from_parts(81_278, 0).saturating_mul(s.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -137,10 +137,10 @@ impl<T: frame_system::Config> pallet_multisig::WeightInfo for WeightInfo<T> {
 		//  Measured:  `313`
 		//  Estimated: `5821`
 		// Minimum execution time: 17_141 nanoseconds.
-		Weight::from_ref_time(18_191_699)
-			.saturating_add(Weight::from_proof_size(5821))
+		Weight::from_parts(18_191_699, 0)
+			.saturating_add(Weight::from_parts(0, 5821))
 			// Standard Error: 546
-			.saturating_add(Weight::from_ref_time(74_486).saturating_mul(s.into()))
+			.saturating_add(Weight::from_parts(74_486, 0).saturating_mul(s.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -152,10 +152,10 @@ impl<T: frame_system::Config> pallet_multisig::WeightInfo for WeightInfo<T> {
 		//  Measured:  `517 + s * (1 ±0)`
 		//  Estimated: `5821`
 		// Minimum execution time: 25_869 nanoseconds.
-		Weight::from_ref_time(28_059_249)
-			.saturating_add(Weight::from_proof_size(5821))
+		Weight::from_parts(28_059_249, 0)
+			.saturating_add(Weight::from_parts(0, 5821))
 			// Standard Error: 677
-			.saturating_add(Weight::from_ref_time(80_187).saturating_mul(s.into()))
+			.saturating_add(Weight::from_parts(80_187, 0).saturating_mul(s.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}

--- a/parachains/runtimes/assets/statemint/src/weights/pallet_proxy.rs
+++ b/parachains/runtimes/assets/statemint/src/weights/pallet_proxy.rs
@@ -55,10 +55,10 @@ impl<T: frame_system::Config> pallet_proxy::WeightInfo for WeightInfo<T> {
 		//  Measured:  `159 + p * (37 ±0)`
 		//  Estimated: `3716`
 		// Minimum execution time: 14_405 nanoseconds.
-		Weight::from_ref_time(15_511_983)
-			.saturating_add(Weight::from_proof_size(3716))
+		Weight::from_parts(15_511_983, 0)
+			.saturating_add(Weight::from_parts(0, 3716))
 			// Standard Error: 2_104
-			.saturating_add(Weight::from_ref_time(19_450).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(19_450, 0).saturating_mul(p.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 	}
 	/// Storage: Proxy Proxies (r:1 w:0)
@@ -74,12 +74,12 @@ impl<T: frame_system::Config> pallet_proxy::WeightInfo for WeightInfo<T> {
 		//  Measured:  `550 + a * (68 ±0) + p * (37 ±0)`
 		//  Estimated: `11027`
 		// Minimum execution time: 31_545 nanoseconds.
-		Weight::from_ref_time(31_928_375)
-			.saturating_add(Weight::from_proof_size(11027))
+		Weight::from_parts(31_928_375, 0)
+			.saturating_add(Weight::from_parts(0, 11027))
 			// Standard Error: 2_022
-			.saturating_add(Weight::from_ref_time(114_479).saturating_mul(a.into()))
+			.saturating_add(Weight::from_parts(114_479, 0).saturating_mul(a.into()))
 			// Standard Error: 2_089
-			.saturating_add(Weight::from_ref_time(34_696).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(34_696, 0).saturating_mul(p.into()))
 			.saturating_add(T::DbWeight::get().reads(3))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -94,12 +94,12 @@ impl<T: frame_system::Config> pallet_proxy::WeightInfo for WeightInfo<T> {
 		//  Measured:  `433 + a * (68 ±0)`
 		//  Estimated: `7311`
 		// Minimum execution time: 20_215 nanoseconds.
-		Weight::from_ref_time(20_970_496)
-			.saturating_add(Weight::from_proof_size(7311))
+		Weight::from_parts(20_970_496, 0)
+			.saturating_add(Weight::from_parts(0, 7311))
 			// Standard Error: 1_277
-			.saturating_add(Weight::from_ref_time(111_015).saturating_mul(a.into()))
+			.saturating_add(Weight::from_parts(111_015, 0).saturating_mul(a.into()))
 			// Standard Error: 1_320
-			.saturating_add(Weight::from_ref_time(9_988).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(9_988, 0).saturating_mul(p.into()))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -114,12 +114,12 @@ impl<T: frame_system::Config> pallet_proxy::WeightInfo for WeightInfo<T> {
 		//  Measured:  `433 + a * (68 ±0)`
 		//  Estimated: `7311`
 		// Minimum execution time: 20_153 nanoseconds.
-		Weight::from_ref_time(21_046_064)
-			.saturating_add(Weight::from_proof_size(7311))
+		Weight::from_parts(21_046_064, 0)
+			.saturating_add(Weight::from_parts(0, 7311))
 			// Standard Error: 1_342
-			.saturating_add(Weight::from_ref_time(108_638).saturating_mul(a.into()))
+			.saturating_add(Weight::from_parts(108_638, 0).saturating_mul(a.into()))
 			// Standard Error: 1_386
-			.saturating_add(Weight::from_ref_time(10_617).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(10_617, 0).saturating_mul(p.into()))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -136,12 +136,12 @@ impl<T: frame_system::Config> pallet_proxy::WeightInfo for WeightInfo<T> {
 		//  Measured:  `482 + a * (68 ±0) + p * (37 ±0)`
 		//  Estimated: `11027`
 		// Minimum execution time: 27_692 nanoseconds.
-		Weight::from_ref_time(28_900_223)
-			.saturating_add(Weight::from_proof_size(11027))
+		Weight::from_parts(28_900_223, 0)
+			.saturating_add(Weight::from_parts(0, 11027))
 			// Standard Error: 1_751
-			.saturating_add(Weight::from_ref_time(100_648).saturating_mul(a.into()))
+			.saturating_add(Weight::from_parts(100_648, 0).saturating_mul(a.into()))
 			// Standard Error: 1_809
-			.saturating_add(Weight::from_ref_time(35_769).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(35_769, 0).saturating_mul(p.into()))
 			.saturating_add(T::DbWeight::get().reads(3))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -153,10 +153,10 @@ impl<T: frame_system::Config> pallet_proxy::WeightInfo for WeightInfo<T> {
 		//  Measured:  `159 + p * (37 ±0)`
 		//  Estimated: `3716`
 		// Minimum execution time: 20_726 nanoseconds.
-		Weight::from_ref_time(21_849_126)
-			.saturating_add(Weight::from_proof_size(3716))
+		Weight::from_parts(21_849_126, 0)
+			.saturating_add(Weight::from_parts(0, 3716))
 			// Standard Error: 1_307
-			.saturating_add(Weight::from_ref_time(43_349).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(43_349, 0).saturating_mul(p.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -168,10 +168,10 @@ impl<T: frame_system::Config> pallet_proxy::WeightInfo for WeightInfo<T> {
 		//  Measured:  `159 + p * (37 ±0)`
 		//  Estimated: `3716`
 		// Minimum execution time: 20_681 nanoseconds.
-		Weight::from_ref_time(21_733_251)
-			.saturating_add(Weight::from_proof_size(3716))
+		Weight::from_parts(21_733_251, 0)
+			.saturating_add(Weight::from_parts(0, 3716))
 			// Standard Error: 1_555
-			.saturating_add(Weight::from_ref_time(59_461).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(59_461, 0).saturating_mul(p.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -183,10 +183,10 @@ impl<T: frame_system::Config> pallet_proxy::WeightInfo for WeightInfo<T> {
 		//  Measured:  `159 + p * (37 ±0)`
 		//  Estimated: `3716`
 		// Minimum execution time: 16_966 nanoseconds.
-		Weight::from_ref_time(17_682_078)
-			.saturating_add(Weight::from_proof_size(3716))
+		Weight::from_parts(17_682_078, 0)
+			.saturating_add(Weight::from_parts(0, 3716))
 			// Standard Error: 1_110
-			.saturating_add(Weight::from_ref_time(28_786).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(28_786, 0).saturating_mul(p.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -198,10 +198,10 @@ impl<T: frame_system::Config> pallet_proxy::WeightInfo for WeightInfo<T> {
 		//  Measured:  `139`
 		//  Estimated: `3716`
 		// Minimum execution time: 22_237 nanoseconds.
-		Weight::from_ref_time(23_324_695)
-			.saturating_add(Weight::from_proof_size(3716))
+		Weight::from_parts(23_324_695, 0)
+			.saturating_add(Weight::from_parts(0, 3716))
 			// Standard Error: 1_481
-			.saturating_add(Weight::from_ref_time(9_284).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(9_284, 0).saturating_mul(p.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -213,10 +213,10 @@ impl<T: frame_system::Config> pallet_proxy::WeightInfo for WeightInfo<T> {
 		//  Measured:  `196 + p * (37 ±0)`
 		//  Estimated: `3716`
 		// Minimum execution time: 18_041 nanoseconds.
-		Weight::from_ref_time(18_668_925)
-			.saturating_add(Weight::from_proof_size(3716))
+		Weight::from_parts(18_668_925, 0)
+			.saturating_add(Weight::from_parts(0, 3716))
 			// Standard Error: 1_209
-			.saturating_add(Weight::from_ref_time(29_794).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(29_794, 0).saturating_mul(p.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}

--- a/parachains/runtimes/assets/statemint/src/weights/pallet_session.rs
+++ b/parachains/runtimes/assets/statemint/src/weights/pallet_session.rs
@@ -56,8 +56,8 @@ impl<T: frame_system::Config> pallet_session::WeightInfo for WeightInfo<T> {
 		//  Measured:  `270`
 		//  Estimated: `5490`
 		// Minimum execution time: 15_561 nanoseconds.
-		Weight::from_ref_time(15_843_000)
-			.saturating_add(Weight::from_proof_size(5490))
+		Weight::from_parts(15_843_000, 0)
+			.saturating_add(Weight::from_parts(0, 5490))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -70,8 +70,8 @@ impl<T: frame_system::Config> pallet_session::WeightInfo for WeightInfo<T> {
 		//  Measured:  `242`
 		//  Estimated: `2959`
 		// Minimum execution time: 11_757 nanoseconds.
-		Weight::from_ref_time(12_093_000)
-			.saturating_add(Weight::from_proof_size(2959))
+		Weight::from_parts(12_093_000, 0)
+			.saturating_add(Weight::from_parts(0, 2959))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}

--- a/parachains/runtimes/assets/statemint/src/weights/pallet_timestamp.rs
+++ b/parachains/runtimes/assets/statemint/src/weights/pallet_timestamp.rs
@@ -56,8 +56,8 @@ impl<T: frame_system::Config> pallet_timestamp::WeightInfo for WeightInfo<T> {
 		//  Measured:  `86`
 		//  Estimated: `1006`
 		// Minimum execution time: 8_399 nanoseconds.
-		Weight::from_ref_time(8_649_000)
-			.saturating_add(Weight::from_proof_size(1006))
+		Weight::from_parts(8_649_000, 0)
+			.saturating_add(Weight::from_parts(0, 1006))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -66,7 +66,7 @@ impl<T: frame_system::Config> pallet_timestamp::WeightInfo for WeightInfo<T> {
 		//  Measured:  `57`
 		//  Estimated: `0`
 		// Minimum execution time: 3_277 nanoseconds.
-		Weight::from_ref_time(3_349_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(3_349_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 	}
 }

--- a/parachains/runtimes/assets/statemint/src/weights/pallet_uniques.rs
+++ b/parachains/runtimes/assets/statemint/src/weights/pallet_uniques.rs
@@ -56,8 +56,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `177`
 		//  Estimated: `2653`
 		// Minimum execution time: 23_738 nanoseconds.
-		Weight::from_ref_time(24_550_000)
-			.saturating_add(Weight::from_proof_size(2653))
+		Weight::from_parts(24_550_000, 0)
+			.saturating_add(Weight::from_parts(0, 2653))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -70,8 +70,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `42`
 		//  Estimated: `2653`
 		// Minimum execution time: 13_165 nanoseconds.
-		Weight::from_ref_time(13_515_000)
-			.saturating_add(Weight::from_proof_size(2653))
+		Weight::from_parts(13_515_000, 0)
+			.saturating_add(Weight::from_parts(0, 2653))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -99,21 +99,21 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `289 + n * (108 ±0) + m * (56 ±0) + a * (107 ±0)`
 		//  Estimated: `5250 + n * (2597 ±0)`
 		// Minimum execution time: 2_258_129 nanoseconds.
-		Weight::from_ref_time(2_289_592_000)
-			.saturating_add(Weight::from_proof_size(5250))
+		Weight::from_parts(2_289_592_000, 0)
+			.saturating_add(Weight::from_parts(0, 5250))
 			// Standard Error: 26_214
-			.saturating_add(Weight::from_ref_time(8_416_144).saturating_mul(n.into()))
+			.saturating_add(Weight::from_parts(8_416_144, 0).saturating_mul(n.into()))
 			// Standard Error: 26_214
-			.saturating_add(Weight::from_ref_time(256_638).saturating_mul(m.into()))
+			.saturating_add(Weight::from_parts(256_638, 0).saturating_mul(m.into()))
 			// Standard Error: 26_214
-			.saturating_add(Weight::from_ref_time(274_803).saturating_mul(a.into()))
+			.saturating_add(Weight::from_parts(274_803, 0).saturating_mul(a.into()))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().reads((1_u64).saturating_mul(n.into())))
 			.saturating_add(T::DbWeight::get().writes(4))
 			.saturating_add(T::DbWeight::get().writes((2_u64).saturating_mul(n.into())))
 			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(m.into())))
 			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(a.into())))
-			.saturating_add(Weight::from_proof_size(2597).saturating_mul(n.into()))
+			.saturating_add(Weight::from_parts(0, 2597).saturating_mul(n.into()))
 	}
 	/// Storage: Uniques Asset (r:1 w:1)
 	/// Proof: Uniques Asset (max_values: None, max_size: Some(122), added: 2597, mode: MaxEncodedLen)
@@ -128,8 +128,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `314`
 		//  Estimated: `7749`
 		// Minimum execution time: 28_974 nanoseconds.
-		Weight::from_ref_time(29_398_000)
-			.saturating_add(Weight::from_proof_size(7749))
+		Weight::from_parts(29_398_000, 0)
+			.saturating_add(Weight::from_parts(0, 7749))
 			.saturating_add(T::DbWeight::get().reads(3))
 			.saturating_add(T::DbWeight::get().writes(3))
 	}
@@ -146,8 +146,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `492`
 		//  Estimated: `5250`
 		// Minimum execution time: 30_070 nanoseconds.
-		Weight::from_ref_time(30_454_000)
-			.saturating_add(Weight::from_proof_size(5250))
+		Weight::from_parts(30_454_000, 0)
+			.saturating_add(Weight::from_parts(0, 5250))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(4))
 	}
@@ -164,8 +164,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `492`
 		//  Estimated: `5250`
 		// Minimum execution time: 24_287 nanoseconds.
-		Weight::from_ref_time(24_509_000)
-			.saturating_add(Weight::from_proof_size(5250))
+		Weight::from_parts(24_509_000, 0)
+			.saturating_add(Weight::from_parts(0, 5250))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(4))
 	}
@@ -179,15 +179,15 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `770 + i * (108 ±0)`
 		//  Estimated: `2653 + i * (2597 ±0)`
 		// Minimum execution time: 14_231 nanoseconds.
-		Weight::from_ref_time(14_454_000)
-			.saturating_add(Weight::from_proof_size(2653))
+		Weight::from_parts(14_454_000, 0)
+			.saturating_add(Weight::from_parts(0, 2653))
 			// Standard Error: 13_135
-			.saturating_add(Weight::from_ref_time(12_152_067).saturating_mul(i.into()))
+			.saturating_add(Weight::from_parts(12_152_067, 0).saturating_mul(i.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().reads((1_u64).saturating_mul(i.into())))
 			.saturating_add(T::DbWeight::get().writes(1))
 			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(i.into())))
-			.saturating_add(Weight::from_proof_size(2597).saturating_mul(i.into()))
+			.saturating_add(Weight::from_parts(0, 2597).saturating_mul(i.into()))
 	}
 	/// Storage: Uniques Asset (r:1 w:1)
 	/// Proof: Uniques Asset (max_values: None, max_size: Some(122), added: 2597, mode: MaxEncodedLen)
@@ -198,8 +198,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `492`
 		//  Estimated: `5250`
 		// Minimum execution time: 17_977 nanoseconds.
-		Weight::from_ref_time(18_415_000)
-			.saturating_add(Weight::from_proof_size(5250))
+		Weight::from_parts(18_415_000, 0)
+			.saturating_add(Weight::from_parts(0, 5250))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -212,8 +212,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `492`
 		//  Estimated: `5250`
 		// Minimum execution time: 17_421 nanoseconds.
-		Weight::from_ref_time(17_830_000)
-			.saturating_add(Weight::from_proof_size(5250))
+		Weight::from_parts(17_830_000, 0)
+			.saturating_add(Weight::from_parts(0, 5250))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -224,8 +224,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `314`
 		//  Estimated: `2653`
 		// Minimum execution time: 13_199 nanoseconds.
-		Weight::from_ref_time(13_615_000)
-			.saturating_add(Weight::from_proof_size(2653))
+		Weight::from_parts(13_615_000, 0)
+			.saturating_add(Weight::from_parts(0, 2653))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -236,8 +236,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `314`
 		//  Estimated: `2653`
 		// Minimum execution time: 13_263 nanoseconds.
-		Weight::from_ref_time(13_575_000)
-			.saturating_add(Weight::from_proof_size(2653))
+		Weight::from_parts(13_575_000, 0)
+			.saturating_add(Weight::from_parts(0, 2653))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -252,8 +252,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `388`
 		//  Estimated: `5180`
 		// Minimum execution time: 20_850 nanoseconds.
-		Weight::from_ref_time(21_223_000)
-			.saturating_add(Weight::from_proof_size(5180))
+		Weight::from_parts(21_223_000, 0)
+			.saturating_add(Weight::from_parts(0, 5180))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(4))
 	}
@@ -264,8 +264,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `314`
 		//  Estimated: `2653`
 		// Minimum execution time: 14_218 nanoseconds.
-		Weight::from_ref_time(14_680_000)
-			.saturating_add(Weight::from_proof_size(2653))
+		Weight::from_parts(14_680_000, 0)
+			.saturating_add(Weight::from_parts(0, 2653))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -278,8 +278,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `314`
 		//  Estimated: `2653`
 		// Minimum execution time: 16_581 nanoseconds.
-		Weight::from_ref_time(16_856_000)
-			.saturating_add(Weight::from_proof_size(2653))
+		Weight::from_parts(16_856_000, 0)
+			.saturating_add(Weight::from_parts(0, 2653))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -294,8 +294,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `623`
 		//  Estimated: `7962`
 		// Minimum execution time: 34_610 nanoseconds.
-		Weight::from_ref_time(34_994_000)
-			.saturating_add(Weight::from_proof_size(7962))
+		Weight::from_parts(34_994_000, 0)
+			.saturating_add(Weight::from_parts(0, 7962))
 			.saturating_add(T::DbWeight::get().reads(3))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -310,8 +310,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `851`
 		//  Estimated: `7962`
 		// Minimum execution time: 34_244 nanoseconds.
-		Weight::from_ref_time(34_542_000)
-			.saturating_add(Weight::from_proof_size(7962))
+		Weight::from_parts(34_542_000, 0)
+			.saturating_add(Weight::from_parts(0, 7962))
 			.saturating_add(T::DbWeight::get().reads(3))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -324,8 +324,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `380`
 		//  Estimated: `5315`
 		// Minimum execution time: 26_652 nanoseconds.
-		Weight::from_ref_time(27_013_000)
-			.saturating_add(Weight::from_proof_size(5315))
+		Weight::from_parts(27_013_000, 0)
+			.saturating_add(Weight::from_parts(0, 5315))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -338,8 +338,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `623`
 		//  Estimated: `5315`
 		// Minimum execution time: 27_427 nanoseconds.
-		Weight::from_ref_time(27_985_000)
-			.saturating_add(Weight::from_proof_size(5315))
+		Weight::from_parts(27_985_000, 0)
+			.saturating_add(Weight::from_parts(0, 5315))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -352,8 +352,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `314`
 		//  Estimated: `5295`
 		// Minimum execution time: 26_557 nanoseconds.
-		Weight::from_ref_time(26_973_000)
-			.saturating_add(Weight::from_proof_size(5295))
+		Weight::from_parts(26_973_000, 0)
+			.saturating_add(Weight::from_parts(0, 5295))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -366,8 +366,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `537`
 		//  Estimated: `5295`
 		// Minimum execution time: 25_091 nanoseconds.
-		Weight::from_ref_time(25_510_000)
-			.saturating_add(Weight::from_proof_size(5295))
+		Weight::from_parts(25_510_000, 0)
+			.saturating_add(Weight::from_parts(0, 5295))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -380,8 +380,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `492`
 		//  Estimated: `5250`
 		// Minimum execution time: 19_129 nanoseconds.
-		Weight::from_ref_time(19_831_000)
-			.saturating_add(Weight::from_proof_size(5250))
+		Weight::from_parts(19_831_000, 0)
+			.saturating_add(Weight::from_parts(0, 5250))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -394,8 +394,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `525`
 		//  Estimated: `5250`
 		// Minimum execution time: 19_393 nanoseconds.
-		Weight::from_ref_time(19_569_000)
-			.saturating_add(Weight::from_proof_size(5250))
+		Weight::from_parts(19_569_000, 0)
+			.saturating_add(Weight::from_parts(0, 5250))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -406,8 +406,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `42`
 		//  Estimated: `2527`
 		// Minimum execution time: 14_863 nanoseconds.
-		Weight::from_ref_time(15_066_000)
-			.saturating_add(Weight::from_proof_size(2527))
+		Weight::from_parts(15_066_000, 0)
+			.saturating_add(Weight::from_parts(0, 2527))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -420,8 +420,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `314`
 		//  Estimated: `5152`
 		// Minimum execution time: 16_144 nanoseconds.
-		Weight::from_ref_time(16_510_000)
-			.saturating_add(Weight::from_proof_size(5152))
+		Weight::from_parts(16_510_000, 0)
+			.saturating_add(Weight::from_parts(0, 5152))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -434,8 +434,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `291`
 		//  Estimated: `2597`
 		// Minimum execution time: 15_884 nanoseconds.
-		Weight::from_ref_time(16_215_000)
-			.saturating_add(Weight::from_proof_size(2597))
+		Weight::from_parts(16_215_000, 0)
+			.saturating_add(Weight::from_parts(0, 2597))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -452,8 +452,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `636`
 		//  Estimated: `7814`
 		// Minimum execution time: 34_190 nanoseconds.
-		Weight::from_ref_time(34_497_000)
-			.saturating_add(Weight::from_proof_size(7814))
+		Weight::from_parts(34_497_000, 0)
+			.saturating_add(Weight::from_parts(0, 7814))
 			.saturating_add(T::DbWeight::get().reads(3))
 			.saturating_add(T::DbWeight::get().writes(4))
 	}

--- a/parachains/runtimes/assets/statemint/src/weights/pallet_utility.rs
+++ b/parachains/runtimes/assets/statemint/src/weights/pallet_utility.rs
@@ -53,18 +53,18 @@ impl<T: frame_system::Config> pallet_utility::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 6_005 nanoseconds.
-		Weight::from_ref_time(18_139_015)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(18_139_015, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			// Standard Error: 2_178
-			.saturating_add(Weight::from_ref_time(3_979_226).saturating_mul(c.into()))
+			.saturating_add(Weight::from_parts(3_979_226, 0).saturating_mul(c.into()))
 	}
 	fn as_derivative() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 4_441 nanoseconds.
-		Weight::from_ref_time(4_622_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(4_622_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 	}
 	/// The range of component `c` is `[0, 1000]`.
 	fn batch_all(c: u32, ) -> Weight {
@@ -72,18 +72,18 @@ impl<T: frame_system::Config> pallet_utility::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 5_910 nanoseconds.
-		Weight::from_ref_time(18_908_357)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(18_908_357, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			// Standard Error: 1_920
-			.saturating_add(Weight::from_ref_time(4_169_103).saturating_mul(c.into()))
+			.saturating_add(Weight::from_parts(4_169_103, 0).saturating_mul(c.into()))
 	}
 	fn dispatch_as() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 7_957 nanoseconds.
-		Weight::from_ref_time(8_145_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(8_145_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 	}
 	/// The range of component `c` is `[0, 1000]`.
 	fn force_batch(c: u32, ) -> Weight {
@@ -91,9 +91,9 @@ impl<T: frame_system::Config> pallet_utility::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 5_925 nanoseconds.
-		Weight::from_ref_time(15_056_349)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(15_056_349, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			// Standard Error: 1_987
-			.saturating_add(Weight::from_ref_time(3_981_287).saturating_mul(c.into()))
+			.saturating_add(Weight::from_parts(3_981_287, 0).saturating_mul(c.into()))
 	}
 }

--- a/parachains/runtimes/assets/statemint/src/weights/pallet_xcm.rs
+++ b/parachains/runtimes/assets/statemint/src/weights/pallet_xcm.rs
@@ -62,8 +62,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `38`
 		//  Estimated: `4645`
 		// Minimum execution time: 24_132 nanoseconds.
-		Weight::from_ref_time(24_554_000)
-			.saturating_add(Weight::from_proof_size(4645))
+		Weight::from_parts(24_554_000, 0)
+			.saturating_add(Weight::from_parts(0, 4645))
 			.saturating_add(T::DbWeight::get().reads(5))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -74,8 +74,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `499`
 		// Minimum execution time: 22_350 nanoseconds.
-		Weight::from_ref_time(22_760_000)
-			.saturating_add(Weight::from_proof_size(499))
+		Weight::from_parts(22_760_000, 0)
+			.saturating_add(Weight::from_parts(0, 499))
 			.saturating_add(T::DbWeight::get().reads(1))
 	}
 	/// Storage: ParachainInfo ParachainId (r:1 w:0)
@@ -85,8 +85,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `499`
 		// Minimum execution time: 17_723 nanoseconds.
-		Weight::from_ref_time(17_951_000)
-			.saturating_add(Weight::from_proof_size(499))
+		Weight::from_parts(17_951_000, 0)
+			.saturating_add(Weight::from_parts(0, 499))
 			.saturating_add(T::DbWeight::get().reads(1))
 	}
 	/// Storage: Benchmark Override (r:0 w:0)
@@ -96,8 +96,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 18_446_744_073_709_551 nanoseconds.
-		Weight::from_ref_time(18_446_744_073_709_551_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(18_446_744_073_709_551_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 	}
 	/// Storage: PolkadotXcm SupportedVersion (r:0 w:1)
 	/// Proof Skipped: PolkadotXcm SupportedVersion (max_values: None, max_size: None, mode: Measured)
@@ -106,8 +106,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 8_641 nanoseconds.
-		Weight::from_ref_time(8_925_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(8_925_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
 	/// Storage: PolkadotXcm SafeXcmVersion (r:0 w:1)
@@ -117,8 +117,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 2_427 nanoseconds.
-		Weight::from_ref_time(2_598_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(2_598_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
 	/// Storage: PolkadotXcm VersionNotifiers (r:1 w:1)
@@ -142,8 +142,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `38`
 		//  Estimated: `7729`
 		// Minimum execution time: 28_650 nanoseconds.
-		Weight::from_ref_time(29_035_000)
-			.saturating_add(Weight::from_proof_size(7729))
+		Weight::from_parts(29_035_000, 0)
+			.saturating_add(Weight::from_parts(0, 7729))
 			.saturating_add(T::DbWeight::get().reads(7))
 			.saturating_add(T::DbWeight::get().writes(5))
 	}
@@ -166,8 +166,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `220`
 		//  Estimated: `8470`
 		// Minimum execution time: 30_797 nanoseconds.
-		Weight::from_ref_time(31_491_000)
-			.saturating_add(Weight::from_proof_size(8470))
+		Weight::from_parts(31_491_000, 0)
+			.saturating_add(Weight::from_parts(0, 8470))
 			.saturating_add(T::DbWeight::get().reads(6))
 			.saturating_add(T::DbWeight::get().writes(4))
 	}
@@ -178,8 +178,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `95`
 		//  Estimated: `9995`
 		// Minimum execution time: 13_639 nanoseconds.
-		Weight::from_ref_time(13_980_000)
-			.saturating_add(Weight::from_proof_size(9995))
+		Weight::from_parts(13_980_000, 0)
+			.saturating_add(Weight::from_parts(0, 9995))
 			.saturating_add(T::DbWeight::get().reads(4))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -190,8 +190,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `99`
 		//  Estimated: `9999`
 		// Minimum execution time: 13_954 nanoseconds.
-		Weight::from_ref_time(14_276_000)
-			.saturating_add(Weight::from_proof_size(9999))
+		Weight::from_parts(14_276_000, 0)
+			.saturating_add(Weight::from_parts(0, 9999))
 			.saturating_add(T::DbWeight::get().reads(4))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -202,8 +202,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `106`
 		//  Estimated: `12481`
 		// Minimum execution time: 15_217 nanoseconds.
-		Weight::from_ref_time(15_422_000)
-			.saturating_add(Weight::from_proof_size(12481))
+		Weight::from_parts(15_422_000, 0)
+			.saturating_add(Weight::from_parts(0, 12481))
 			.saturating_add(T::DbWeight::get().reads(5))
 	}
 	/// Storage: PolkadotXcm VersionNotifyTargets (r:2 w:1)
@@ -223,8 +223,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `106`
 		//  Estimated: `10041`
 		// Minimum execution time: 27_362 nanoseconds.
-		Weight::from_ref_time(28_034_000)
-			.saturating_add(Weight::from_proof_size(10041))
+		Weight::from_parts(28_034_000, 0)
+			.saturating_add(Weight::from_parts(0, 10041))
 			.saturating_add(T::DbWeight::get().reads(7))
 			.saturating_add(T::DbWeight::get().writes(3))
 	}
@@ -235,8 +235,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `136`
 		//  Estimated: `7561`
 		// Minimum execution time: 7_768 nanoseconds.
-		Weight::from_ref_time(7_890_000)
-			.saturating_add(Weight::from_proof_size(7561))
+		Weight::from_parts(7_890_000, 0)
+			.saturating_add(Weight::from_parts(0, 7561))
 			.saturating_add(T::DbWeight::get().reads(3))
 	}
 	/// Storage: PolkadotXcm VersionNotifyTargets (r:4 w:2)
@@ -246,8 +246,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `106`
 		//  Estimated: `10006`
 		// Minimum execution time: 15_165 nanoseconds.
-		Weight::from_ref_time(15_430_000)
-			.saturating_add(Weight::from_proof_size(10006))
+		Weight::from_parts(15_430_000, 0)
+			.saturating_add(Weight::from_parts(0, 10006))
 			.saturating_add(T::DbWeight::get().reads(4))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -268,8 +268,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `112`
 		//  Estimated: `15027`
 		// Minimum execution time: 35_310 nanoseconds.
-		Weight::from_ref_time(35_698_000)
-			.saturating_add(Weight::from_proof_size(15027))
+		Weight::from_parts(35_698_000, 0)
+			.saturating_add(Weight::from_parts(0, 15027))
 			.saturating_add(T::DbWeight::get().reads(9))
 			.saturating_add(T::DbWeight::get().writes(4))
 	}

--- a/parachains/runtimes/assets/statemint/src/weights/xcm/mod.rs
+++ b/parachains/runtimes/assets/statemint/src/weights/xcm/mod.rs
@@ -65,7 +65,7 @@ impl<Call> XcmWeightInfo<Call> for StatemintXcmWeight<Call> {
 	// Currently there is no trusted reserve
 	fn reserve_asset_deposited(_assets: &MultiAssets) -> Weight {
 		// TODO: hardcoded - fix https://github.com/paritytech/cumulus/issues/1974
-		Weight::from_ref_time(1_000_000_000 as u64)
+		Weight::from_parts(1_000_000_000 as u64, 0)
 	}
 	fn receive_teleported_asset(assets: &MultiAssets) -> Weight {
 		assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::receive_teleported_asset())
@@ -123,7 +123,7 @@ impl<Call> XcmWeightInfo<Call> for StatemintXcmWeight<Call> {
 
 	fn deposit_asset(assets: &MultiAssetFilter, _dest: &MultiLocation) -> Weight {
 		// Hardcoded till the XCM pallet is fixed
-		let hardcoded_weight = Weight::from_ref_time(1_000_000_000 as u64);
+		let hardcoded_weight = Weight::from_parts(1_000_000_000 as u64, 0);
 		let weight = assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::deposit_asset());
 		hardcoded_weight.min(weight)
 	}

--- a/parachains/runtimes/assets/statemint/src/weights/xcm/pallet_xcm_benchmarks_fungible.rs
+++ b/parachains/runtimes/assets/statemint/src/weights/xcm/pallet_xcm_benchmarks_fungible.rs
@@ -51,14 +51,14 @@ impl<T: frame_system::Config> WeightInfo<T> {
 	// Storage: System Account (r:1 w:1)
 	// Proof: System Account (max_values: None, max_size: Some(128), added: 2603, mode: MaxEncodedLen)
 	pub(crate) fn withdraw_asset() -> Weight {
-		Weight::from_ref_time(21_004_000 as u64)
+		Weight::from_parts(21_004_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: System Account (r:2 w:2)
 	// Proof: System Account (max_values: None, max_size: Some(128), added: 2603, mode: MaxEncodedLen)
 	pub(crate) fn transfer_asset() -> Weight {
-		Weight::from_ref_time(29_344_000 as u64)
+		Weight::from_parts(29_344_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
@@ -77,17 +77,17 @@ impl<T: frame_system::Config> WeightInfo<T> {
 	// Storage: ParachainSystem PendingUpwardMessages (r:1 w:1)
 	// Proof Skipped: ParachainSystem PendingUpwardMessages (max_values: Some(1), max_size: None, mode: Measured)
 	pub(crate) fn transfer_reserve_asset() -> Weight {
-		Weight::from_ref_time(49_988_000 as u64)
+		Weight::from_parts(49_988_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(8 as u64))
 			.saturating_add(T::DbWeight::get().writes(4 as u64))
 	}
 	pub(crate) fn receive_teleported_asset() -> Weight {
-		Weight::from_ref_time(4_040_000 as u64)
+		Weight::from_parts(4_040_000 as u64, 0)
 	}
 	// Storage: System Account (r:1 w:1)
 	// Proof: System Account (max_values: None, max_size: Some(128), added: 2603, mode: MaxEncodedLen)
 	pub(crate) fn deposit_asset() -> Weight {
-		Weight::from_ref_time(22_762_000 as u64)
+		Weight::from_parts(22_762_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
@@ -106,7 +106,7 @@ impl<T: frame_system::Config> WeightInfo<T> {
 	// Storage: ParachainSystem PendingUpwardMessages (r:1 w:1)
 	// Proof Skipped: ParachainSystem PendingUpwardMessages (max_values: Some(1), max_size: None, mode: Measured)
 	pub(crate) fn deposit_reserve_asset() -> Weight {
-		Weight::from_ref_time(44_404_000 as u64)
+		Weight::from_parts(44_404_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(7 as u64))
 			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
@@ -123,7 +123,7 @@ impl<T: frame_system::Config> WeightInfo<T> {
 	// Storage: ParachainSystem PendingUpwardMessages (r:1 w:1)
 	// Proof Skipped: ParachainSystem PendingUpwardMessages (max_values: Some(1), max_size: None, mode: Measured)
 	pub(crate) fn initiate_teleport() -> Weight {
-		Weight::from_ref_time(28_179_000 as u64)
+		Weight::from_parts(28_179_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(6 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}

--- a/parachains/runtimes/assets/statemint/src/weights/xcm/pallet_xcm_benchmarks_generic.rs
+++ b/parachains/runtimes/assets/statemint/src/weights/xcm/pallet_xcm_benchmarks_generic.rs
@@ -61,39 +61,39 @@ impl<T: frame_system::Config> WeightInfo<T> {
 	// Storage: ParachainSystem PendingUpwardMessages (r:1 w:1)
 	// Proof Skipped: ParachainSystem PendingUpwardMessages (max_values: Some(1), max_size: None, mode: Measured)
 	pub(crate) fn report_holding() -> Weight {
-		Weight::from_ref_time(352_828_000 as u64)
+		Weight::from_parts(352_828_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(6 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	pub(crate) fn buy_execution() -> Weight {
-		Weight::from_ref_time(3_719_000 as u64)
+		Weight::from_parts(3_719_000 as u64, 0)
 	}
 	// Storage: PolkadotXcm Queries (r:1 w:0)
 	// Proof Skipped: PolkadotXcm Queries (max_values: None, max_size: None, mode: Measured)
 	pub(crate) fn query_response() -> Weight {
-		Weight::from_ref_time(10_697_000 as u64)
+		Weight::from_parts(10_697_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 	}
 	pub(crate) fn transact() -> Weight {
-		Weight::from_ref_time(12_215_000 as u64)
+		Weight::from_parts(12_215_000 as u64, 0)
 	}
 	pub(crate) fn refund_surplus() -> Weight {
-		Weight::from_ref_time(3_925_000 as u64)
+		Weight::from_parts(3_925_000 as u64, 0)
 	}
 	pub(crate) fn set_error_handler() -> Weight {
-		Weight::from_ref_time(2_782_000 as u64)
+		Weight::from_parts(2_782_000 as u64, 0)
 	}
 	pub(crate) fn set_appendix() -> Weight {
-		Weight::from_ref_time(2_765_000 as u64)
+		Weight::from_parts(2_765_000 as u64, 0)
 	}
 	pub(crate) fn clear_error() -> Weight {
-		Weight::from_ref_time(2_766_000 as u64)
+		Weight::from_parts(2_766_000 as u64, 0)
 	}
 	pub(crate) fn descend_origin() -> Weight {
-		Weight::from_ref_time(3_553_000 as u64)
+		Weight::from_parts(3_553_000 as u64, 0)
 	}
 	pub(crate) fn clear_origin() -> Weight {
-		Weight::from_ref_time(2_732_000 as u64)
+		Weight::from_parts(2_732_000 as u64, 0)
 	}
 	// Storage: ParachainInfo ParachainId (r:1 w:0)
 	// Proof: ParachainInfo ParachainId (max_values: Some(1), max_size: Some(4), added: 499, mode: MaxEncodedLen)
@@ -108,19 +108,19 @@ impl<T: frame_system::Config> WeightInfo<T> {
 	// Storage: ParachainSystem PendingUpwardMessages (r:1 w:1)
 	// Proof Skipped: ParachainSystem PendingUpwardMessages (max_values: Some(1), max_size: None, mode: Measured)
 	pub(crate) fn report_error() -> Weight {
-		Weight::from_ref_time(23_189_000 as u64)
+		Weight::from_parts(23_189_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(6 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: PolkadotXcm AssetTraps (r:1 w:1)
 	// Proof Skipped: PolkadotXcm AssetTraps (max_values: None, max_size: None, mode: Measured)
 	pub(crate) fn claim_asset() -> Weight {
-		Weight::from_ref_time(14_569_000 as u64)
+		Weight::from_parts(14_569_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	pub(crate) fn trap() -> Weight {
-		Weight::from_ref_time(2_759_000 as u64)
+		Weight::from_parts(2_759_000 as u64, 0)
 	}
 	// Storage: PolkadotXcm VersionNotifyTargets (r:1 w:1)
 	// Proof Skipped: PolkadotXcm VersionNotifyTargets (max_values: None, max_size: None, mode: Measured)
@@ -135,14 +135,14 @@ impl<T: frame_system::Config> WeightInfo<T> {
 	// Storage: ParachainSystem PendingUpwardMessages (r:1 w:1)
 	// Proof Skipped: ParachainSystem PendingUpwardMessages (max_values: Some(1), max_size: None, mode: Measured)
 	pub(crate) fn subscribe_version() -> Weight {
-		Weight::from_ref_time(24_423_000 as u64)
+		Weight::from_parts(24_423_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(6 as u64))
 			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: PolkadotXcm VersionNotifyTargets (r:0 w:1)
 	// Proof Skipped: PolkadotXcm VersionNotifyTargets (max_values: None, max_size: None, mode: Measured)
 	pub(crate) fn unsubscribe_version() -> Weight {
-		Weight::from_ref_time(4_575_000 as u64)
+		Weight::from_parts(4_575_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: ParachainInfo ParachainId (r:1 w:0)
@@ -158,24 +158,24 @@ impl<T: frame_system::Config> WeightInfo<T> {
 	// Storage: ParachainSystem PendingUpwardMessages (r:1 w:1)
 	// Proof Skipped: ParachainSystem PendingUpwardMessages (max_values: Some(1), max_size: None, mode: Measured)
 	pub(crate) fn initiate_reserve_withdraw() -> Weight {
-		Weight::from_ref_time(406_184_000 as u64)
+		Weight::from_parts(406_184_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(6 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	pub(crate) fn burn_asset() -> Weight {
-		Weight::from_ref_time(125_739_000 as u64)
+		Weight::from_parts(125_739_000 as u64, 0)
 	}
 	pub(crate) fn expect_asset() -> Weight {
-		Weight::from_ref_time(13_105_000 as u64)
+		Weight::from_parts(13_105_000 as u64, 0)
 	}
 	pub(crate) fn expect_origin() -> Weight {
-		Weight::from_ref_time(2_823_000 as u64)
+		Weight::from_parts(2_823_000 as u64, 0)
 	}
 	pub(crate) fn expect_error() -> Weight {
-		Weight::from_ref_time(2_771_000 as u64)
+		Weight::from_parts(2_771_000 as u64, 0)
 	}
 	pub(crate) fn expect_transact_status() -> Weight {
-		Weight::from_ref_time(2_883_000 as u64)
+		Weight::from_parts(2_883_000 as u64, 0)
 	}
 	// Storage: ParachainInfo ParachainId (r:1 w:0)
 	// Proof: ParachainInfo ParachainId (max_values: Some(1), max_size: Some(4), added: 499, mode: MaxEncodedLen)
@@ -190,12 +190,12 @@ impl<T: frame_system::Config> WeightInfo<T> {
 	// Storage: ParachainSystem PendingUpwardMessages (r:1 w:1)
 	// Proof Skipped: ParachainSystem PendingUpwardMessages (max_values: Some(1), max_size: None, mode: Measured)
 	pub(crate) fn query_pallet() -> Weight {
-		Weight::from_ref_time(25_695_000 as u64)
+		Weight::from_parts(25_695_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(6 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	pub(crate) fn expect_pallet() -> Weight {
-		Weight::from_ref_time(4_650_000 as u64)
+		Weight::from_parts(4_650_000 as u64, 0)
 	}
 	// Storage: ParachainInfo ParachainId (r:1 w:0)
 	// Proof: ParachainInfo ParachainId (max_values: Some(1), max_size: Some(4), added: 499, mode: MaxEncodedLen)
@@ -210,23 +210,23 @@ impl<T: frame_system::Config> WeightInfo<T> {
 	// Storage: ParachainSystem PendingUpwardMessages (r:1 w:1)
 	// Proof Skipped: ParachainSystem PendingUpwardMessages (max_values: Some(1), max_size: None, mode: Measured)
 	pub(crate) fn report_transact_status() -> Weight {
-		Weight::from_ref_time(23_415_000 as u64)
+		Weight::from_parts(23_415_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(6 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	pub(crate) fn clear_transact_status() -> Weight {
-		Weight::from_ref_time(2_756_000 as u64)
+		Weight::from_parts(2_756_000 as u64, 0)
 	}
 	pub(crate) fn set_topic() -> Weight {
-		Weight::from_ref_time(2_702_000 as u64)
+		Weight::from_parts(2_702_000 as u64, 0)
 	}
 	pub(crate) fn clear_topic() -> Weight {
-		Weight::from_ref_time(2_738_000 as u64)
+		Weight::from_parts(2_738_000 as u64, 0)
 	}
 	pub(crate) fn set_fees_mode() -> Weight {
-		Weight::from_ref_time(2_700_000 as u64)
+		Weight::from_parts(2_700_000 as u64, 0)
 	}
 	pub(crate) fn unpaid_execution() -> Weight {
-		Weight::from_ref_time(2_894_000 as u64)
+		Weight::from_parts(2_894_000 as u64, 0)
 	}
 }

--- a/parachains/runtimes/assets/statemint/tests/tests.rs
+++ b/parachains/runtimes/assets/statemint/tests/tests.rs
@@ -66,7 +66,7 @@ fn test_asset_xcm_trader() {
 			// Because of the ED being higher in statemine
 			// and not to complicate things, we use a little
 			// bit more of weight
-			let bought = Weight::from_ref_time(400_000_000_000u64);
+			let bought = Weight::from_parts(400_000_000_000u64, 0);
 
 			// Lets calculate amount needed
 			let asset_amount_needed =
@@ -145,7 +145,7 @@ fn test_asset_xcm_trader_with_refund() {
 			// Because of the ED being higher in statemine
 			// and not to complicate things, we use a little
 			// bit more of weight
-			let bought = Weight::from_ref_time(400_000_000_000u64);
+			let bought = Weight::from_parts(400_000_000_000u64, 0);
 
 			let asset_multilocation = MultiLocation::new(
 				0,
@@ -226,7 +226,7 @@ fn test_asset_xcm_trader_refund_not_possible_since_amount_less_than_ed() {
 			// Because of the ED being higher in statemine
 			// and not to complicate things, we use a little
 			// bit more of weight
-			let bought = Weight::from_ref_time(50_000_000_000u64);
+			let bought = Weight::from_parts(50_000_000_000u64, 0);
 
 			let asset_multilocation = MultiLocation::new(
 				0,
@@ -286,7 +286,7 @@ fn test_that_buying_ed_refund_does_not_refund() {
 			RuntimeHelper::<Runtime>::run_to_block(2, Some(AccountId::from(ALICE)));
 
 			// We are gonna buy ED
-			let bought = Weight::from_ref_time(ExistentialDeposit::get().try_into().unwrap());
+			let bought = Weight::from_parts(ExistentialDeposit::get().try_into().unwrap(), 0);
 
 			let asset_multilocation = MultiLocation::new(
 				0,
@@ -370,7 +370,7 @@ fn test_asset_xcm_trader_not_possible_for_non_sufficient_assets() {
 			// Because of the ED being higher in statemine
 			// and not to complicate things, we use a little
 			// bit more of weight
-			let bought = Weight::from_ref_time(400_000_000_000u64);
+			let bought = Weight::from_parts(400_000_000_000u64, 0);
 
 			// lets calculate amount needed
 			let asset_amount_needed = WeightToFee::weight_to_fee(&bought);

--- a/parachains/runtimes/assets/westmint/src/weights/block_weights.rs
+++ b/parachains/runtimes/assets/westmint/src/weights/block_weights.rs
@@ -24,7 +24,7 @@ pub mod constants {
 	parameter_types! {
 		/// Importing a block with 0 Extrinsics.
 		pub const BlockExecutionWeight: Weight =
-			Weight::from_ref_time(constants::WEIGHT_REF_TIME_PER_NANOS.saturating_mul(5_000_000));
+			Weight::from_parts(constants::WEIGHT_REF_TIME_PER_NANOS.saturating_mul(5_000_000), 0);
 	}
 
 	#[cfg(test)]

--- a/parachains/runtimes/assets/westmint/src/weights/cumulus_pallet_xcmp_queue.rs
+++ b/parachains/runtimes/assets/westmint/src/weights/cumulus_pallet_xcmp_queue.rs
@@ -54,8 +54,8 @@ impl<T: frame_system::Config> cumulus_pallet_xcmp_queue::WeightInfo for WeightIn
 		//  Measured:  `76`
 		//  Estimated: `571`
 		// Minimum execution time: 4_844 nanoseconds.
-		Weight::from_ref_time(5_119_000)
-			.saturating_add(Weight::from_proof_size(571))
+		Weight::from_parts(5_119_000, 0)
+			.saturating_add(Weight::from_parts(0, 571))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -66,8 +66,8 @@ impl<T: frame_system::Config> cumulus_pallet_xcmp_queue::WeightInfo for WeightIn
 		//  Measured:  `76`
 		//  Estimated: `571`
 		// Minimum execution time: 5_017 nanoseconds.
-		Weight::from_ref_time(5_231_000)
-			.saturating_add(Weight::from_proof_size(571))
+		Weight::from_parts(5_231_000, 0)
+			.saturating_add(Weight::from_parts(0, 571))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}

--- a/parachains/runtimes/assets/westmint/src/weights/extrinsic_weights.rs
+++ b/parachains/runtimes/assets/westmint/src/weights/extrinsic_weights.rs
@@ -24,7 +24,7 @@ pub mod constants {
 	parameter_types! {
 		/// Executing a NO-OP `System::remarks` Extrinsic.
 		pub const ExtrinsicBaseWeight: Weight =
-			Weight::from_ref_time(constants::WEIGHT_REF_TIME_PER_NANOS.saturating_mul(125_000));
+			Weight::from_parts(constants::WEIGHT_REF_TIME_PER_NANOS.saturating_mul(125_000), 0);
 	}
 
 	#[cfg(test)]

--- a/parachains/runtimes/assets/westmint/src/weights/frame_system.rs
+++ b/parachains/runtimes/assets/westmint/src/weights/frame_system.rs
@@ -53,10 +53,10 @@ impl<T: frame_system::Config> frame_system::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 1_737 nanoseconds.
-		Weight::from_ref_time(1_780_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(1_780_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			// Standard Error: 0
-			.saturating_add(Weight::from_ref_time(368).saturating_mul(b.into()))
+			.saturating_add(Weight::from_parts(368, 0).saturating_mul(b.into()))
 	}
 	/// The range of component `b` is `[0, 3932160]`.
 	fn remark_with_event(b: u32, ) -> Weight {
@@ -64,10 +64,10 @@ impl<T: frame_system::Config> frame_system::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 6_941 nanoseconds.
-		Weight::from_ref_time(6_990_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(6_990_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			// Standard Error: 0
-			.saturating_add(Weight::from_ref_time(1_716).saturating_mul(b.into()))
+			.saturating_add(Weight::from_parts(1_716, 0).saturating_mul(b.into()))
 	}
 	/// Storage: System Digest (r:1 w:1)
 	/// Proof Skipped: System Digest (max_values: Some(1), max_size: None, mode: Measured)
@@ -78,8 +78,8 @@ impl<T: frame_system::Config> frame_system::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `495`
 		// Minimum execution time: 3_697 nanoseconds.
-		Weight::from_ref_time(3_855_000)
-			.saturating_add(Weight::from_proof_size(495))
+		Weight::from_parts(3_855_000, 0)
+			.saturating_add(Weight::from_parts(0, 495))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -91,10 +91,10 @@ impl<T: frame_system::Config> frame_system::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 1_957 nanoseconds.
-		Weight::from_ref_time(2_009_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(2_009_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			// Standard Error: 1_909
-			.saturating_add(Weight::from_ref_time(577_980).saturating_mul(i.into()))
+			.saturating_add(Weight::from_parts(577_980, 0).saturating_mul(i.into()))
 			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(i.into())))
 	}
 	/// Storage: Skipped Metadata (r:0 w:0)
@@ -105,10 +105,10 @@ impl<T: frame_system::Config> frame_system::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 1_921 nanoseconds.
-		Weight::from_ref_time(1_983_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(1_983_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			// Standard Error: 841
-			.saturating_add(Weight::from_ref_time(443_784).saturating_mul(i.into()))
+			.saturating_add(Weight::from_parts(443_784, 0).saturating_mul(i.into()))
 			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(i.into())))
 	}
 	/// Storage: Skipped Metadata (r:0 w:0)
@@ -119,11 +119,11 @@ impl<T: frame_system::Config> frame_system::WeightInfo for WeightInfo<T> {
 		//  Measured:  `84 + p * (69 ±0)`
 		//  Estimated: `75 + p * (70 ±0)`
 		// Minimum execution time: 3_576 nanoseconds.
-		Weight::from_ref_time(3_661_000)
-			.saturating_add(Weight::from_proof_size(75))
+		Weight::from_parts(3_661_000, 0)
+			.saturating_add(Weight::from_parts(0, 75))
 			// Standard Error: 919
-			.saturating_add(Weight::from_ref_time(955_752).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(955_752, 0).saturating_mul(p.into()))
 			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(p.into())))
-			.saturating_add(Weight::from_proof_size(70).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(0, 70).saturating_mul(p.into()))
 	}
 }

--- a/parachains/runtimes/assets/westmint/src/weights/pallet_assets.rs
+++ b/parachains/runtimes/assets/westmint/src/weights/pallet_assets.rs
@@ -56,8 +56,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `141`
 		//  Estimated: `5288`
 		// Minimum execution time: 22_825 nanoseconds.
-		Weight::from_ref_time(26_008_000)
-			.saturating_add(Weight::from_proof_size(5288))
+		Weight::from_parts(26_008_000, 0)
+			.saturating_add(Weight::from_parts(0, 5288))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -68,8 +68,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `6`
 		//  Estimated: `2685`
 		// Minimum execution time: 10_898 nanoseconds.
-		Weight::from_ref_time(12_626_000)
-			.saturating_add(Weight::from_proof_size(2685))
+		Weight::from_parts(12_626_000, 0)
+			.saturating_add(Weight::from_parts(0, 2685))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -80,8 +80,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `309`
 		//  Estimated: `2685`
 		// Minimum execution time: 13_057 nanoseconds.
-		Weight::from_ref_time(13_932_000)
-			.saturating_add(Weight::from_proof_size(2685))
+		Weight::from_parts(13_932_000, 0)
+			.saturating_add(Weight::from_parts(0, 2685))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -97,15 +97,15 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0 + c * (240 ±0)`
 		//  Estimated: `5262 + c * (5180 ±0)`
 		// Minimum execution time: 16_823 nanoseconds.
-		Weight::from_ref_time(31_002_000)
-			.saturating_add(Weight::from_proof_size(5262))
+		Weight::from_parts(31_002_000, 0)
+			.saturating_add(Weight::from_parts(0, 5262))
 			// Standard Error: 10_169
-			.saturating_add(Weight::from_ref_time(13_922_578).saturating_mul(c.into()))
+			.saturating_add(Weight::from_parts(13_922_578, 0).saturating_mul(c.into()))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().reads((2_u64).saturating_mul(c.into())))
 			.saturating_add(T::DbWeight::get().writes(1))
 			.saturating_add(T::DbWeight::get().writes((2_u64).saturating_mul(c.into())))
-			.saturating_add(Weight::from_proof_size(5180).saturating_mul(c.into()))
+			.saturating_add(Weight::from_parts(0, 5180).saturating_mul(c.into()))
 	}
 	/// Storage: Assets Asset (r:1 w:1)
 	/// Proof: Assets Asset (max_values: None, max_size: Some(210), added: 2685, mode: MaxEncodedLen)
@@ -117,15 +117,15 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `446 + a * (86 ±0)`
 		//  Estimated: `5308 + a * (2623 ±0)`
 		// Minimum execution time: 16_683 nanoseconds.
-		Weight::from_ref_time(16_754_000)
-			.saturating_add(Weight::from_proof_size(5308))
+		Weight::from_parts(16_754_000, 0)
+			.saturating_add(Weight::from_parts(0, 5308))
 			// Standard Error: 7_193
-			.saturating_add(Weight::from_ref_time(13_722_963).saturating_mul(a.into()))
+			.saturating_add(Weight::from_parts(13_722_963, 0).saturating_mul(a.into()))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().reads((1_u64).saturating_mul(a.into())))
 			.saturating_add(T::DbWeight::get().writes(1))
 			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(a.into())))
-			.saturating_add(Weight::from_proof_size(2623).saturating_mul(a.into()))
+			.saturating_add(Weight::from_parts(0, 2623).saturating_mul(a.into()))
 	}
 	/// Storage: Assets Asset (r:1 w:1)
 	/// Proof: Assets Asset (max_values: None, max_size: Some(210), added: 2685, mode: MaxEncodedLen)
@@ -136,8 +136,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `275`
 		//  Estimated: `5300`
 		// Minimum execution time: 12_892 nanoseconds.
-		Weight::from_ref_time(13_218_000)
-			.saturating_add(Weight::from_proof_size(5300))
+		Weight::from_parts(13_218_000, 0)
+			.saturating_add(Weight::from_parts(0, 5300))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -150,8 +150,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `275`
 		//  Estimated: `5262`
 		// Minimum execution time: 23_073 nanoseconds.
-		Weight::from_ref_time(23_435_000)
-			.saturating_add(Weight::from_proof_size(5262))
+		Weight::from_parts(23_435_000, 0)
+			.saturating_add(Weight::from_parts(0, 5262))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -164,8 +164,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `383`
 		//  Estimated: `5262`
 		// Minimum execution time: 29_411 nanoseconds.
-		Weight::from_ref_time(30_019_000)
-			.saturating_add(Weight::from_proof_size(5262))
+		Weight::from_parts(30_019_000, 0)
+			.saturating_add(Weight::from_parts(0, 5262))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -180,8 +180,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `383`
 		//  Estimated: `10442`
 		// Minimum execution time: 38_929 nanoseconds.
-		Weight::from_ref_time(39_602_000)
-			.saturating_add(Weight::from_proof_size(10442))
+		Weight::from_parts(39_602_000, 0)
+			.saturating_add(Weight::from_parts(0, 10442))
 			.saturating_add(T::DbWeight::get().reads(4))
 			.saturating_add(T::DbWeight::get().writes(4))
 	}
@@ -196,8 +196,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `383`
 		//  Estimated: `10442`
 		// Minimum execution time: 34_910 nanoseconds.
-		Weight::from_ref_time(35_686_000)
-			.saturating_add(Weight::from_proof_size(10442))
+		Weight::from_parts(35_686_000, 0)
+			.saturating_add(Weight::from_parts(0, 10442))
 			.saturating_add(T::DbWeight::get().reads(4))
 			.saturating_add(T::DbWeight::get().writes(4))
 	}
@@ -212,8 +212,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `383`
 		//  Estimated: `10442`
 		// Minimum execution time: 38_959 nanoseconds.
-		Weight::from_ref_time(39_627_000)
-			.saturating_add(Weight::from_proof_size(10442))
+		Weight::from_parts(39_627_000, 0)
+			.saturating_add(Weight::from_parts(0, 10442))
 			.saturating_add(T::DbWeight::get().reads(4))
 			.saturating_add(T::DbWeight::get().writes(4))
 	}
@@ -226,8 +226,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `383`
 		//  Estimated: `5262`
 		// Minimum execution time: 16_367 nanoseconds.
-		Weight::from_ref_time(16_761_000)
-			.saturating_add(Weight::from_proof_size(5262))
+		Weight::from_parts(16_761_000, 0)
+			.saturating_add(Weight::from_parts(0, 5262))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -240,8 +240,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `383`
 		//  Estimated: `5262`
 		// Minimum execution time: 16_361 nanoseconds.
-		Weight::from_ref_time(18_506_000)
-			.saturating_add(Weight::from_proof_size(5262))
+		Weight::from_parts(18_506_000, 0)
+			.saturating_add(Weight::from_parts(0, 5262))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -252,8 +252,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `309`
 		//  Estimated: `2685`
 		// Minimum execution time: 12_980 nanoseconds.
-		Weight::from_ref_time(14_272_000)
-			.saturating_add(Weight::from_proof_size(2685))
+		Weight::from_parts(14_272_000, 0)
+			.saturating_add(Weight::from_parts(0, 2685))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -264,8 +264,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `309`
 		//  Estimated: `2685`
 		// Minimum execution time: 12_510 nanoseconds.
-		Weight::from_ref_time(12_996_000)
-			.saturating_add(Weight::from_proof_size(2685))
+		Weight::from_parts(12_996_000, 0)
+			.saturating_add(Weight::from_parts(0, 2685))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -278,8 +278,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `275`
 		//  Estimated: `5300`
 		// Minimum execution time: 13_958 nanoseconds.
-		Weight::from_ref_time(14_458_000)
-			.saturating_add(Weight::from_proof_size(5300))
+		Weight::from_parts(14_458_000, 0)
+			.saturating_add(Weight::from_parts(0, 5300))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -290,8 +290,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `275`
 		//  Estimated: `2685`
 		// Minimum execution time: 12_820 nanoseconds.
-		Weight::from_ref_time(13_136_000)
-			.saturating_add(Weight::from_proof_size(2685))
+		Weight::from_parts(13_136_000, 0)
+			.saturating_add(Weight::from_parts(0, 2685))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -306,10 +306,10 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `275`
 		//  Estimated: `5300`
 		// Minimum execution time: 22_433 nanoseconds.
-		Weight::from_ref_time(23_664_666)
-			.saturating_add(Weight::from_proof_size(5300))
+		Weight::from_parts(23_664_666, 0)
+			.saturating_add(Weight::from_parts(0, 5300))
 			// Standard Error: 648
-			.saturating_add(Weight::from_ref_time(2_428).saturating_mul(s.into()))
+			.saturating_add(Weight::from_parts(2_428, 0).saturating_mul(s.into()))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -322,8 +322,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `471`
 		//  Estimated: `5300`
 		// Minimum execution time: 22_969 nanoseconds.
-		Weight::from_ref_time(23_330_000)
-			.saturating_add(Weight::from_proof_size(5300))
+		Weight::from_parts(23_330_000, 0)
+			.saturating_add(Weight::from_parts(0, 5300))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -338,10 +338,10 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `82`
 		//  Estimated: `5300`
 		// Minimum execution time: 11_969 nanoseconds.
-		Weight::from_ref_time(12_659_111)
-			.saturating_add(Weight::from_proof_size(5300))
+		Weight::from_parts(12_659_111, 0)
+			.saturating_add(Weight::from_parts(0, 5300))
 			// Standard Error: 345
-			.saturating_add(Weight::from_ref_time(1_879).saturating_mul(s.into()))
+			.saturating_add(Weight::from_parts(1_879, 0).saturating_mul(s.into()))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -354,8 +354,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `471`
 		//  Estimated: `5300`
 		// Minimum execution time: 23_002 nanoseconds.
-		Weight::from_ref_time(23_320_000)
-			.saturating_add(Weight::from_proof_size(5300))
+		Weight::from_parts(23_320_000, 0)
+			.saturating_add(Weight::from_parts(0, 5300))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -366,8 +366,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `275`
 		//  Estimated: `2685`
 		// Minimum execution time: 11_994 nanoseconds.
-		Weight::from_ref_time(12_256_000)
-			.saturating_add(Weight::from_proof_size(2685))
+		Weight::from_parts(12_256_000, 0)
+			.saturating_add(Weight::from_parts(0, 2685))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -380,8 +380,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `309`
 		//  Estimated: `5308`
 		// Minimum execution time: 26_321 nanoseconds.
-		Weight::from_ref_time(26_867_000)
-			.saturating_add(Weight::from_proof_size(5308))
+		Weight::from_parts(26_867_000, 0)
+			.saturating_add(Weight::from_parts(0, 5308))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -398,8 +398,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `553`
 		//  Estimated: `13065`
 		// Minimum execution time: 52_855 nanoseconds.
-		Weight::from_ref_time(54_006_000)
-			.saturating_add(Weight::from_proof_size(13065))
+		Weight::from_parts(54_006_000, 0)
+			.saturating_add(Weight::from_parts(0, 13065))
 			.saturating_add(T::DbWeight::get().reads(5))
 			.saturating_add(T::DbWeight::get().writes(5))
 	}
@@ -412,8 +412,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `479`
 		//  Estimated: `5308`
 		// Minimum execution time: 28_148 nanoseconds.
-		Weight::from_ref_time(28_416_000)
-			.saturating_add(Weight::from_proof_size(5308))
+		Weight::from_parts(28_416_000, 0)
+			.saturating_add(Weight::from_parts(0, 5308))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -426,8 +426,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `479`
 		//  Estimated: `5308`
 		// Minimum execution time: 28_456 nanoseconds.
-		Weight::from_ref_time(28_913_000)
-			.saturating_add(Weight::from_proof_size(5308))
+		Weight::from_parts(28_913_000, 0)
+			.saturating_add(Weight::from_parts(0, 5308))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}

--- a/parachains/runtimes/assets/westmint/src/weights/pallet_assets.rs
+++ b/parachains/runtimes/assets/westmint/src/weights/pallet_assets.rs
@@ -438,8 +438,8 @@ impl<T: frame_system::Config> pallet_assets::WeightInfo for WeightInfo<T> {
 		//  Measured:  `383`
 		//  Estimated: `3675`
 		// Minimum execution time: 16_213 nanoseconds.
-		Weight::from_ref_time(16_575_000)
-			.saturating_add(Weight::from_proof_size(3675))
+		Weight::from_parts(16_575_000, 0)
+			.saturating_add(Weight::from_parts(0, 3675))
 			.saturating_add(T::DbWeight::get().reads(1_u64))
 			.saturating_add(T::DbWeight::get().writes(1_u64))
 	}

--- a/parachains/runtimes/assets/westmint/src/weights/pallet_balances.rs
+++ b/parachains/runtimes/assets/westmint/src/weights/pallet_balances.rs
@@ -54,8 +54,8 @@ impl<T: frame_system::Config> pallet_balances::WeightInfo for WeightInfo<T> {
 		//  Measured:  `1177`
 		//  Estimated: `2603`
 		// Minimum execution time: 45_988 nanoseconds.
-		Weight::from_ref_time(46_507_000)
-			.saturating_add(Weight::from_proof_size(2603))
+		Weight::from_parts(46_507_000, 0)
+			.saturating_add(Weight::from_parts(0, 2603))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -66,8 +66,8 @@ impl<T: frame_system::Config> pallet_balances::WeightInfo for WeightInfo<T> {
 		//  Measured:  `1061`
 		//  Estimated: `2603`
 		// Minimum execution time: 34_574 nanoseconds.
-		Weight::from_ref_time(35_575_000)
-			.saturating_add(Weight::from_proof_size(2603))
+		Weight::from_parts(35_575_000, 0)
+			.saturating_add(Weight::from_parts(0, 2603))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -78,8 +78,8 @@ impl<T: frame_system::Config> pallet_balances::WeightInfo for WeightInfo<T> {
 		//  Measured:  `1173`
 		//  Estimated: `2603`
 		// Minimum execution time: 25_859 nanoseconds.
-		Weight::from_ref_time(26_467_000)
-			.saturating_add(Weight::from_proof_size(2603))
+		Weight::from_parts(26_467_000, 0)
+			.saturating_add(Weight::from_parts(0, 2603))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -90,8 +90,8 @@ impl<T: frame_system::Config> pallet_balances::WeightInfo for WeightInfo<T> {
 		//  Measured:  `1173`
 		//  Estimated: `2603`
 		// Minimum execution time: 28_563 nanoseconds.
-		Weight::from_ref_time(29_082_000)
-			.saturating_add(Weight::from_proof_size(2603))
+		Weight::from_parts(29_082_000, 0)
+			.saturating_add(Weight::from_parts(0, 2603))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -102,8 +102,8 @@ impl<T: frame_system::Config> pallet_balances::WeightInfo for WeightInfo<T> {
 		//  Measured:  `1173`
 		//  Estimated: `5206`
 		// Minimum execution time: 45_594 nanoseconds.
-		Weight::from_ref_time(46_296_000)
-			.saturating_add(Weight::from_proof_size(5206))
+		Weight::from_parts(46_296_000, 0)
+			.saturating_add(Weight::from_parts(0, 5206))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -114,8 +114,8 @@ impl<T: frame_system::Config> pallet_balances::WeightInfo for WeightInfo<T> {
 		//  Measured:  `1061`
 		//  Estimated: `2603`
 		// Minimum execution time: 40_085 nanoseconds.
-		Weight::from_ref_time(40_675_000)
-			.saturating_add(Weight::from_proof_size(2603))
+		Weight::from_parts(40_675_000, 0)
+			.saturating_add(Weight::from_parts(0, 2603))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -126,8 +126,8 @@ impl<T: frame_system::Config> pallet_balances::WeightInfo for WeightInfo<T> {
 		//  Measured:  `1057`
 		//  Estimated: `2603`
 		// Minimum execution time: 22_208 nanoseconds.
-		Weight::from_ref_time(22_815_000)
-			.saturating_add(Weight::from_proof_size(2603))
+		Weight::from_parts(22_815_000, 0)
+			.saturating_add(Weight::from_parts(0, 2603))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}

--- a/parachains/runtimes/assets/westmint/src/weights/pallet_collator_selection.rs
+++ b/parachains/runtimes/assets/westmint/src/weights/pallet_collator_selection.rs
@@ -57,13 +57,13 @@ impl<T: frame_system::Config> pallet_collator_selection::WeightInfo for WeightIn
 		//  Measured:  `178 + b * (78 ±0)`
 		//  Estimated: `178 + b * (2554 ±0)`
 		// Minimum execution time: 13_864 nanoseconds.
-		Weight::from_ref_time(14_046_919)
-			.saturating_add(Weight::from_proof_size(178))
+		Weight::from_parts(14_046_919, 0)
+			.saturating_add(Weight::from_parts(0, 178))
 			// Standard Error: 4_684
-			.saturating_add(Weight::from_ref_time(2_474_689).saturating_mul(b.into()))
+			.saturating_add(Weight::from_parts(2_474_689, 0).saturating_mul(b.into()))
 			.saturating_add(T::DbWeight::get().reads((1_u64).saturating_mul(b.into())))
 			.saturating_add(T::DbWeight::get().writes(1))
-			.saturating_add(Weight::from_proof_size(2554).saturating_mul(b.into()))
+			.saturating_add(Weight::from_parts(0, 2554).saturating_mul(b.into()))
 	}
 	/// Storage: CollatorSelection DesiredCandidates (r:0 w:1)
 	/// Proof: CollatorSelection DesiredCandidates (max_values: Some(1), max_size: Some(4), added: 499, mode: MaxEncodedLen)
@@ -72,8 +72,8 @@ impl<T: frame_system::Config> pallet_collator_selection::WeightInfo for WeightIn
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 6_556 nanoseconds.
-		Weight::from_ref_time(6_751_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(6_751_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
 	/// Storage: CollatorSelection CandidacyBond (r:0 w:1)
@@ -83,8 +83,8 @@ impl<T: frame_system::Config> pallet_collator_selection::WeightInfo for WeightIn
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 6_816 nanoseconds.
-		Weight::from_ref_time(7_009_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(7_009_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
 	/// Storage: CollatorSelection Candidates (r:1 w:1)
@@ -105,13 +105,13 @@ impl<T: frame_system::Config> pallet_collator_selection::WeightInfo for WeightIn
 		//  Measured:  `1171 + c * (48 ±0)`
 		//  Estimated: `56784 + c * (49 ±0)`
 		// Minimum execution time: 35_423 nanoseconds.
-		Weight::from_ref_time(27_578_125)
-			.saturating_add(Weight::from_proof_size(56784))
+		Weight::from_parts(27_578_125, 0)
+			.saturating_add(Weight::from_parts(0, 56784))
 			// Standard Error: 1_255
-			.saturating_add(Weight::from_ref_time(105_521).saturating_mul(c.into()))
+			.saturating_add(Weight::from_parts(105_521, 0).saturating_mul(c.into()))
 			.saturating_add(T::DbWeight::get().reads(5))
 			.saturating_add(T::DbWeight::get().writes(2))
-			.saturating_add(Weight::from_proof_size(49).saturating_mul(c.into()))
+			.saturating_add(Weight::from_parts(0, 49).saturating_mul(c.into()))
 	}
 	/// Storage: CollatorSelection Candidates (r:1 w:1)
 	/// Proof: CollatorSelection Candidates (max_values: Some(1), max_size: Some(48002), added: 48497, mode: MaxEncodedLen)
@@ -123,10 +123,10 @@ impl<T: frame_system::Config> pallet_collator_selection::WeightInfo for WeightIn
 		//  Measured:  `541 + c * (48 ±0)`
 		//  Estimated: `48497`
 		// Minimum execution time: 24_550 nanoseconds.
-		Weight::from_ref_time(15_908_548)
-			.saturating_add(Weight::from_proof_size(48497))
+		Weight::from_parts(15_908_548, 0)
+			.saturating_add(Weight::from_parts(0, 48497))
 			// Standard Error: 1_238
-			.saturating_add(Weight::from_ref_time(105_175).saturating_mul(c.into()))
+			.saturating_add(Weight::from_parts(105_175, 0).saturating_mul(c.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -141,8 +141,8 @@ impl<T: frame_system::Config> pallet_collator_selection::WeightInfo for WeightIn
 		//  Measured:  `135`
 		//  Estimated: `5749`
 		// Minimum execution time: 25_675 nanoseconds.
-		Weight::from_ref_time(26_392_000)
-			.saturating_add(Weight::from_proof_size(5749))
+		Weight::from_parts(26_392_000, 0)
+			.saturating_add(Weight::from_parts(0, 5749))
 			.saturating_add(T::DbWeight::get().reads(3))
 			.saturating_add(T::DbWeight::get().writes(4))
 	}
@@ -163,15 +163,15 @@ impl<T: frame_system::Config> pallet_collator_selection::WeightInfo for WeightIn
 		//  Measured:  `22756 + r * (148 ±0) + c * (97 ±0)`
 		//  Estimated: `52737 + c * (2519 ±0) + r * (2603 ±0)`
 		// Minimum execution time: 16_612 nanoseconds.
-		Weight::from_ref_time(16_892_000)
-			.saturating_add(Weight::from_proof_size(52737))
+		Weight::from_parts(16_892_000, 0)
+			.saturating_add(Weight::from_parts(0, 52737))
 			// Standard Error: 755_441
-			.saturating_add(Weight::from_ref_time(27_658_379).saturating_mul(c.into()))
+			.saturating_add(Weight::from_parts(27_658_379, 0).saturating_mul(c.into()))
 			.saturating_add(T::DbWeight::get().reads(4))
 			.saturating_add(T::DbWeight::get().reads((1_u64).saturating_mul(c.into())))
 			.saturating_add(T::DbWeight::get().writes(1))
 			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(c.into())))
-			.saturating_add(Weight::from_proof_size(2519).saturating_mul(c.into()))
-			.saturating_add(Weight::from_proof_size(2603).saturating_mul(r.into()))
+			.saturating_add(Weight::from_parts(0, 2519).saturating_mul(c.into()))
+			.saturating_add(Weight::from_parts(0, 2603).saturating_mul(r.into()))
 	}
 }

--- a/parachains/runtimes/assets/westmint/src/weights/pallet_multisig.rs
+++ b/parachains/runtimes/assets/westmint/src/weights/pallet_multisig.rs
@@ -53,10 +53,10 @@ impl<T: frame_system::Config> pallet_multisig::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 11_762 nanoseconds.
-		Weight::from_ref_time(12_267_870)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(12_267_870, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			// Standard Error: 1
-			.saturating_add(Weight::from_ref_time(493).saturating_mul(z.into()))
+			.saturating_add(Weight::from_parts(493, 0).saturating_mul(z.into()))
 	}
 	/// Storage: Multisig Multisigs (r:1 w:1)
 	/// Proof: Multisig Multisigs (max_values: None, max_size: Some(3346), added: 5821, mode: MaxEncodedLen)
@@ -67,12 +67,12 @@ impl<T: frame_system::Config> pallet_multisig::WeightInfo for WeightInfo<T> {
 		//  Measured:  `311 + s * (2 ±0)`
 		//  Estimated: `5821`
 		// Minimum execution time: 35_352 nanoseconds.
-		Weight::from_ref_time(28_499_037)
-			.saturating_add(Weight::from_proof_size(5821))
+		Weight::from_parts(28_499_037, 0)
+			.saturating_add(Weight::from_parts(0, 5821))
 			// Standard Error: 1_231
-			.saturating_add(Weight::from_ref_time(73_158).saturating_mul(s.into()))
+			.saturating_add(Weight::from_parts(73_158, 0).saturating_mul(s.into()))
 			// Standard Error: 12
-			.saturating_add(Weight::from_ref_time(1_528).saturating_mul(z.into()))
+			.saturating_add(Weight::from_parts(1_528, 0).saturating_mul(z.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -85,12 +85,12 @@ impl<T: frame_system::Config> pallet_multisig::WeightInfo for WeightInfo<T> {
 		//  Measured:  `313`
 		//  Estimated: `5821`
 		// Minimum execution time: 26_412 nanoseconds.
-		Weight::from_ref_time(20_296_722)
-			.saturating_add(Weight::from_proof_size(5821))
+		Weight::from_parts(20_296_722, 0)
+			.saturating_add(Weight::from_parts(0, 5821))
 			// Standard Error: 402
-			.saturating_add(Weight::from_ref_time(67_954).saturating_mul(s.into()))
+			.saturating_add(Weight::from_parts(67_954, 0).saturating_mul(s.into()))
 			// Standard Error: 3
-			.saturating_add(Weight::from_ref_time(1_495).saturating_mul(z.into()))
+			.saturating_add(Weight::from_parts(1_495, 0).saturating_mul(z.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -105,12 +105,12 @@ impl<T: frame_system::Config> pallet_multisig::WeightInfo for WeightInfo<T> {
 		//  Measured:  `448 + s * (33 ±0)`
 		//  Estimated: `8424`
 		// Minimum execution time: 39_936 nanoseconds.
-		Weight::from_ref_time(31_699_007)
-			.saturating_add(Weight::from_proof_size(8424))
+		Weight::from_parts(31_699_007, 0)
+			.saturating_add(Weight::from_parts(0, 8424))
 			// Standard Error: 632
-			.saturating_add(Weight::from_ref_time(90_100).saturating_mul(s.into()))
+			.saturating_add(Weight::from_parts(90_100, 0).saturating_mul(s.into()))
 			// Standard Error: 6
-			.saturating_add(Weight::from_ref_time(1_544).saturating_mul(z.into()))
+			.saturating_add(Weight::from_parts(1_544, 0).saturating_mul(z.into()))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -122,10 +122,10 @@ impl<T: frame_system::Config> pallet_multisig::WeightInfo for WeightInfo<T> {
 		//  Measured:  `318 + s * (2 ±0)`
 		//  Estimated: `5821`
 		// Minimum execution time: 25_146 nanoseconds.
-		Weight::from_ref_time(26_857_601)
-			.saturating_add(Weight::from_proof_size(5821))
+		Weight::from_parts(26_857_601, 0)
+			.saturating_add(Weight::from_parts(0, 5821))
 			// Standard Error: 669
-			.saturating_add(Weight::from_ref_time(76_520).saturating_mul(s.into()))
+			.saturating_add(Weight::from_parts(76_520, 0).saturating_mul(s.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -137,10 +137,10 @@ impl<T: frame_system::Config> pallet_multisig::WeightInfo for WeightInfo<T> {
 		//  Measured:  `313`
 		//  Estimated: `5821`
 		// Minimum execution time: 17_187 nanoseconds.
-		Weight::from_ref_time(18_410_072)
-			.saturating_add(Weight::from_proof_size(5821))
+		Weight::from_parts(18_410_072, 0)
+			.saturating_add(Weight::from_parts(0, 5821))
 			// Standard Error: 491
-			.saturating_add(Weight::from_ref_time(72_318).saturating_mul(s.into()))
+			.saturating_add(Weight::from_parts(72_318, 0).saturating_mul(s.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -152,10 +152,10 @@ impl<T: frame_system::Config> pallet_multisig::WeightInfo for WeightInfo<T> {
 		//  Measured:  `517 + s * (1 ±0)`
 		//  Estimated: `5821`
 		// Minimum execution time: 25_956 nanoseconds.
-		Weight::from_ref_time(28_043_929)
-			.saturating_add(Weight::from_proof_size(5821))
+		Weight::from_parts(28_043_929, 0)
+			.saturating_add(Weight::from_parts(0, 5821))
 			// Standard Error: 830
-			.saturating_add(Weight::from_ref_time(80_119).saturating_mul(s.into()))
+			.saturating_add(Weight::from_parts(80_119, 0).saturating_mul(s.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}

--- a/parachains/runtimes/assets/westmint/src/weights/pallet_nfts.rs
+++ b/parachains/runtimes/assets/westmint/src/weights/pallet_nfts.rs
@@ -62,8 +62,8 @@ impl<T: frame_system::Config> pallet_nfts::WeightInfo for WeightInfo<T> {
 		//  Measured:  `177`
 		//  Estimated: `3054`
 		// Minimum execution time: 30_978 nanoseconds.
-		Weight::from_ref_time(31_489_000)
-			.saturating_add(Weight::from_proof_size(3054))
+		Weight::from_parts(31_489_000, 0)
+			.saturating_add(Weight::from_parts(0, 3054))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(5))
 	}
@@ -82,8 +82,8 @@ impl<T: frame_system::Config> pallet_nfts::WeightInfo for WeightInfo<T> {
 		//  Measured:  `42`
 		//  Estimated: `3054`
 		// Minimum execution time: 20_101 nanoseconds.
-		Weight::from_ref_time(20_488_000)
-			.saturating_add(Weight::from_proof_size(3054))
+		Weight::from_parts(20_488_000, 0)
+			.saturating_add(Weight::from_parts(0, 3054))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(5))
 	}
@@ -115,20 +115,20 @@ impl<T: frame_system::Config> pallet_nfts::WeightInfo for WeightInfo<T> {
 		//  Measured:  `172673 + m * (206 ±0) + a * (210 ±0)`
 		//  Estimated: `3347314 + m * (2694 ±0) + a * (2729 ±0)`
 		// Minimum execution time: 23_505_821 nanoseconds.
-		Weight::from_ref_time(16_948_157_713)
-			.saturating_add(Weight::from_proof_size(3347314))
+		Weight::from_parts(16_948_157_713, 0)
+			.saturating_add(Weight::from_parts(0, 3347314))
 			// Standard Error: 20_494
-			.saturating_add(Weight::from_ref_time(7_059_571).saturating_mul(m.into()))
+			.saturating_add(Weight::from_parts(7_059_571, 0).saturating_mul(m.into()))
 			// Standard Error: 20_494
-			.saturating_add(Weight::from_ref_time(8_471_367).saturating_mul(a.into()))
+			.saturating_add(Weight::from_parts(8_471_367, 0).saturating_mul(a.into()))
 			.saturating_add(T::DbWeight::get().reads(1004))
 			.saturating_add(T::DbWeight::get().reads((1_u64).saturating_mul(m.into())))
 			.saturating_add(T::DbWeight::get().reads((1_u64).saturating_mul(a.into())))
 			.saturating_add(T::DbWeight::get().writes(3005))
 			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(m.into())))
 			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(a.into())))
-			.saturating_add(Weight::from_proof_size(2694).saturating_mul(m.into()))
-			.saturating_add(Weight::from_proof_size(2729).saturating_mul(a.into()))
+			.saturating_add(Weight::from_parts(0, 2694).saturating_mul(m.into()))
+			.saturating_add(Weight::from_parts(0, 2729).saturating_mul(a.into()))
 	}
 	/// Storage: Nfts CollectionConfigOf (r:1 w:0)
 	/// Proof: Nfts CollectionConfigOf (max_values: None, max_size: Some(73), added: 2548, mode: MaxEncodedLen)
@@ -147,8 +147,8 @@ impl<T: frame_system::Config> pallet_nfts::WeightInfo for WeightInfo<T> {
 		//  Measured:  `448`
 		//  Estimated: `13506`
 		// Minimum execution time: 39_850 nanoseconds.
-		Weight::from_ref_time(40_227_000)
-			.saturating_add(Weight::from_proof_size(13506))
+		Weight::from_parts(40_227_000, 0)
+			.saturating_add(Weight::from_parts(0, 13506))
 			.saturating_add(T::DbWeight::get().reads(5))
 			.saturating_add(T::DbWeight::get().writes(4))
 	}
@@ -169,8 +169,8 @@ impl<T: frame_system::Config> pallet_nfts::WeightInfo for WeightInfo<T> {
 		//  Measured:  `448`
 		//  Estimated: `13506`
 		// Minimum execution time: 40_379 nanoseconds.
-		Weight::from_ref_time(41_110_000)
-			.saturating_add(Weight::from_proof_size(13506))
+		Weight::from_parts(41_110_000, 0)
+			.saturating_add(Weight::from_parts(0, 13506))
 			.saturating_add(T::DbWeight::get().reads(5))
 			.saturating_add(T::DbWeight::get().writes(4))
 	}
@@ -197,8 +197,8 @@ impl<T: frame_system::Config> pallet_nfts::WeightInfo for WeightInfo<T> {
 		//  Measured:  `647`
 		//  Estimated: `13652`
 		// Minimum execution time: 43_534 nanoseconds.
-		Weight::from_ref_time(43_846_000)
-			.saturating_add(Weight::from_proof_size(13652))
+		Weight::from_parts(43_846_000, 0)
+			.saturating_add(Weight::from_parts(0, 13652))
 			.saturating_add(T::DbWeight::get().reads(5))
 			.saturating_add(T::DbWeight::get().writes(7))
 	}
@@ -225,8 +225,8 @@ impl<T: frame_system::Config> pallet_nfts::WeightInfo for WeightInfo<T> {
 		//  Measured:  `811`
 		//  Estimated: `16109`
 		// Minimum execution time: 49_184 nanoseconds.
-		Weight::from_ref_time(49_935_000)
-			.saturating_add(Weight::from_proof_size(16109))
+		Weight::from_parts(49_935_000, 0)
+			.saturating_add(Weight::from_parts(0, 16109))
 			.saturating_add(T::DbWeight::get().reads(6))
 			.saturating_add(T::DbWeight::get().writes(6))
 	}
@@ -242,14 +242,14 @@ impl<T: frame_system::Config> pallet_nfts::WeightInfo for WeightInfo<T> {
 		//  Measured:  `756 + i * (140 ±0)`
 		//  Estimated: `5103 + i * (3336 ±0)`
 		// Minimum execution time: 15_668 nanoseconds.
-		Weight::from_ref_time(15_762_000)
-			.saturating_add(Weight::from_proof_size(5103))
+		Weight::from_parts(15_762_000, 0)
+			.saturating_add(Weight::from_parts(0, 5103))
 			// Standard Error: 12_791
-			.saturating_add(Weight::from_ref_time(12_224_567).saturating_mul(i.into()))
+			.saturating_add(Weight::from_parts(12_224_567, 0).saturating_mul(i.into()))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().reads((1_u64).saturating_mul(i.into())))
 			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(i.into())))
-			.saturating_add(Weight::from_proof_size(3336).saturating_mul(i.into()))
+			.saturating_add(Weight::from_parts(0, 3336).saturating_mul(i.into()))
 	}
 	/// Storage: Nfts CollectionRoleOf (r:1 w:0)
 	/// Proof: Nfts CollectionRoleOf (max_values: None, max_size: Some(69), added: 2544, mode: MaxEncodedLen)
@@ -260,8 +260,8 @@ impl<T: frame_system::Config> pallet_nfts::WeightInfo for WeightInfo<T> {
 		//  Measured:  `401`
 		//  Estimated: `5067`
 		// Minimum execution time: 18_861 nanoseconds.
-		Weight::from_ref_time(19_195_000)
-			.saturating_add(Weight::from_proof_size(5067))
+		Weight::from_parts(19_195_000, 0)
+			.saturating_add(Weight::from_parts(0, 5067))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -274,8 +274,8 @@ impl<T: frame_system::Config> pallet_nfts::WeightInfo for WeightInfo<T> {
 		//  Measured:  `401`
 		//  Estimated: `5067`
 		// Minimum execution time: 18_710 nanoseconds.
-		Weight::from_ref_time(18_971_000)
-			.saturating_add(Weight::from_proof_size(5067))
+		Weight::from_parts(18_971_000, 0)
+			.saturating_add(Weight::from_parts(0, 5067))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -288,8 +288,8 @@ impl<T: frame_system::Config> pallet_nfts::WeightInfo for WeightInfo<T> {
 		//  Measured:  `289`
 		//  Estimated: `5092`
 		// Minimum execution time: 17_067 nanoseconds.
-		Weight::from_ref_time(17_233_000)
-			.saturating_add(Weight::from_proof_size(5092))
+		Weight::from_parts(17_233_000, 0)
+			.saturating_add(Weight::from_parts(0, 5092))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -304,8 +304,8 @@ impl<T: frame_system::Config> pallet_nfts::WeightInfo for WeightInfo<T> {
 		//  Measured:  `381`
 		//  Estimated: `5082`
 		// Minimum execution time: 21_203 nanoseconds.
-		Weight::from_ref_time(21_468_000)
-			.saturating_add(Weight::from_proof_size(5082))
+		Weight::from_parts(21_468_000, 0)
+			.saturating_add(Weight::from_parts(0, 5082))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(4))
 	}
@@ -318,8 +318,8 @@ impl<T: frame_system::Config> pallet_nfts::WeightInfo for WeightInfo<T> {
 		//  Measured:  `362`
 		//  Estimated: `2555`
 		// Minimum execution time: 24_304 nanoseconds.
-		Weight::from_ref_time(24_823_000)
-			.saturating_add(Weight::from_proof_size(2555))
+		Weight::from_parts(24_823_000, 0)
+			.saturating_add(Weight::from_parts(0, 2555))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(5))
 	}
@@ -332,8 +332,8 @@ impl<T: frame_system::Config> pallet_nfts::WeightInfo for WeightInfo<T> {
 		//  Measured:  `304`
 		//  Estimated: `2555`
 		// Minimum execution time: 17_173 nanoseconds.
-		Weight::from_ref_time(17_448_000)
-			.saturating_add(Weight::from_proof_size(2555))
+		Weight::from_parts(17_448_000, 0)
+			.saturating_add(Weight::from_parts(0, 2555))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(3))
 	}
@@ -346,8 +346,8 @@ impl<T: frame_system::Config> pallet_nfts::WeightInfo for WeightInfo<T> {
 		//  Measured:  `242`
 		//  Estimated: `2555`
 		// Minimum execution time: 13_697 nanoseconds.
-		Weight::from_ref_time(13_924_000)
-			.saturating_add(Weight::from_proof_size(2555))
+		Weight::from_parts(13_924_000, 0)
+			.saturating_add(Weight::from_parts(0, 2555))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -360,8 +360,8 @@ impl<T: frame_system::Config> pallet_nfts::WeightInfo for WeightInfo<T> {
 		//  Measured:  `445`
 		//  Estimated: `5078`
 		// Minimum execution time: 18_063 nanoseconds.
-		Weight::from_ref_time(18_438_000)
-			.saturating_add(Weight::from_proof_size(5078))
+		Weight::from_parts(18_438_000, 0)
+			.saturating_add(Weight::from_parts(0, 5078))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -378,8 +378,8 @@ impl<T: frame_system::Config> pallet_nfts::WeightInfo for WeightInfo<T> {
 		//  Measured:  `474`
 		//  Estimated: `10355`
 		// Minimum execution time: 37_582 nanoseconds.
-		Weight::from_ref_time(38_155_000)
-			.saturating_add(Weight::from_proof_size(10355))
+		Weight::from_parts(38_155_000, 0)
+			.saturating_add(Weight::from_parts(0, 10355))
 			.saturating_add(T::DbWeight::get().reads(4))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -392,8 +392,8 @@ impl<T: frame_system::Config> pallet_nfts::WeightInfo for WeightInfo<T> {
 		//  Measured:  `337`
 		//  Estimated: `5284`
 		// Minimum execution time: 24_392 nanoseconds.
-		Weight::from_ref_time(24_787_000)
-			.saturating_add(Weight::from_proof_size(5284))
+		Weight::from_parts(24_787_000, 0)
+			.saturating_add(Weight::from_parts(0, 5284))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -408,8 +408,8 @@ impl<T: frame_system::Config> pallet_nfts::WeightInfo for WeightInfo<T> {
 		//  Measured:  `724`
 		//  Estimated: `7807`
 		// Minimum execution time: 34_564 nanoseconds.
-		Weight::from_ref_time(34_956_000)
-			.saturating_add(Weight::from_proof_size(7807))
+		Weight::from_parts(34_956_000, 0)
+			.saturating_add(Weight::from_parts(0, 7807))
 			.saturating_add(T::DbWeight::get().reads(3))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -422,8 +422,8 @@ impl<T: frame_system::Config> pallet_nfts::WeightInfo for WeightInfo<T> {
 		//  Measured:  `379`
 		//  Estimated: `6812`
 		// Minimum execution time: 17_194 nanoseconds.
-		Weight::from_ref_time(17_467_000)
-			.saturating_add(Weight::from_proof_size(6812))
+		Weight::from_parts(17_467_000, 0)
+			.saturating_add(Weight::from_parts(0, 6812))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -441,15 +441,15 @@ impl<T: frame_system::Config> pallet_nfts::WeightInfo for WeightInfo<T> {
 		//  Measured:  `828 + n * (204 ±0)`
 		//  Estimated: `12144 + n * (2729 ±0)`
 		// Minimum execution time: 25_617 nanoseconds.
-		Weight::from_ref_time(25_917_000)
-			.saturating_add(Weight::from_proof_size(12144))
+		Weight::from_parts(25_917_000, 0)
+			.saturating_add(Weight::from_parts(0, 12144))
 			// Standard Error: 5_524
-			.saturating_add(Weight::from_ref_time(7_538_893).saturating_mul(n.into()))
+			.saturating_add(Weight::from_parts(7_538_893, 0).saturating_mul(n.into()))
 			.saturating_add(T::DbWeight::get().reads(4))
 			.saturating_add(T::DbWeight::get().reads((1_u64).saturating_mul(n.into())))
 			.saturating_add(T::DbWeight::get().writes(2))
 			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(n.into())))
-			.saturating_add(Weight::from_proof_size(2729).saturating_mul(n.into()))
+			.saturating_add(Weight::from_parts(0, 2729).saturating_mul(n.into()))
 	}
 	/// Storage: Nfts Collection (r:1 w:1)
 	/// Proof: Nfts Collection (max_values: None, max_size: Some(80), added: 2555, mode: MaxEncodedLen)
@@ -464,8 +464,8 @@ impl<T: frame_system::Config> pallet_nfts::WeightInfo for WeightInfo<T> {
 		//  Measured:  `474`
 		//  Estimated: `10320`
 		// Minimum execution time: 32_053 nanoseconds.
-		Weight::from_ref_time(32_510_000)
-			.saturating_add(Weight::from_proof_size(10320))
+		Weight::from_parts(32_510_000, 0)
+			.saturating_add(Weight::from_parts(0, 10320))
 			.saturating_add(T::DbWeight::get().reads(4))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -480,8 +480,8 @@ impl<T: frame_system::Config> pallet_nfts::WeightInfo for WeightInfo<T> {
 		//  Measured:  `688`
 		//  Estimated: `7772`
 		// Minimum execution time: 30_654 nanoseconds.
-		Weight::from_ref_time(31_113_000)
-			.saturating_add(Weight::from_proof_size(7772))
+		Weight::from_parts(31_113_000, 0)
+			.saturating_add(Weight::from_parts(0, 7772))
 			.saturating_add(T::DbWeight::get().reads(3))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -496,8 +496,8 @@ impl<T: frame_system::Config> pallet_nfts::WeightInfo for WeightInfo<T> {
 		//  Measured:  `333`
 		//  Estimated: `7744`
 		// Minimum execution time: 27_700 nanoseconds.
-		Weight::from_ref_time(28_291_000)
-			.saturating_add(Weight::from_proof_size(7744))
+		Weight::from_parts(28_291_000, 0)
+			.saturating_add(Weight::from_parts(0, 7744))
 			.saturating_add(T::DbWeight::get().reads(3))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -512,8 +512,8 @@ impl<T: frame_system::Config> pallet_nfts::WeightInfo for WeightInfo<T> {
 		//  Measured:  `555`
 		//  Estimated: `7744`
 		// Minimum execution time: 27_483 nanoseconds.
-		Weight::from_ref_time(27_830_000)
-			.saturating_add(Weight::from_proof_size(7744))
+		Weight::from_parts(27_830_000, 0)
+			.saturating_add(Weight::from_parts(0, 7744))
 			.saturating_add(T::DbWeight::get().reads(3))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -528,8 +528,8 @@ impl<T: frame_system::Config> pallet_nfts::WeightInfo for WeightInfo<T> {
 		//  Measured:  `466`
 		//  Estimated: `8428`
 		// Minimum execution time: 23_623 nanoseconds.
-		Weight::from_ref_time(24_282_000)
-			.saturating_add(Weight::from_proof_size(8428))
+		Weight::from_parts(24_282_000, 0)
+			.saturating_add(Weight::from_parts(0, 8428))
 			.saturating_add(T::DbWeight::get().reads(3))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -542,8 +542,8 @@ impl<T: frame_system::Config> pallet_nfts::WeightInfo for WeightInfo<T> {
 		//  Measured:  `474`
 		//  Estimated: `5880`
 		// Minimum execution time: 21_115 nanoseconds.
-		Weight::from_ref_time(22_036_000)
-			.saturating_add(Weight::from_proof_size(5880))
+		Weight::from_parts(22_036_000, 0)
+			.saturating_add(Weight::from_parts(0, 5880))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -556,8 +556,8 @@ impl<T: frame_system::Config> pallet_nfts::WeightInfo for WeightInfo<T> {
 		//  Measured:  `474`
 		//  Estimated: `5880`
 		// Minimum execution time: 20_352 nanoseconds.
-		Weight::from_ref_time(20_627_000)
-			.saturating_add(Weight::from_proof_size(5880))
+		Weight::from_parts(20_627_000, 0)
+			.saturating_add(Weight::from_parts(0, 5880))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -568,8 +568,8 @@ impl<T: frame_system::Config> pallet_nfts::WeightInfo for WeightInfo<T> {
 		//  Measured:  `42`
 		//  Estimated: `2527`
 		// Minimum execution time: 14_427 nanoseconds.
-		Weight::from_ref_time(15_169_000)
-			.saturating_add(Weight::from_proof_size(2527))
+		Weight::from_parts(15_169_000, 0)
+			.saturating_add(Weight::from_parts(0, 2527))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -582,8 +582,8 @@ impl<T: frame_system::Config> pallet_nfts::WeightInfo for WeightInfo<T> {
 		//  Measured:  `333`
 		//  Estimated: `5103`
 		// Minimum execution time: 18_049 nanoseconds.
-		Weight::from_ref_time(18_431_000)
-			.saturating_add(Weight::from_proof_size(5103))
+		Weight::from_parts(18_431_000, 0)
+			.saturating_add(Weight::from_parts(0, 5103))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -596,8 +596,8 @@ impl<T: frame_system::Config> pallet_nfts::WeightInfo for WeightInfo<T> {
 		//  Measured:  `333`
 		//  Estimated: `5103`
 		// Minimum execution time: 17_166 nanoseconds.
-		Weight::from_ref_time(17_511_000)
-			.saturating_add(Weight::from_proof_size(5103))
+		Weight::from_parts(17_511_000, 0)
+			.saturating_add(Weight::from_parts(0, 5103))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -614,8 +614,8 @@ impl<T: frame_system::Config> pallet_nfts::WeightInfo for WeightInfo<T> {
 		//  Measured:  `516`
 		//  Estimated: `8407`
 		// Minimum execution time: 22_556 nanoseconds.
-		Weight::from_ref_time(22_839_000)
-			.saturating_add(Weight::from_proof_size(8407))
+		Weight::from_parts(22_839_000, 0)
+			.saturating_add(Weight::from_parts(0, 8407))
 			.saturating_add(T::DbWeight::get().reads(3))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -640,8 +640,8 @@ impl<T: frame_system::Config> pallet_nfts::WeightInfo for WeightInfo<T> {
 		//  Measured:  `897`
 		//  Estimated: `16129`
 		// Minimum execution time: 53_554 nanoseconds.
-		Weight::from_ref_time(54_285_000)
-			.saturating_add(Weight::from_proof_size(16129))
+		Weight::from_parts(54_285_000, 0)
+			.saturating_add(Weight::from_parts(0, 16129))
 			.saturating_add(T::DbWeight::get().reads(6))
 			.saturating_add(T::DbWeight::get().writes(6))
 	}
@@ -651,10 +651,10 @@ impl<T: frame_system::Config> pallet_nfts::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 2_031 nanoseconds.
-		Weight::from_ref_time(3_579_973)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(3_579_973, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			// Standard Error: 8_727
-			.saturating_add(Weight::from_ref_time(3_165_511).saturating_mul(n.into()))
+			.saturating_add(Weight::from_parts(3_165_511, 0).saturating_mul(n.into()))
 	}
 	/// Storage: Nfts Item (r:2 w:0)
 	/// Proof: Nfts Item (max_values: None, max_size: Some(861), added: 3336, mode: MaxEncodedLen)
@@ -665,8 +665,8 @@ impl<T: frame_system::Config> pallet_nfts::WeightInfo for WeightInfo<T> {
 		//  Measured:  `524`
 		//  Estimated: `6672`
 		// Minimum execution time: 20_161 nanoseconds.
-		Weight::from_ref_time(20_487_000)
-			.saturating_add(Weight::from_proof_size(6672))
+		Weight::from_parts(20_487_000, 0)
+			.saturating_add(Weight::from_parts(0, 6672))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -679,8 +679,8 @@ impl<T: frame_system::Config> pallet_nfts::WeightInfo for WeightInfo<T> {
 		//  Measured:  `511`
 		//  Estimated: `5882`
 		// Minimum execution time: 19_470 nanoseconds.
-		Weight::from_ref_time(19_832_000)
-			.saturating_add(Weight::from_proof_size(5882))
+		Weight::from_parts(19_832_000, 0)
+			.saturating_add(Weight::from_parts(0, 5882))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -705,8 +705,8 @@ impl<T: frame_system::Config> pallet_nfts::WeightInfo for WeightInfo<T> {
 		//  Measured:  `1026`
 		//  Estimated: `21970`
 		// Minimum execution time: 78_114 nanoseconds.
-		Weight::from_ref_time(79_459_000)
-			.saturating_add(Weight::from_proof_size(21970))
+		Weight::from_parts(79_459_000, 0)
+			.saturating_add(Weight::from_parts(0, 21970))
 			.saturating_add(T::DbWeight::get().reads(8))
 			.saturating_add(T::DbWeight::get().writes(11))
 	}
@@ -732,15 +732,15 @@ impl<T: frame_system::Config> pallet_nfts::WeightInfo for WeightInfo<T> {
 		//  Measured:  `525`
 		//  Estimated: `16259 + n * (2729 ±0)`
 		// Minimum execution time: 108_373 nanoseconds.
-		Weight::from_ref_time(112_094_892)
-			.saturating_add(Weight::from_proof_size(16259))
+		Weight::from_parts(112_094_892, 0)
+			.saturating_add(Weight::from_parts(0, 16259))
 			// Standard Error: 27_186
-			.saturating_add(Weight::from_ref_time(20_710_983).saturating_mul(n.into()))
+			.saturating_add(Weight::from_parts(20_710_983, 0).saturating_mul(n.into()))
 			.saturating_add(T::DbWeight::get().reads(6))
 			.saturating_add(T::DbWeight::get().reads((1_u64).saturating_mul(n.into())))
 			.saturating_add(T::DbWeight::get().writes(6))
 			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(n.into())))
-			.saturating_add(Weight::from_proof_size(2729).saturating_mul(n.into()))
+			.saturating_add(Weight::from_parts(0, 2729).saturating_mul(n.into()))
 	}
 	/// Storage: Nfts Item (r:1 w:0)
 	/// Proof: Nfts Item (max_values: None, max_size: Some(861), added: 3336, mode: MaxEncodedLen)
@@ -760,14 +760,14 @@ impl<T: frame_system::Config> pallet_nfts::WeightInfo for WeightInfo<T> {
 		//  Measured:  `716`
 		//  Estimated: `14198 + n * (2921 ±0)`
 		// Minimum execution time: 84_153 nanoseconds.
-		Weight::from_ref_time(96_401_623)
-			.saturating_add(Weight::from_proof_size(14198))
+		Weight::from_parts(96_401_623, 0)
+			.saturating_add(Weight::from_parts(0, 14198))
 			// Standard Error: 70_244
-			.saturating_add(Weight::from_ref_time(26_866_222).saturating_mul(n.into()))
+			.saturating_add(Weight::from_parts(26_866_222, 0).saturating_mul(n.into()))
 			.saturating_add(T::DbWeight::get().reads(4_u64))
 			.saturating_add(T::DbWeight::get().reads((1_u64).saturating_mul(n.into())))
 			.saturating_add(T::DbWeight::get().writes(2_u64))
 			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(n.into())))
-			.saturating_add(Weight::from_proof_size(2921).saturating_mul(n.into()))
+			.saturating_add(Weight::from_parts(0, 2921).saturating_mul(n.into()))
 	}
 }

--- a/parachains/runtimes/assets/westmint/src/weights/pallet_proxy.rs
+++ b/parachains/runtimes/assets/westmint/src/weights/pallet_proxy.rs
@@ -55,10 +55,10 @@ impl<T: frame_system::Config> pallet_proxy::WeightInfo for WeightInfo<T> {
 		//  Measured:  `159 + p * (37 ±0)`
 		//  Estimated: `3716`
 		// Minimum execution time: 14_854 nanoseconds.
-		Weight::from_ref_time(15_600_203)
-			.saturating_add(Weight::from_proof_size(3716))
+		Weight::from_parts(15_600_203, 0)
+			.saturating_add(Weight::from_parts(0, 3716))
 			// Standard Error: 1_181
-			.saturating_add(Weight::from_ref_time(28_891).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(28_891, 0).saturating_mul(p.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 	}
 	/// Storage: Proxy Proxies (r:1 w:0)
@@ -74,12 +74,12 @@ impl<T: frame_system::Config> pallet_proxy::WeightInfo for WeightInfo<T> {
 		//  Measured:  `550 + a * (68 ±0) + p * (37 ±0)`
 		//  Estimated: `11027`
 		// Minimum execution time: 32_063 nanoseconds.
-		Weight::from_ref_time(32_624_200)
-			.saturating_add(Weight::from_proof_size(11027))
+		Weight::from_parts(32_624_200, 0)
+			.saturating_add(Weight::from_parts(0, 11027))
 			// Standard Error: 1_727
-			.saturating_add(Weight::from_ref_time(113_689).saturating_mul(a.into()))
+			.saturating_add(Weight::from_parts(113_689, 0).saturating_mul(a.into()))
 			// Standard Error: 1_785
-			.saturating_add(Weight::from_ref_time(29_618).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(29_618, 0).saturating_mul(p.into()))
 			.saturating_add(T::DbWeight::get().reads(3))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -94,12 +94,12 @@ impl<T: frame_system::Config> pallet_proxy::WeightInfo for WeightInfo<T> {
 		//  Measured:  `433 + a * (68 ±0)`
 		//  Estimated: `7311`
 		// Minimum execution time: 20_449 nanoseconds.
-		Weight::from_ref_time(21_345_957)
-			.saturating_add(Weight::from_proof_size(7311))
+		Weight::from_parts(21_345_957, 0)
+			.saturating_add(Weight::from_parts(0, 7311))
 			// Standard Error: 1_390
-			.saturating_add(Weight::from_ref_time(105_313).saturating_mul(a.into()))
+			.saturating_add(Weight::from_parts(105_313, 0).saturating_mul(a.into()))
 			// Standard Error: 1_436
-			.saturating_add(Weight::from_ref_time(9_437).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(9_437, 0).saturating_mul(p.into()))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -114,12 +114,12 @@ impl<T: frame_system::Config> pallet_proxy::WeightInfo for WeightInfo<T> {
 		//  Measured:  `433 + a * (68 ±0)`
 		//  Estimated: `7311`
 		// Minimum execution time: 20_423 nanoseconds.
-		Weight::from_ref_time(21_290_701)
-			.saturating_add(Weight::from_proof_size(7311))
+		Weight::from_parts(21_290_701, 0)
+			.saturating_add(Weight::from_parts(0, 7311))
 			// Standard Error: 1_398
-			.saturating_add(Weight::from_ref_time(110_034).saturating_mul(a.into()))
+			.saturating_add(Weight::from_parts(110_034, 0).saturating_mul(a.into()))
 			// Standard Error: 1_444
-			.saturating_add(Weight::from_ref_time(9_968).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(9_968, 0).saturating_mul(p.into()))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -136,12 +136,12 @@ impl<T: frame_system::Config> pallet_proxy::WeightInfo for WeightInfo<T> {
 		//  Measured:  `482 + a * (68 ±0) + p * (37 ±0)`
 		//  Estimated: `11027`
 		// Minimum execution time: 28_014 nanoseconds.
-		Weight::from_ref_time(28_864_371)
-			.saturating_add(Weight::from_proof_size(11027))
+		Weight::from_parts(28_864_371, 0)
+			.saturating_add(Weight::from_parts(0, 11027))
 			// Standard Error: 1_933
-			.saturating_add(Weight::from_ref_time(109_536).saturating_mul(a.into()))
+			.saturating_add(Weight::from_parts(109_536, 0).saturating_mul(a.into()))
 			// Standard Error: 1_998
-			.saturating_add(Weight::from_ref_time(43_779).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(43_779, 0).saturating_mul(p.into()))
 			.saturating_add(T::DbWeight::get().reads(3))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -153,10 +153,10 @@ impl<T: frame_system::Config> pallet_proxy::WeightInfo for WeightInfo<T> {
 		//  Measured:  `159 + p * (37 ±0)`
 		//  Estimated: `3716`
 		// Minimum execution time: 21_285 nanoseconds.
-		Weight::from_ref_time(22_065_300)
-			.saturating_add(Weight::from_proof_size(3716))
+		Weight::from_parts(22_065_300, 0)
+			.saturating_add(Weight::from_parts(0, 3716))
 			// Standard Error: 1_703
-			.saturating_add(Weight::from_ref_time(42_186).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(42_186, 0).saturating_mul(p.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -168,10 +168,10 @@ impl<T: frame_system::Config> pallet_proxy::WeightInfo for WeightInfo<T> {
 		//  Measured:  `159 + p * (37 ±0)`
 		//  Estimated: `3716`
 		// Minimum execution time: 20_992 nanoseconds.
-		Weight::from_ref_time(22_026_633)
-			.saturating_add(Weight::from_proof_size(3716))
+		Weight::from_parts(22_026_633, 0)
+			.saturating_add(Weight::from_parts(0, 3716))
 			// Standard Error: 1_663
-			.saturating_add(Weight::from_ref_time(60_910).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(60_910, 0).saturating_mul(p.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -183,10 +183,10 @@ impl<T: frame_system::Config> pallet_proxy::WeightInfo for WeightInfo<T> {
 		//  Measured:  `159 + p * (37 ±0)`
 		//  Estimated: `3716`
 		// Minimum execution time: 16_755 nanoseconds.
-		Weight::from_ref_time(17_775_492)
-			.saturating_add(Weight::from_proof_size(3716))
+		Weight::from_parts(17_775_492, 0)
+			.saturating_add(Weight::from_parts(0, 3716))
 			// Standard Error: 1_281
-			.saturating_add(Weight::from_ref_time(28_738).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(28_738, 0).saturating_mul(p.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -198,8 +198,8 @@ impl<T: frame_system::Config> pallet_proxy::WeightInfo for WeightInfo<T> {
 		//  Measured:  `139`
 		//  Estimated: `3716`
 		// Minimum execution time: 22_598 nanoseconds.
-		Weight::from_ref_time(23_639_320)
-			.saturating_add(Weight::from_proof_size(3716))
+		Weight::from_parts(23_639_320, 0)
+			.saturating_add(Weight::from_parts(0, 3716))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -211,10 +211,10 @@ impl<T: frame_system::Config> pallet_proxy::WeightInfo for WeightInfo<T> {
 		//  Measured:  `196 + p * (37 ±0)`
 		//  Estimated: `3716`
 		// Minimum execution time: 17_907 nanoseconds.
-		Weight::from_ref_time(18_737_185)
-			.saturating_add(Weight::from_proof_size(3716))
+		Weight::from_parts(18_737_185, 0)
+			.saturating_add(Weight::from_parts(0, 3716))
 			// Standard Error: 1_069
-			.saturating_add(Weight::from_ref_time(26_491).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(26_491, 0).saturating_mul(p.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}

--- a/parachains/runtimes/assets/westmint/src/weights/pallet_session.rs
+++ b/parachains/runtimes/assets/westmint/src/weights/pallet_session.rs
@@ -56,8 +56,8 @@ impl<T: frame_system::Config> pallet_session::WeightInfo for WeightInfo<T> {
 		//  Measured:  `270`
 		//  Estimated: `5490`
 		// Minimum execution time: 15_416 nanoseconds.
-		Weight::from_ref_time(15_764_000)
-			.saturating_add(Weight::from_proof_size(5490))
+		Weight::from_parts(15_764_000, 0)
+			.saturating_add(Weight::from_parts(0, 5490))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -70,8 +70,8 @@ impl<T: frame_system::Config> pallet_session::WeightInfo for WeightInfo<T> {
 		//  Measured:  `242`
 		//  Estimated: `2959`
 		// Minimum execution time: 11_720 nanoseconds.
-		Weight::from_ref_time(12_152_000)
-			.saturating_add(Weight::from_proof_size(2959))
+		Weight::from_parts(12_152_000, 0)
+			.saturating_add(Weight::from_parts(0, 2959))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}

--- a/parachains/runtimes/assets/westmint/src/weights/pallet_timestamp.rs
+++ b/parachains/runtimes/assets/westmint/src/weights/pallet_timestamp.rs
@@ -56,8 +56,8 @@ impl<T: frame_system::Config> pallet_timestamp::WeightInfo for WeightInfo<T> {
 		//  Measured:  `86`
 		//  Estimated: `1006`
 		// Minimum execution time: 8_384 nanoseconds.
-		Weight::from_ref_time(8_706_000)
-			.saturating_add(Weight::from_proof_size(1006))
+		Weight::from_parts(8_706_000, 0)
+			.saturating_add(Weight::from_parts(0, 1006))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -66,7 +66,7 @@ impl<T: frame_system::Config> pallet_timestamp::WeightInfo for WeightInfo<T> {
 		//  Measured:  `57`
 		//  Estimated: `0`
 		// Minimum execution time: 3_110 nanoseconds.
-		Weight::from_ref_time(3_206_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(3_206_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 	}
 }

--- a/parachains/runtimes/assets/westmint/src/weights/pallet_uniques.rs
+++ b/parachains/runtimes/assets/westmint/src/weights/pallet_uniques.rs
@@ -56,8 +56,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `177`
 		//  Estimated: `2653`
 		// Minimum execution time: 23_302 nanoseconds.
-		Weight::from_ref_time(23_817_000)
-			.saturating_add(Weight::from_proof_size(2653))
+		Weight::from_parts(23_817_000, 0)
+			.saturating_add(Weight::from_parts(0, 2653))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -70,8 +70,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `42`
 		//  Estimated: `2653`
 		// Minimum execution time: 12_529 nanoseconds.
-		Weight::from_ref_time(13_079_000)
-			.saturating_add(Weight::from_proof_size(2653))
+		Weight::from_parts(13_079_000, 0)
+			.saturating_add(Weight::from_parts(0, 2653))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -99,21 +99,21 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `289 + n * (108 ±0) + m * (56 ±0) + a * (107 ±0)`
 		//  Estimated: `5250 + n * (2597 ±0)`
 		// Minimum execution time: 2_305_045 nanoseconds.
-		Weight::from_ref_time(2_312_341_000)
-			.saturating_add(Weight::from_proof_size(5250))
+		Weight::from_parts(2_312_341_000, 0)
+			.saturating_add(Weight::from_parts(0, 5250))
 			// Standard Error: 26_047
-			.saturating_add(Weight::from_ref_time(8_440_544).saturating_mul(n.into()))
+			.saturating_add(Weight::from_parts(8_440_544, 0).saturating_mul(n.into()))
 			// Standard Error: 26_047
-			.saturating_add(Weight::from_ref_time(223_194).saturating_mul(m.into()))
+			.saturating_add(Weight::from_parts(223_194, 0).saturating_mul(m.into()))
 			// Standard Error: 26_047
-			.saturating_add(Weight::from_ref_time(313_891).saturating_mul(a.into()))
+			.saturating_add(Weight::from_parts(313_891, 0).saturating_mul(a.into()))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().reads((1_u64).saturating_mul(n.into())))
 			.saturating_add(T::DbWeight::get().writes(4))
 			.saturating_add(T::DbWeight::get().writes((2_u64).saturating_mul(n.into())))
 			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(m.into())))
 			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(a.into())))
-			.saturating_add(Weight::from_proof_size(2597).saturating_mul(n.into()))
+			.saturating_add(Weight::from_parts(0, 2597).saturating_mul(n.into()))
 	}
 	/// Storage: Uniques Asset (r:1 w:1)
 	/// Proof: Uniques Asset (max_values: None, max_size: Some(122), added: 2597, mode: MaxEncodedLen)
@@ -128,8 +128,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `314`
 		//  Estimated: `7749`
 		// Minimum execution time: 28_581 nanoseconds.
-		Weight::from_ref_time(29_011_000)
-			.saturating_add(Weight::from_proof_size(7749))
+		Weight::from_parts(29_011_000, 0)
+			.saturating_add(Weight::from_parts(0, 7749))
 			.saturating_add(T::DbWeight::get().reads(3))
 			.saturating_add(T::DbWeight::get().writes(3))
 	}
@@ -146,8 +146,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `492`
 		//  Estimated: `5250`
 		// Minimum execution time: 29_869 nanoseconds.
-		Weight::from_ref_time(30_206_000)
-			.saturating_add(Weight::from_proof_size(5250))
+		Weight::from_parts(30_206_000, 0)
+			.saturating_add(Weight::from_parts(0, 5250))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(4))
 	}
@@ -164,8 +164,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `492`
 		//  Estimated: `5250`
 		// Minimum execution time: 23_945 nanoseconds.
-		Weight::from_ref_time(24_259_000)
-			.saturating_add(Weight::from_proof_size(5250))
+		Weight::from_parts(24_259_000, 0)
+			.saturating_add(Weight::from_parts(0, 5250))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(4))
 	}
@@ -179,15 +179,15 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `770 + i * (108 ±0)`
 		//  Estimated: `2653 + i * (2597 ±0)`
 		// Minimum execution time: 13_847 nanoseconds.
-		Weight::from_ref_time(14_105_000)
-			.saturating_add(Weight::from_proof_size(2653))
+		Weight::from_parts(14_105_000, 0)
+			.saturating_add(Weight::from_parts(0, 2653))
 			// Standard Error: 12_887
-			.saturating_add(Weight::from_ref_time(12_017_604).saturating_mul(i.into()))
+			.saturating_add(Weight::from_parts(12_017_604, 0).saturating_mul(i.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().reads((1_u64).saturating_mul(i.into())))
 			.saturating_add(T::DbWeight::get().writes(1))
 			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(i.into())))
-			.saturating_add(Weight::from_proof_size(2597).saturating_mul(i.into()))
+			.saturating_add(Weight::from_parts(0, 2597).saturating_mul(i.into()))
 	}
 	/// Storage: Uniques Asset (r:1 w:1)
 	/// Proof: Uniques Asset (max_values: None, max_size: Some(122), added: 2597, mode: MaxEncodedLen)
@@ -198,8 +198,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `492`
 		//  Estimated: `5250`
 		// Minimum execution time: 17_259 nanoseconds.
-		Weight::from_ref_time(17_731_000)
-			.saturating_add(Weight::from_proof_size(5250))
+		Weight::from_parts(17_731_000, 0)
+			.saturating_add(Weight::from_parts(0, 5250))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -212,8 +212,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `492`
 		//  Estimated: `5250`
 		// Minimum execution time: 16_951 nanoseconds.
-		Weight::from_ref_time(17_177_000)
-			.saturating_add(Weight::from_proof_size(5250))
+		Weight::from_parts(17_177_000, 0)
+			.saturating_add(Weight::from_parts(0, 5250))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -224,8 +224,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `314`
 		//  Estimated: `2653`
 		// Minimum execution time: 12_733 nanoseconds.
-		Weight::from_ref_time(13_154_000)
-			.saturating_add(Weight::from_proof_size(2653))
+		Weight::from_parts(13_154_000, 0)
+			.saturating_add(Weight::from_parts(0, 2653))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -236,8 +236,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `314`
 		//  Estimated: `2653`
 		// Minimum execution time: 12_624 nanoseconds.
-		Weight::from_ref_time(12_887_000)
-			.saturating_add(Weight::from_proof_size(2653))
+		Weight::from_parts(12_887_000, 0)
+			.saturating_add(Weight::from_parts(0, 2653))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -252,8 +252,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `388`
 		//  Estimated: `5180`
 		// Minimum execution time: 20_089 nanoseconds.
-		Weight::from_ref_time(20_583_000)
-			.saturating_add(Weight::from_proof_size(5180))
+		Weight::from_parts(20_583_000, 0)
+			.saturating_add(Weight::from_parts(0, 5180))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(4))
 	}
@@ -264,8 +264,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `314`
 		//  Estimated: `2653`
 		// Minimum execution time: 13_647 nanoseconds.
-		Weight::from_ref_time(13_894_000)
-			.saturating_add(Weight::from_proof_size(2653))
+		Weight::from_parts(13_894_000, 0)
+			.saturating_add(Weight::from_parts(0, 2653))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -278,8 +278,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `314`
 		//  Estimated: `2653`
 		// Minimum execution time: 16_035 nanoseconds.
-		Weight::from_ref_time(16_232_000)
-			.saturating_add(Weight::from_proof_size(2653))
+		Weight::from_parts(16_232_000, 0)
+			.saturating_add(Weight::from_parts(0, 2653))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -294,8 +294,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `623`
 		//  Estimated: `7962`
 		// Minimum execution time: 33_357 nanoseconds.
-		Weight::from_ref_time(34_794_000)
-			.saturating_add(Weight::from_proof_size(7962))
+		Weight::from_parts(34_794_000, 0)
+			.saturating_add(Weight::from_parts(0, 7962))
 			.saturating_add(T::DbWeight::get().reads(3))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -310,8 +310,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `851`
 		//  Estimated: `7962`
 		// Minimum execution time: 32_496 nanoseconds.
-		Weight::from_ref_time(33_068_000)
-			.saturating_add(Weight::from_proof_size(7962))
+		Weight::from_parts(33_068_000, 0)
+			.saturating_add(Weight::from_parts(0, 7962))
 			.saturating_add(T::DbWeight::get().reads(3))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -324,8 +324,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `380`
 		//  Estimated: `5315`
 		// Minimum execution time: 25_557 nanoseconds.
-		Weight::from_ref_time(25_923_000)
-			.saturating_add(Weight::from_proof_size(5315))
+		Weight::from_parts(25_923_000, 0)
+			.saturating_add(Weight::from_parts(0, 5315))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -338,8 +338,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `623`
 		//  Estimated: `5315`
 		// Minimum execution time: 26_147 nanoseconds.
-		Weight::from_ref_time(26_386_000)
-			.saturating_add(Weight::from_proof_size(5315))
+		Weight::from_parts(26_386_000, 0)
+			.saturating_add(Weight::from_parts(0, 5315))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -352,8 +352,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `314`
 		//  Estimated: `5295`
 		// Minimum execution time: 25_233 nanoseconds.
-		Weight::from_ref_time(25_665_000)
-			.saturating_add(Weight::from_proof_size(5295))
+		Weight::from_parts(25_665_000, 0)
+			.saturating_add(Weight::from_parts(0, 5295))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -366,8 +366,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `537`
 		//  Estimated: `5295`
 		// Minimum execution time: 24_311 nanoseconds.
-		Weight::from_ref_time(24_544_000)
-			.saturating_add(Weight::from_proof_size(5295))
+		Weight::from_parts(24_544_000, 0)
+			.saturating_add(Weight::from_parts(0, 5295))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -380,8 +380,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `492`
 		//  Estimated: `5250`
 		// Minimum execution time: 18_197 nanoseconds.
-		Weight::from_ref_time(18_442_000)
-			.saturating_add(Weight::from_proof_size(5250))
+		Weight::from_parts(18_442_000, 0)
+			.saturating_add(Weight::from_parts(0, 5250))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -394,8 +394,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `525`
 		//  Estimated: `5250`
 		// Minimum execution time: 18_606 nanoseconds.
-		Weight::from_ref_time(19_032_000)
-			.saturating_add(Weight::from_proof_size(5250))
+		Weight::from_parts(19_032_000, 0)
+			.saturating_add(Weight::from_parts(0, 5250))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -406,8 +406,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `42`
 		//  Estimated: `2527`
 		// Minimum execution time: 14_902 nanoseconds.
-		Weight::from_ref_time(15_216_000)
-			.saturating_add(Weight::from_proof_size(2527))
+		Weight::from_parts(15_216_000, 0)
+			.saturating_add(Weight::from_parts(0, 2527))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -420,8 +420,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `314`
 		//  Estimated: `5152`
 		// Minimum execution time: 15_771 nanoseconds.
-		Weight::from_ref_time(16_013_000)
-			.saturating_add(Weight::from_proof_size(5152))
+		Weight::from_parts(16_013_000, 0)
+			.saturating_add(Weight::from_parts(0, 5152))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -434,8 +434,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `291`
 		//  Estimated: `2597`
 		// Minimum execution time: 15_703 nanoseconds.
-		Weight::from_ref_time(15_905_000)
-			.saturating_add(Weight::from_proof_size(2597))
+		Weight::from_parts(15_905_000, 0)
+			.saturating_add(Weight::from_parts(0, 2597))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -452,8 +452,8 @@ impl<T: frame_system::Config> pallet_uniques::WeightInfo for WeightInfo<T> {
 		//  Measured:  `636`
 		//  Estimated: `7814`
 		// Minimum execution time: 33_712 nanoseconds.
-		Weight::from_ref_time(34_365_000)
-			.saturating_add(Weight::from_proof_size(7814))
+		Weight::from_parts(34_365_000, 0)
+			.saturating_add(Weight::from_parts(0, 7814))
 			.saturating_add(T::DbWeight::get().reads(3))
 			.saturating_add(T::DbWeight::get().writes(4))
 	}

--- a/parachains/runtimes/assets/westmint/src/weights/pallet_utility.rs
+++ b/parachains/runtimes/assets/westmint/src/weights/pallet_utility.rs
@@ -53,18 +53,18 @@ impl<T: frame_system::Config> pallet_utility::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 6_171 nanoseconds.
-		Weight::from_ref_time(14_264_475)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(14_264_475, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			// Standard Error: 3_826
-			.saturating_add(Weight::from_ref_time(4_102_412).saturating_mul(c.into()))
+			.saturating_add(Weight::from_parts(4_102_412, 0).saturating_mul(c.into()))
 	}
 	fn as_derivative() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 4_750 nanoseconds.
-		Weight::from_ref_time(4_872_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(4_872_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 	}
 	/// The range of component `c` is `[0, 1000]`.
 	fn batch_all(c: u32, ) -> Weight {
@@ -72,18 +72,18 @@ impl<T: frame_system::Config> pallet_utility::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 6_448 nanoseconds.
-		Weight::from_ref_time(20_274_161)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(20_274_161, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			// Standard Error: 4_587
-			.saturating_add(Weight::from_ref_time(4_321_327).saturating_mul(c.into()))
+			.saturating_add(Weight::from_parts(4_321_327, 0).saturating_mul(c.into()))
 	}
 	fn dispatch_as() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 8_092 nanoseconds.
-		Weight::from_ref_time(8_417_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(8_417_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 	}
 	/// The range of component `c` is `[0, 1000]`.
 	fn force_batch(c: u32, ) -> Weight {
@@ -91,9 +91,9 @@ impl<T: frame_system::Config> pallet_utility::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 6_410 nanoseconds.
-		Weight::from_ref_time(19_538_670)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(19_538_670, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			// Standard Error: 4_387
-			.saturating_add(Weight::from_ref_time(4_098_456).saturating_mul(c.into()))
+			.saturating_add(Weight::from_parts(4_098_456, 0).saturating_mul(c.into()))
 	}
 }

--- a/parachains/runtimes/assets/westmint/src/weights/pallet_xcm.rs
+++ b/parachains/runtimes/assets/westmint/src/weights/pallet_xcm.rs
@@ -62,8 +62,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `75`
 		//  Estimated: `4830`
 		// Minimum execution time: 26_692 nanoseconds.
-		Weight::from_ref_time(27_382_000)
-			.saturating_add(Weight::from_proof_size(4830))
+		Weight::from_parts(27_382_000, 0)
+			.saturating_add(Weight::from_parts(0, 4830))
 			.saturating_add(T::DbWeight::get().reads(5))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -74,8 +74,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `499`
 		// Minimum execution time: 22_056 nanoseconds.
-		Weight::from_ref_time(22_401_000)
-			.saturating_add(Weight::from_proof_size(499))
+		Weight::from_parts(22_401_000, 0)
+			.saturating_add(Weight::from_parts(0, 499))
 			.saturating_add(T::DbWeight::get().reads(1))
 	}
 	/// Storage: ParachainInfo ParachainId (r:1 w:0)
@@ -85,8 +85,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `499`
 		// Minimum execution time: 16_901 nanoseconds.
-		Weight::from_ref_time(17_262_000)
-			.saturating_add(Weight::from_proof_size(499))
+		Weight::from_parts(17_262_000, 0)
+			.saturating_add(Weight::from_parts(0, 499))
 			.saturating_add(T::DbWeight::get().reads(1))
 	}
 	fn execute() -> Weight {
@@ -94,8 +94,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 8_467 nanoseconds.
-		Weight::from_ref_time(8_708_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(8_708_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 	}
 	/// Storage: PolkadotXcm SupportedVersion (r:0 w:1)
 	/// Proof Skipped: PolkadotXcm SupportedVersion (max_values: None, max_size: None, mode: Measured)
@@ -104,8 +104,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 8_532 nanoseconds.
-		Weight::from_ref_time(8_766_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(8_766_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
 	/// Storage: PolkadotXcm SafeXcmVersion (r:0 w:1)
@@ -115,8 +115,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 2_399 nanoseconds.
-		Weight::from_ref_time(2_586_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(2_586_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
 	/// Storage: PolkadotXcm VersionNotifiers (r:1 w:1)
@@ -140,8 +140,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `75`
 		//  Estimated: `8025`
 		// Minimum execution time: 30_956 nanoseconds.
-		Weight::from_ref_time(31_602_000)
-			.saturating_add(Weight::from_proof_size(8025))
+		Weight::from_parts(31_602_000, 0)
+			.saturating_add(Weight::from_parts(0, 8025))
 			.saturating_add(T::DbWeight::get().reads(7))
 			.saturating_add(T::DbWeight::get().writes(5))
 	}
@@ -164,8 +164,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `257`
 		//  Estimated: `8729`
 		// Minimum execution time: 33_283 nanoseconds.
-		Weight::from_ref_time(34_433_000)
-			.saturating_add(Weight::from_proof_size(8729))
+		Weight::from_parts(34_433_000, 0)
+			.saturating_add(Weight::from_parts(0, 8729))
 			.saturating_add(T::DbWeight::get().reads(6))
 			.saturating_add(T::DbWeight::get().writes(4))
 	}
@@ -176,8 +176,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `129`
 		//  Estimated: `10029`
 		// Minimum execution time: 17_349 nanoseconds.
-		Weight::from_ref_time(18_701_000)
-			.saturating_add(Weight::from_proof_size(10029))
+		Weight::from_parts(18_701_000, 0)
+			.saturating_add(Weight::from_parts(0, 10029))
 			.saturating_add(T::DbWeight::get().reads(4))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -188,8 +188,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `133`
 		//  Estimated: `10033`
 		// Minimum execution time: 18_574 nanoseconds.
-		Weight::from_ref_time(19_071_000)
-			.saturating_add(Weight::from_proof_size(10033))
+		Weight::from_parts(19_071_000, 0)
+			.saturating_add(Weight::from_parts(0, 10033))
 			.saturating_add(T::DbWeight::get().reads(4))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -200,8 +200,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `140`
 		//  Estimated: `12515`
 		// Minimum execution time: 22_520 nanoseconds.
-		Weight::from_ref_time(23_083_000)
-			.saturating_add(Weight::from_proof_size(12515))
+		Weight::from_parts(23_083_000, 0)
+			.saturating_add(Weight::from_parts(0, 12515))
 			.saturating_add(T::DbWeight::get().reads(5))
 	}
 	/// Storage: PolkadotXcm VersionNotifyTargets (r:2 w:1)
@@ -221,8 +221,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `142`
 		//  Estimated: `10257`
 		// Minimum execution time: 39_510 nanoseconds.
-		Weight::from_ref_time(40_272_000)
-			.saturating_add(Weight::from_proof_size(10257))
+		Weight::from_parts(40_272_000, 0)
+			.saturating_add(Weight::from_parts(0, 10257))
 			.saturating_add(T::DbWeight::get().reads(7))
 			.saturating_add(T::DbWeight::get().writes(3))
 	}
@@ -233,8 +233,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `172`
 		//  Estimated: `7597`
 		// Minimum execution time: 11_057 nanoseconds.
-		Weight::from_ref_time(11_408_000)
-			.saturating_add(Weight::from_proof_size(7597))
+		Weight::from_parts(11_408_000, 0)
+			.saturating_add(Weight::from_parts(0, 7597))
 			.saturating_add(T::DbWeight::get().reads(3))
 	}
 	/// Storage: PolkadotXcm VersionNotifyTargets (r:4 w:2)
@@ -244,8 +244,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `140`
 		//  Estimated: `10040`
 		// Minimum execution time: 22_914 nanoseconds.
-		Weight::from_ref_time(23_231_000)
-			.saturating_add(Weight::from_proof_size(10040))
+		Weight::from_parts(23_231_000, 0)
+			.saturating_add(Weight::from_parts(0, 10040))
 			.saturating_add(T::DbWeight::get().reads(4))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -266,8 +266,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `146`
 		//  Estimated: `15231`
 		// Minimum execution time: 47_637 nanoseconds.
-		Weight::from_ref_time(48_179_000)
-			.saturating_add(Weight::from_proof_size(15231))
+		Weight::from_parts(48_179_000, 0)
+			.saturating_add(Weight::from_parts(0, 15231))
 			.saturating_add(T::DbWeight::get().reads(9))
 			.saturating_add(T::DbWeight::get().writes(4))
 	}

--- a/parachains/runtimes/assets/westmint/src/weights/xcm/mod.rs
+++ b/parachains/runtimes/assets/westmint/src/weights/xcm/mod.rs
@@ -65,7 +65,7 @@ impl<Call> XcmWeightInfo<Call> for WestmintXcmWeight<Call> {
 	// Currently there is no trusted reserve
 	fn reserve_asset_deposited(_assets: &MultiAssets) -> Weight {
 		// TODO: hardcoded - fix https://github.com/paritytech/cumulus/issues/1974
-		Weight::from_ref_time(1_000_000_000 as u64)
+		Weight::from_parts(1_000_000_000 as u64, 0)
 	}
 	fn receive_teleported_asset(assets: &MultiAssets) -> Weight {
 		assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::receive_teleported_asset())
@@ -123,7 +123,7 @@ impl<Call> XcmWeightInfo<Call> for WestmintXcmWeight<Call> {
 
 	fn deposit_asset(assets: &MultiAssetFilter, _dest: &MultiLocation) -> Weight {
 		// Hardcoded till the XCM pallet is fixed
-		let hardcoded_weight = Weight::from_ref_time(1_000_000_000 as u64);
+		let hardcoded_weight = Weight::from_parts(1_000_000_000 as u64, 0);
 		let weight = assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::deposit_asset());
 		hardcoded_weight.min(weight)
 	}

--- a/parachains/runtimes/assets/westmint/src/weights/xcm/pallet_xcm_benchmarks_fungible.rs
+++ b/parachains/runtimes/assets/westmint/src/weights/xcm/pallet_xcm_benchmarks_fungible.rs
@@ -51,14 +51,14 @@ impl<T: frame_system::Config> WeightInfo<T> {
 	// Storage: System Account (r:1 w:1)
 	// Proof: System Account (max_values: None, max_size: Some(128), added: 2603, mode: MaxEncodedLen)
 	pub(crate) fn withdraw_asset() -> Weight {
-		Weight::from_ref_time(20_735_000 as u64)
+		Weight::from_parts(20_735_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: System Account (r:2 w:2)
 	// Proof: System Account (max_values: None, max_size: Some(128), added: 2603, mode: MaxEncodedLen)
 	pub(crate) fn transfer_asset() -> Weight {
-		Weight::from_ref_time(28_940_000 as u64)
+		Weight::from_parts(28_940_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
@@ -77,17 +77,17 @@ impl<T: frame_system::Config> WeightInfo<T> {
 	// Storage: ParachainSystem PendingUpwardMessages (r:1 w:1)
 	// Proof Skipped: ParachainSystem PendingUpwardMessages (max_values: Some(1), max_size: None, mode: Measured)
 	pub(crate) fn transfer_reserve_asset() -> Weight {
-		Weight::from_ref_time(50_175_000 as u64)
+		Weight::from_parts(50_175_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(8 as u64))
 			.saturating_add(T::DbWeight::get().writes(4 as u64))
 	}
 	pub(crate) fn receive_teleported_asset() -> Weight {
-		Weight::from_ref_time(4_059_000 as u64)
+		Weight::from_parts(4_059_000 as u64, 0)
 	}
 	// Storage: System Account (r:1 w:1)
 	// Proof: System Account (max_values: None, max_size: Some(128), added: 2603, mode: MaxEncodedLen)
 	pub(crate) fn deposit_asset() -> Weight {
-		Weight::from_ref_time(22_181_000 as u64)
+		Weight::from_parts(22_181_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
@@ -106,7 +106,7 @@ impl<T: frame_system::Config> WeightInfo<T> {
 	// Storage: ParachainSystem PendingUpwardMessages (r:1 w:1)
 	// Proof Skipped: ParachainSystem PendingUpwardMessages (max_values: Some(1), max_size: None, mode: Measured)
 	pub(crate) fn deposit_reserve_asset() -> Weight {
-		Weight::from_ref_time(45_905_000 as u64)
+		Weight::from_parts(45_905_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(7 as u64))
 			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
@@ -123,7 +123,7 @@ impl<T: frame_system::Config> WeightInfo<T> {
 	// Storage: ParachainSystem PendingUpwardMessages (r:1 w:1)
 	// Proof Skipped: ParachainSystem PendingUpwardMessages (max_values: Some(1), max_size: None, mode: Measured)
 	pub(crate) fn initiate_teleport() -> Weight {
-		Weight::from_ref_time(29_820_000 as u64)
+		Weight::from_parts(29_820_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(6 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}

--- a/parachains/runtimes/assets/westmint/src/weights/xcm/pallet_xcm_benchmarks_generic.rs
+++ b/parachains/runtimes/assets/westmint/src/weights/xcm/pallet_xcm_benchmarks_generic.rs
@@ -61,39 +61,39 @@ impl<T: frame_system::Config> WeightInfo<T> {
 	// Storage: ParachainSystem PendingUpwardMessages (r:1 w:1)
 	// Proof Skipped: ParachainSystem PendingUpwardMessages (max_values: Some(1), max_size: None, mode: Measured)
 	pub(crate) fn report_holding() -> Weight {
-		Weight::from_ref_time(360_208_000 as u64)
+		Weight::from_parts(360_208_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(6 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	pub(crate) fn buy_execution() -> Weight {
-		Weight::from_ref_time(3_876_000 as u64)
+		Weight::from_parts(3_876_000 as u64, 0)
 	}
 	// Storage: PolkadotXcm Queries (r:1 w:0)
 	// Proof Skipped: PolkadotXcm Queries (max_values: None, max_size: None, mode: Measured)
 	pub(crate) fn query_response() -> Weight {
-		Weight::from_ref_time(11_240_000 as u64)
+		Weight::from_parts(11_240_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 	}
 	pub(crate) fn transact() -> Weight {
-		Weight::from_ref_time(12_244_000 as u64)
+		Weight::from_parts(12_244_000 as u64, 0)
 	}
 	pub(crate) fn refund_surplus() -> Weight {
-		Weight::from_ref_time(3_963_000 as u64)
+		Weight::from_parts(3_963_000 as u64, 0)
 	}
 	pub(crate) fn set_error_handler() -> Weight {
-		Weight::from_ref_time(2_871_000 as u64)
+		Weight::from_parts(2_871_000 as u64, 0)
 	}
 	pub(crate) fn set_appendix() -> Weight {
-		Weight::from_ref_time(2_805_000 as u64)
+		Weight::from_parts(2_805_000 as u64, 0)
 	}
 	pub(crate) fn clear_error() -> Weight {
-		Weight::from_ref_time(2_759_000 as u64)
+		Weight::from_parts(2_759_000 as u64, 0)
 	}
 	pub(crate) fn descend_origin() -> Weight {
-		Weight::from_ref_time(3_596_000 as u64)
+		Weight::from_parts(3_596_000 as u64, 0)
 	}
 	pub(crate) fn clear_origin() -> Weight {
-		Weight::from_ref_time(2_750_000 as u64)
+		Weight::from_parts(2_750_000 as u64, 0)
 	}
 	// Storage: ParachainInfo ParachainId (r:1 w:0)
 	// Proof: ParachainInfo ParachainId (max_values: Some(1), max_size: Some(4), added: 499, mode: MaxEncodedLen)
@@ -108,19 +108,19 @@ impl<T: frame_system::Config> WeightInfo<T> {
 	// Storage: ParachainSystem PendingUpwardMessages (r:1 w:1)
 	// Proof Skipped: ParachainSystem PendingUpwardMessages (max_values: Some(1), max_size: None, mode: Measured)
 	pub(crate) fn report_error() -> Weight {
-		Weight::from_ref_time(24_921_000 as u64)
+		Weight::from_parts(24_921_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(6 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: PolkadotXcm AssetTraps (r:1 w:1)
 	// Proof Skipped: PolkadotXcm AssetTraps (max_values: None, max_size: None, mode: Measured)
 	pub(crate) fn claim_asset() -> Weight {
-		Weight::from_ref_time(15_880_000 as u64)
+		Weight::from_parts(15_880_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	pub(crate) fn trap() -> Weight {
-		Weight::from_ref_time(2_771_000 as u64)
+		Weight::from_parts(2_771_000 as u64, 0)
 	}
 	// Storage: PolkadotXcm VersionNotifyTargets (r:1 w:1)
 	// Proof Skipped: PolkadotXcm VersionNotifyTargets (max_values: None, max_size: None, mode: Measured)
@@ -135,14 +135,14 @@ impl<T: frame_system::Config> WeightInfo<T> {
 	// Storage: ParachainSystem PendingUpwardMessages (r:1 w:1)
 	// Proof Skipped: ParachainSystem PendingUpwardMessages (max_values: Some(1), max_size: None, mode: Measured)
 	pub(crate) fn subscribe_version() -> Weight {
-		Weight::from_ref_time(27_043_000 as u64)
+		Weight::from_parts(27_043_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(6 as u64))
 			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: PolkadotXcm VersionNotifyTargets (r:0 w:1)
 	// Proof Skipped: PolkadotXcm VersionNotifyTargets (max_values: None, max_size: None, mode: Measured)
 	pub(crate) fn unsubscribe_version() -> Weight {
-		Weight::from_ref_time(4_668_000 as u64)
+		Weight::from_parts(4_668_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: ParachainInfo ParachainId (r:1 w:0)
@@ -158,24 +158,24 @@ impl<T: frame_system::Config> WeightInfo<T> {
 	// Storage: ParachainSystem PendingUpwardMessages (r:1 w:1)
 	// Proof Skipped: ParachainSystem PendingUpwardMessages (max_values: Some(1), max_size: None, mode: Measured)
 	pub(crate) fn initiate_reserve_withdraw() -> Weight {
-		Weight::from_ref_time(399_081_000 as u64)
+		Weight::from_parts(399_081_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(6 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	pub(crate) fn burn_asset() -> Weight {
-		Weight::from_ref_time(123_792_000 as u64)
+		Weight::from_parts(123_792_000 as u64, 0)
 	}
 	pub(crate) fn expect_asset() -> Weight {
-		Weight::from_ref_time(13_056_000 as u64)
+		Weight::from_parts(13_056_000 as u64, 0)
 	}
 	pub(crate) fn expect_origin() -> Weight {
-		Weight::from_ref_time(2_780_000 as u64)
+		Weight::from_parts(2_780_000 as u64, 0)
 	}
 	pub(crate) fn expect_error() -> Weight {
-		Weight::from_ref_time(2_839_000 as u64)
+		Weight::from_parts(2_839_000 as u64, 0)
 	}
 	pub(crate) fn expect_transact_status() -> Weight {
-		Weight::from_ref_time(2_951_000 as u64)
+		Weight::from_parts(2_951_000 as u64, 0)
 	}
 	// Storage: ParachainInfo ParachainId (r:1 w:0)
 	// Proof: ParachainInfo ParachainId (max_values: Some(1), max_size: Some(4), added: 499, mode: MaxEncodedLen)
@@ -190,12 +190,12 @@ impl<T: frame_system::Config> WeightInfo<T> {
 	// Storage: ParachainSystem PendingUpwardMessages (r:1 w:1)
 	// Proof Skipped: ParachainSystem PendingUpwardMessages (max_values: Some(1), max_size: None, mode: Measured)
 	pub(crate) fn query_pallet() -> Weight {
-		Weight::from_ref_time(28_130_000 as u64)
+		Weight::from_parts(28_130_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(6 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	pub(crate) fn expect_pallet() -> Weight {
-		Weight::from_ref_time(4_754_000 as u64)
+		Weight::from_parts(4_754_000 as u64, 0)
 	}
 	// Storage: ParachainInfo ParachainId (r:1 w:0)
 	// Proof: ParachainInfo ParachainId (max_values: Some(1), max_size: Some(4), added: 499, mode: MaxEncodedLen)
@@ -210,23 +210,23 @@ impl<T: frame_system::Config> WeightInfo<T> {
 	// Storage: ParachainSystem PendingUpwardMessages (r:1 w:1)
 	// Proof Skipped: ParachainSystem PendingUpwardMessages (max_values: Some(1), max_size: None, mode: Measured)
 	pub(crate) fn report_transact_status() -> Weight {
-		Weight::from_ref_time(25_584_000 as u64)
+		Weight::from_parts(25_584_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(6 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	pub(crate) fn clear_transact_status() -> Weight {
-		Weight::from_ref_time(2_832_000 as u64)
+		Weight::from_parts(2_832_000 as u64, 0)
 	}
 	pub(crate) fn set_topic() -> Weight {
-		Weight::from_ref_time(2_804_000 as u64)
+		Weight::from_parts(2_804_000 as u64, 0)
 	}
 	pub(crate) fn clear_topic() -> Weight {
-		Weight::from_ref_time(2_747_000 as u64)
+		Weight::from_parts(2_747_000 as u64, 0)
 	}
 	pub(crate) fn set_fees_mode() -> Weight {
-		Weight::from_ref_time(2_736_000 as u64)
+		Weight::from_parts(2_736_000 as u64, 0)
 	}
 	pub(crate) fn unpaid_execution() -> Weight {
-		Weight::from_ref_time(2_969_000 as u64)
+		Weight::from_parts(2_969_000 as u64, 0)
 	}
 }

--- a/parachains/runtimes/assets/westmint/tests/tests.rs
+++ b/parachains/runtimes/assets/westmint/tests/tests.rs
@@ -63,7 +63,7 @@ fn test_asset_xcm_trader() {
 			RuntimeHelper::<Runtime>::run_to_block(2, Some(AccountId::from(ALICE)));
 
 			// We are going to buy 4e9 weight
-			let bought = Weight::from_ref_time(4_000_000_000u64);
+			let bought = Weight::from_parts(4_000_000_000u64, 0);
 
 			// Lets calculate amount needed
 			let asset_amount_needed =
@@ -139,7 +139,7 @@ fn test_asset_xcm_trader_with_refund() {
 			RuntimeHelper::<Runtime>::run_to_block(2, Some(AccountId::from(ALICE)));
 
 			// We are going to buy 4e9 weight
-			let bought = Weight::from_ref_time(4_000_000_000u64);
+			let bought = Weight::from_parts(4_000_000_000u64, 0);
 			let asset_multilocation = MultiLocation::new(
 				0,
 				X2(
@@ -216,7 +216,7 @@ fn test_asset_xcm_trader_refund_not_possible_since_amount_less_than_ed() {
 			RuntimeHelper::<Runtime>::run_to_block(2, Some(AccountId::from(ALICE)));
 
 			// We are going to buy 5e9 weight
-			let bought = Weight::from_ref_time(500_000_000u64);
+			let bought = Weight::from_parts(500_000_000u64, 0);
 
 			let asset_multilocation = MultiLocation::new(
 				0,
@@ -275,7 +275,7 @@ fn test_that_buying_ed_refund_does_not_refund() {
 			// Set Alice as block author, who will receive fees
 			RuntimeHelper::<Runtime>::run_to_block(2, Some(AccountId::from(ALICE)));
 
-			let bought = Weight::from_ref_time(500_000_000u64);
+			let bought = Weight::from_parts(500_000_000u64, 0);
 
 			let asset_multilocation = MultiLocation::new(
 				0,
@@ -356,7 +356,7 @@ fn test_asset_xcm_trader_not_possible_for_non_sufficient_assets() {
 			RuntimeHelper::<Runtime>::run_to_block(2, Some(AccountId::from(ALICE)));
 
 			// We are going to buy 4e9 weight
-			let bought = Weight::from_ref_time(4_000_000_000u64);
+			let bought = Weight::from_parts(4_000_000_000u64, 0);
 
 			// lets calculate amount needed
 			let asset_amount_needed = WeightToFee::weight_to_fee(&bought);

--- a/parachains/runtimes/bridge-hubs/bridge-hub-kusama/src/weights/block_weights.rs
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-kusama/src/weights/block_weights.rs
@@ -24,7 +24,7 @@ pub mod constants {
 	parameter_types! {
 		/// Importing a block with 0 Extrinsics.
 		pub const BlockExecutionWeight: Weight =
-			Weight::from_ref_time(constants::WEIGHT_REF_TIME_PER_NANOS.saturating_mul(5_000_000));
+			Weight::from_parts(constants::WEIGHT_REF_TIME_PER_NANOS.saturating_mul(5_000_000), 0);
 	}
 
 	#[cfg(test)]

--- a/parachains/runtimes/bridge-hubs/bridge-hub-kusama/src/weights/cumulus_pallet_xcmp_queue.rs
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-kusama/src/weights/cumulus_pallet_xcmp_queue.rs
@@ -54,8 +54,8 @@ impl<T: frame_system::Config> cumulus_pallet_xcmp_queue::WeightInfo for WeightIn
 		//  Measured:  `76`
 		//  Estimated: `571`
 		// Minimum execution time: 4_956 nanoseconds.
-		Weight::from_ref_time(5_247_000)
-			.saturating_add(Weight::from_proof_size(571))
+		Weight::from_parts(5_247_000, 0)
+			.saturating_add(Weight::from_parts(0, 571))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -66,8 +66,8 @@ impl<T: frame_system::Config> cumulus_pallet_xcmp_queue::WeightInfo for WeightIn
 		//  Measured:  `76`
 		//  Estimated: `571`
 		// Minimum execution time: 4_875 nanoseconds.
-		Weight::from_ref_time(5_123_000)
-			.saturating_add(Weight::from_proof_size(571))
+		Weight::from_parts(5_123_000, 0)
+			.saturating_add(Weight::from_parts(0, 571))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}

--- a/parachains/runtimes/bridge-hubs/bridge-hub-kusama/src/weights/extrinsic_weights.rs
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-kusama/src/weights/extrinsic_weights.rs
@@ -24,7 +24,7 @@ pub mod constants {
 	parameter_types! {
 		/// Executing a NO-OP `System::remarks` Extrinsic.
 		pub const ExtrinsicBaseWeight: Weight =
-			Weight::from_ref_time(constants::WEIGHT_REF_TIME_PER_NANOS.saturating_mul(125_000));
+			Weight::from_parts(constants::WEIGHT_REF_TIME_PER_NANOS.saturating_mul(125_000), 0);
 	}
 
 	#[cfg(test)]

--- a/parachains/runtimes/bridge-hubs/bridge-hub-kusama/src/weights/frame_system.rs
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-kusama/src/weights/frame_system.rs
@@ -53,10 +53,10 @@ impl<T: frame_system::Config> frame_system::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 1_541 nanoseconds.
-		Weight::from_ref_time(1_600_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(1_600_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			// Standard Error: 0
-			.saturating_add(Weight::from_ref_time(368).saturating_mul(b.into()))
+			.saturating_add(Weight::from_parts(368, 0).saturating_mul(b.into()))
 	}
 	/// The range of component `b` is `[0, 3932160]`.
 	fn remark_with_event(b: u32, ) -> Weight {
@@ -64,10 +64,10 @@ impl<T: frame_system::Config> frame_system::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 6_433 nanoseconds.
-		Weight::from_ref_time(6_528_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(6_528_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			// Standard Error: 0
-			.saturating_add(Weight::from_ref_time(1_718).saturating_mul(b.into()))
+			.saturating_add(Weight::from_parts(1_718, 0).saturating_mul(b.into()))
 	}
 	/// Storage: System Digest (r:1 w:1)
 	/// Proof Skipped: System Digest (max_values: Some(1), max_size: None, mode: Measured)
@@ -78,8 +78,8 @@ impl<T: frame_system::Config> frame_system::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `495`
 		// Minimum execution time: 3_378 nanoseconds.
-		Weight::from_ref_time(3_546_000)
-			.saturating_add(Weight::from_proof_size(495))
+		Weight::from_parts(3_546_000, 0)
+			.saturating_add(Weight::from_parts(0, 495))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -91,10 +91,10 @@ impl<T: frame_system::Config> frame_system::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 1_595 nanoseconds.
-		Weight::from_ref_time(1_637_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(1_637_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			// Standard Error: 1_677
-			.saturating_add(Weight::from_ref_time(581_830).saturating_mul(i.into()))
+			.saturating_add(Weight::from_parts(581_830, 0).saturating_mul(i.into()))
 			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(i.into())))
 	}
 	/// Storage: Skipped Metadata (r:0 w:0)
@@ -105,10 +105,10 @@ impl<T: frame_system::Config> frame_system::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 1_602 nanoseconds.
-		Weight::from_ref_time(1_645_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(1_645_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			// Standard Error: 808
-			.saturating_add(Weight::from_ref_time(448_210).saturating_mul(i.into()))
+			.saturating_add(Weight::from_parts(448_210, 0).saturating_mul(i.into()))
 			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(i.into())))
 	}
 	/// Storage: Skipped Metadata (r:0 w:0)
@@ -119,11 +119,11 @@ impl<T: frame_system::Config> frame_system::WeightInfo for WeightInfo<T> {
 		//  Measured:  `68 + p * (69 ±0)`
 		//  Estimated: `66 + p * (70 ±0)`
 		// Minimum execution time: 3_400 nanoseconds.
-		Weight::from_ref_time(3_518_000)
-			.saturating_add(Weight::from_proof_size(66))
+		Weight::from_parts(3_518_000, 0)
+			.saturating_add(Weight::from_parts(0, 66))
 			// Standard Error: 949
-			.saturating_add(Weight::from_ref_time(952_748).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(952_748, 0).saturating_mul(p.into()))
 			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(p.into())))
-			.saturating_add(Weight::from_proof_size(70).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(0, 70).saturating_mul(p.into()))
 	}
 }

--- a/parachains/runtimes/bridge-hubs/bridge-hub-kusama/src/weights/pallet_balances.rs
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-kusama/src/weights/pallet_balances.rs
@@ -54,8 +54,8 @@ impl<T: frame_system::Config> pallet_balances::WeightInfo for WeightInfo<T> {
 		//  Measured:  `1314`
 		//  Estimated: `2603`
 		// Minimum execution time: 45_555 nanoseconds.
-		Weight::from_ref_time(46_097_000)
-			.saturating_add(Weight::from_proof_size(2603))
+		Weight::from_parts(46_097_000, 0)
+			.saturating_add(Weight::from_parts(0, 2603))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -66,8 +66,8 @@ impl<T: frame_system::Config> pallet_balances::WeightInfo for WeightInfo<T> {
 		//  Measured:  `1198`
 		//  Estimated: `2603`
 		// Minimum execution time: 34_465 nanoseconds.
-		Weight::from_ref_time(35_054_000)
-			.saturating_add(Weight::from_proof_size(2603))
+		Weight::from_parts(35_054_000, 0)
+			.saturating_add(Weight::from_parts(0, 2603))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -78,8 +78,8 @@ impl<T: frame_system::Config> pallet_balances::WeightInfo for WeightInfo<T> {
 		//  Measured:  `1348`
 		//  Estimated: `2603`
 		// Minimum execution time: 25_670 nanoseconds.
-		Weight::from_ref_time(26_254_000)
-			.saturating_add(Weight::from_proof_size(2603))
+		Weight::from_parts(26_254_000, 0)
+			.saturating_add(Weight::from_parts(0, 2603))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -90,8 +90,8 @@ impl<T: frame_system::Config> pallet_balances::WeightInfo for WeightInfo<T> {
 		//  Measured:  `1348`
 		//  Estimated: `2603`
 		// Minimum execution time: 28_919 nanoseconds.
-		Weight::from_ref_time(29_611_000)
-			.saturating_add(Weight::from_proof_size(2603))
+		Weight::from_parts(29_611_000, 0)
+			.saturating_add(Weight::from_parts(0, 2603))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -102,8 +102,8 @@ impl<T: frame_system::Config> pallet_balances::WeightInfo for WeightInfo<T> {
 		//  Measured:  `1310`
 		//  Estimated: `5206`
 		// Minimum execution time: 44_604 nanoseconds.
-		Weight::from_ref_time(45_498_000)
-			.saturating_add(Weight::from_proof_size(5206))
+		Weight::from_parts(45_498_000, 0)
+			.saturating_add(Weight::from_parts(0, 5206))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -114,8 +114,8 @@ impl<T: frame_system::Config> pallet_balances::WeightInfo for WeightInfo<T> {
 		//  Measured:  `1198`
 		//  Estimated: `2603`
 		// Minimum execution time: 39_412 nanoseconds.
-		Weight::from_ref_time(40_181_000)
-			.saturating_add(Weight::from_proof_size(2603))
+		Weight::from_parts(40_181_000, 0)
+			.saturating_add(Weight::from_parts(0, 2603))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -126,8 +126,8 @@ impl<T: frame_system::Config> pallet_balances::WeightInfo for WeightInfo<T> {
 		//  Measured:  `1232`
 		//  Estimated: `2603`
 		// Minimum execution time: 22_520 nanoseconds.
-		Weight::from_ref_time(23_045_000)
-			.saturating_add(Weight::from_proof_size(2603))
+		Weight::from_parts(23_045_000, 0)
+			.saturating_add(Weight::from_parts(0, 2603))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}

--- a/parachains/runtimes/bridge-hubs/bridge-hub-kusama/src/weights/pallet_collator_selection.rs
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-kusama/src/weights/pallet_collator_selection.rs
@@ -57,13 +57,13 @@ impl<T: frame_system::Config> pallet_collator_selection::WeightInfo for WeightIn
 		//  Measured:  `214 + b * (78 ±0)`
 		//  Estimated: `213 + b * (2554 ±0)`
 		// Minimum execution time: 13_768 nanoseconds.
-		Weight::from_ref_time(15_128_018)
-			.saturating_add(Weight::from_proof_size(213))
+		Weight::from_parts(15_128_018, 0)
+			.saturating_add(Weight::from_parts(0, 213))
 			// Standard Error: 3_110
-			.saturating_add(Weight::from_ref_time(2_490_861).saturating_mul(b.into()))
+			.saturating_add(Weight::from_parts(2_490_861, 0).saturating_mul(b.into()))
 			.saturating_add(T::DbWeight::get().reads((1_u64).saturating_mul(b.into())))
 			.saturating_add(T::DbWeight::get().writes(1))
-			.saturating_add(Weight::from_proof_size(2554).saturating_mul(b.into()))
+			.saturating_add(Weight::from_parts(0, 2554).saturating_mul(b.into()))
 	}
 	/// Storage: CollatorSelection DesiredCandidates (r:0 w:1)
 	/// Proof: CollatorSelection DesiredCandidates (max_values: Some(1), max_size: Some(4), added: 499, mode: MaxEncodedLen)
@@ -72,8 +72,8 @@ impl<T: frame_system::Config> pallet_collator_selection::WeightInfo for WeightIn
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 6_359 nanoseconds.
-		Weight::from_ref_time(6_591_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(6_591_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
 	/// Storage: CollatorSelection CandidacyBond (r:0 w:1)
@@ -83,8 +83,8 @@ impl<T: frame_system::Config> pallet_collator_selection::WeightInfo for WeightIn
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 6_722 nanoseconds.
-		Weight::from_ref_time(6_963_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(6_963_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
 	/// Storage: CollatorSelection Candidates (r:1 w:1)
@@ -105,13 +105,13 @@ impl<T: frame_system::Config> pallet_collator_selection::WeightInfo for WeightIn
 		//  Measured:  `1167 + c * (48 ±0)`
 		//  Estimated: `56785 + c * (49 ±0)`
 		// Minimum execution time: 35_190 nanoseconds.
-		Weight::from_ref_time(27_223_783)
-			.saturating_add(Weight::from_proof_size(56785))
+		Weight::from_parts(27_223_783, 0)
+			.saturating_add(Weight::from_parts(0, 56785))
 			// Standard Error: 1_270
-			.saturating_add(Weight::from_ref_time(103_824).saturating_mul(c.into()))
+			.saturating_add(Weight::from_parts(103_824, 0).saturating_mul(c.into()))
 			.saturating_add(T::DbWeight::get().reads(5))
 			.saturating_add(T::DbWeight::get().writes(2))
-			.saturating_add(Weight::from_proof_size(49).saturating_mul(c.into()))
+			.saturating_add(Weight::from_parts(0, 49).saturating_mul(c.into()))
 	}
 	/// Storage: CollatorSelection Candidates (r:1 w:1)
 	/// Proof: CollatorSelection Candidates (max_values: Some(1), max_size: Some(48002), added: 48497, mode: MaxEncodedLen)
@@ -123,10 +123,10 @@ impl<T: frame_system::Config> pallet_collator_selection::WeightInfo for WeightIn
 		//  Measured:  `503 + c * (48 ±0)`
 		//  Estimated: `48497`
 		// Minimum execution time: 26_271 nanoseconds.
-		Weight::from_ref_time(16_336_190)
-			.saturating_add(Weight::from_proof_size(48497))
+		Weight::from_parts(16_336_190, 0)
+			.saturating_add(Weight::from_parts(0, 48497))
 			// Standard Error: 1_250
-			.saturating_add(Weight::from_ref_time(105_123).saturating_mul(c.into()))
+			.saturating_add(Weight::from_parts(105_123, 0).saturating_mul(c.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -141,8 +141,8 @@ impl<T: frame_system::Config> pallet_collator_selection::WeightInfo for WeightIn
 		//  Measured:  `187`
 		//  Estimated: `5749`
 		// Minimum execution time: 26_583 nanoseconds.
-		Weight::from_ref_time(26_888_000)
-			.saturating_add(Weight::from_proof_size(5749))
+		Weight::from_parts(26_888_000, 0)
+			.saturating_add(Weight::from_parts(0, 5749))
 			.saturating_add(T::DbWeight::get().reads(3))
 			.saturating_add(T::DbWeight::get().writes(4))
 	}
@@ -163,15 +163,15 @@ impl<T: frame_system::Config> pallet_collator_selection::WeightInfo for WeightIn
 		//  Measured:  `22878 + r * (148 ±0) + c * (97 ±0)`
 		//  Estimated: `52737 + c * (2519 ±0) + r * (2602 ±0)`
 		// Minimum execution time: 16_250 nanoseconds.
-		Weight::from_ref_time(16_601_000)
-			.saturating_add(Weight::from_proof_size(52737))
+		Weight::from_parts(16_601_000, 0)
+			.saturating_add(Weight::from_parts(0, 52737))
 			// Standard Error: 763_853
-			.saturating_add(Weight::from_ref_time(27_869_355).saturating_mul(c.into()))
+			.saturating_add(Weight::from_parts(27_869_355, 0).saturating_mul(c.into()))
 			.saturating_add(T::DbWeight::get().reads(4))
 			.saturating_add(T::DbWeight::get().reads((1_u64).saturating_mul(c.into())))
 			.saturating_add(T::DbWeight::get().writes(1))
 			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(c.into())))
-			.saturating_add(Weight::from_proof_size(2519).saturating_mul(c.into()))
-			.saturating_add(Weight::from_proof_size(2602).saturating_mul(r.into()))
+			.saturating_add(Weight::from_parts(0, 2519).saturating_mul(c.into()))
+			.saturating_add(Weight::from_parts(0, 2602).saturating_mul(r.into()))
 	}
 }

--- a/parachains/runtimes/bridge-hubs/bridge-hub-kusama/src/weights/pallet_multisig.rs
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-kusama/src/weights/pallet_multisig.rs
@@ -53,10 +53,10 @@ impl<T: frame_system::Config> pallet_multisig::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 12_039 nanoseconds.
-		Weight::from_ref_time(12_378_049)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(12_378_049, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			// Standard Error: 1
-			.saturating_add(Weight::from_ref_time(485).saturating_mul(z.into()))
+			.saturating_add(Weight::from_parts(485, 0).saturating_mul(z.into()))
 	}
 	/// Storage: Multisig Multisigs (r:1 w:1)
 	/// Proof: Multisig Multisigs (max_values: None, max_size: Some(3346), added: 5821, mode: MaxEncodedLen)
@@ -67,12 +67,12 @@ impl<T: frame_system::Config> pallet_multisig::WeightInfo for WeightInfo<T> {
 		//  Measured:  `314 + s * (2 ±0)`
 		//  Estimated: `5821`
 		// Minimum execution time: 35_309 nanoseconds.
-		Weight::from_ref_time(28_767_595)
-			.saturating_add(Weight::from_proof_size(5821))
+		Weight::from_parts(28_767_595, 0)
+			.saturating_add(Weight::from_parts(0, 5821))
 			// Standard Error: 572
-			.saturating_add(Weight::from_ref_time(73_429).saturating_mul(s.into()))
+			.saturating_add(Weight::from_parts(73_429, 0).saturating_mul(s.into()))
 			// Standard Error: 5
-			.saturating_add(Weight::from_ref_time(1_487).saturating_mul(z.into()))
+			.saturating_add(Weight::from_parts(1_487, 0).saturating_mul(z.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -85,12 +85,12 @@ impl<T: frame_system::Config> pallet_multisig::WeightInfo for WeightInfo<T> {
 		//  Measured:  `313`
 		//  Estimated: `5821`
 		// Minimum execution time: 26_191 nanoseconds.
-		Weight::from_ref_time(19_850_530)
-			.saturating_add(Weight::from_proof_size(5821))
+		Weight::from_parts(19_850_530, 0)
+			.saturating_add(Weight::from_parts(0, 5821))
 			// Standard Error: 440
-			.saturating_add(Weight::from_ref_time(68_426).saturating_mul(s.into()))
+			.saturating_add(Weight::from_parts(68_426, 0).saturating_mul(s.into()))
 			// Standard Error: 4
-			.saturating_add(Weight::from_ref_time(1_505).saturating_mul(z.into()))
+			.saturating_add(Weight::from_parts(1_505, 0).saturating_mul(z.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -105,12 +105,12 @@ impl<T: frame_system::Config> pallet_multisig::WeightInfo for WeightInfo<T> {
 		//  Measured:  `451 + s * (33 ±0)`
 		//  Estimated: `8424`
 		// Minimum execution time: 39_875 nanoseconds.
-		Weight::from_ref_time(32_057_678)
-			.saturating_add(Weight::from_proof_size(8424))
+		Weight::from_parts(32_057_678, 0)
+			.saturating_add(Weight::from_parts(0, 8424))
 			// Standard Error: 715
-			.saturating_add(Weight::from_ref_time(84_736).saturating_mul(s.into()))
+			.saturating_add(Weight::from_parts(84_736, 0).saturating_mul(s.into()))
 			// Standard Error: 7
-			.saturating_add(Weight::from_ref_time(1_511).saturating_mul(z.into()))
+			.saturating_add(Weight::from_parts(1_511, 0).saturating_mul(z.into()))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -122,10 +122,10 @@ impl<T: frame_system::Config> pallet_multisig::WeightInfo for WeightInfo<T> {
 		//  Measured:  `321 + s * (2 ±0)`
 		//  Estimated: `5821`
 		// Minimum execution time: 25_536 nanoseconds.
-		Weight::from_ref_time(27_146_180)
-			.saturating_add(Weight::from_proof_size(5821))
+		Weight::from_parts(27_146_180, 0)
+			.saturating_add(Weight::from_parts(0, 5821))
 			// Standard Error: 991
-			.saturating_add(Weight::from_ref_time(77_408).saturating_mul(s.into()))
+			.saturating_add(Weight::from_parts(77_408, 0).saturating_mul(s.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -137,10 +137,10 @@ impl<T: frame_system::Config> pallet_multisig::WeightInfo for WeightInfo<T> {
 		//  Measured:  `313`
 		//  Estimated: `5821`
 		// Minimum execution time: 17_409 nanoseconds.
-		Weight::from_ref_time(18_559_189)
-			.saturating_add(Weight::from_proof_size(5821))
+		Weight::from_parts(18_559_189, 0)
+			.saturating_add(Weight::from_parts(0, 5821))
 			// Standard Error: 518
-			.saturating_add(Weight::from_ref_time(72_083).saturating_mul(s.into()))
+			.saturating_add(Weight::from_parts(72_083, 0).saturating_mul(s.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -152,10 +152,10 @@ impl<T: frame_system::Config> pallet_multisig::WeightInfo for WeightInfo<T> {
 		//  Measured:  `517 + s * (1 ±0)`
 		//  Estimated: `5821`
 		// Minimum execution time: 26_502 nanoseconds.
-		Weight::from_ref_time(28_258_573)
-			.saturating_add(Weight::from_proof_size(5821))
+		Weight::from_parts(28_258_573, 0)
+			.saturating_add(Weight::from_parts(0, 5821))
 			// Standard Error: 819
-			.saturating_add(Weight::from_ref_time(78_480).saturating_mul(s.into()))
+			.saturating_add(Weight::from_parts(78_480, 0).saturating_mul(s.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}

--- a/parachains/runtimes/bridge-hubs/bridge-hub-kusama/src/weights/pallet_session.rs
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-kusama/src/weights/pallet_session.rs
@@ -56,8 +56,8 @@ impl<T: frame_system::Config> pallet_session::WeightInfo for WeightInfo<T> {
 		//  Measured:  `297`
 		//  Estimated: `5544`
 		// Minimum execution time: 15_673 nanoseconds.
-		Weight::from_ref_time(16_101_000)
-			.saturating_add(Weight::from_proof_size(5544))
+		Weight::from_parts(16_101_000, 0)
+			.saturating_add(Weight::from_parts(0, 5544))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -70,8 +70,8 @@ impl<T: frame_system::Config> pallet_session::WeightInfo for WeightInfo<T> {
 		//  Measured:  `279`
 		//  Estimated: `3033`
 		// Minimum execution time: 12_241 nanoseconds.
-		Weight::from_ref_time(12_552_000)
-			.saturating_add(Weight::from_proof_size(3033))
+		Weight::from_parts(12_552_000, 0)
+			.saturating_add(Weight::from_parts(0, 3033))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}

--- a/parachains/runtimes/bridge-hubs/bridge-hub-kusama/src/weights/pallet_timestamp.rs
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-kusama/src/weights/pallet_timestamp.rs
@@ -56,8 +56,8 @@ impl<T: frame_system::Config> pallet_timestamp::WeightInfo for WeightInfo<T> {
 		//  Measured:  `49`
 		//  Estimated: `1006`
 		// Minimum execution time: 7_105 nanoseconds.
-		Weight::from_ref_time(7_296_000)
-			.saturating_add(Weight::from_proof_size(1006))
+		Weight::from_parts(7_296_000, 0)
+			.saturating_add(Weight::from_parts(0, 1006))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -66,7 +66,7 @@ impl<T: frame_system::Config> pallet_timestamp::WeightInfo for WeightInfo<T> {
 		//  Measured:  `57`
 		//  Estimated: `0`
 		// Minimum execution time: 3_270 nanoseconds.
-		Weight::from_ref_time(3_398_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(3_398_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 	}
 }

--- a/parachains/runtimes/bridge-hubs/bridge-hub-kusama/src/weights/pallet_utility.rs
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-kusama/src/weights/pallet_utility.rs
@@ -53,18 +53,18 @@ impl<T: frame_system::Config> pallet_utility::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 5_752 nanoseconds.
-		Weight::from_ref_time(15_025_089)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(15_025_089, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			// Standard Error: 1_912
-			.saturating_add(Weight::from_ref_time(3_735_986).saturating_mul(c.into()))
+			.saturating_add(Weight::from_parts(3_735_986, 0).saturating_mul(c.into()))
 	}
 	fn as_derivative() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 4_237 nanoseconds.
-		Weight::from_ref_time(4_392_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(4_392_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 	}
 	/// The range of component `c` is `[0, 1000]`.
 	fn batch_all(c: u32, ) -> Weight {
@@ -72,18 +72,18 @@ impl<T: frame_system::Config> pallet_utility::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 5_645 nanoseconds.
-		Weight::from_ref_time(16_082_395)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(16_082_395, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			// Standard Error: 2_061
-			.saturating_add(Weight::from_ref_time(3_918_503).saturating_mul(c.into()))
+			.saturating_add(Weight::from_parts(3_918_503, 0).saturating_mul(c.into()))
 	}
 	fn dispatch_as() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 7_613 nanoseconds.
-		Weight::from_ref_time(7_868_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(7_868_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 	}
 	/// The range of component `c` is `[0, 1000]`.
 	fn force_batch(c: u32, ) -> Weight {
@@ -91,9 +91,9 @@ impl<T: frame_system::Config> pallet_utility::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 5_909 nanoseconds.
-		Weight::from_ref_time(11_406_668)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(11_406_668, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			// Standard Error: 2_399
-			.saturating_add(Weight::from_ref_time(3_759_278).saturating_mul(c.into()))
+			.saturating_add(Weight::from_parts(3_759_278, 0).saturating_mul(c.into()))
 	}
 }

--- a/parachains/runtimes/bridge-hubs/bridge-hub-kusama/src/weights/pallet_xcm.rs
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-kusama/src/weights/pallet_xcm.rs
@@ -62,8 +62,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `38`
 		//  Estimated: `4645`
 		// Minimum execution time: 23_601 nanoseconds.
-		Weight::from_ref_time(24_078_000)
-			.saturating_add(Weight::from_proof_size(4645))
+		Weight::from_parts(24_078_000, 0)
+			.saturating_add(Weight::from_parts(0, 4645))
 			.saturating_add(T::DbWeight::get().reads(5))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -74,8 +74,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `32`
 		//  Estimated: `499`
 		// Minimum execution time: 23_225 nanoseconds.
-		Weight::from_ref_time(23_887_000)
-			.saturating_add(Weight::from_proof_size(499))
+		Weight::from_parts(23_887_000, 0)
+			.saturating_add(Weight::from_parts(0, 499))
 			.saturating_add(T::DbWeight::get().reads(1))
 	}
 	/// Storage: Benchmark Override (r:0 w:0)
@@ -85,8 +85,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 18_446_744_073_709_551 nanoseconds.
-		Weight::from_ref_time(18_446_744_073_709_551_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(18_446_744_073_709_551_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 	}
 	/// Storage: Benchmark Override (r:0 w:0)
 	/// Proof Skipped: Benchmark Override (max_values: None, max_size: None, mode: Measured)
@@ -95,8 +95,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 18_446_744_073_709_551 nanoseconds.
-		Weight::from_ref_time(18_446_744_073_709_551_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(18_446_744_073_709_551_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 	}
 	/// Storage: PolkadotXcm SupportedVersion (r:0 w:1)
 	/// Proof Skipped: PolkadotXcm SupportedVersion (max_values: None, max_size: None, mode: Measured)
@@ -105,8 +105,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 8_434 nanoseconds.
-		Weight::from_ref_time(8_839_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(8_839_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
 	/// Storage: PolkadotXcm SafeXcmVersion (r:0 w:1)
@@ -116,8 +116,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 2_484 nanoseconds.
-		Weight::from_ref_time(2_611_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(2_611_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
 	/// Storage: PolkadotXcm VersionNotifiers (r:1 w:1)
@@ -141,8 +141,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `38`
 		//  Estimated: `7729`
 		// Minimum execution time: 28_465 nanoseconds.
-		Weight::from_ref_time(29_023_000)
-			.saturating_add(Weight::from_proof_size(7729))
+		Weight::from_parts(29_023_000, 0)
+			.saturating_add(Weight::from_parts(0, 7729))
 			.saturating_add(T::DbWeight::get().reads(7))
 			.saturating_add(T::DbWeight::get().writes(5))
 	}
@@ -165,8 +165,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `220`
 		//  Estimated: `8470`
 		// Minimum execution time: 31_086 nanoseconds.
-		Weight::from_ref_time(31_385_000)
-			.saturating_add(Weight::from_proof_size(8470))
+		Weight::from_parts(31_385_000, 0)
+			.saturating_add(Weight::from_parts(0, 8470))
 			.saturating_add(T::DbWeight::get().reads(6))
 			.saturating_add(T::DbWeight::get().writes(4))
 	}
@@ -177,8 +177,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `95`
 		//  Estimated: `9995`
 		// Minimum execution time: 13_701 nanoseconds.
-		Weight::from_ref_time(13_987_000)
-			.saturating_add(Weight::from_proof_size(9995))
+		Weight::from_parts(13_987_000, 0)
+			.saturating_add(Weight::from_parts(0, 9995))
 			.saturating_add(T::DbWeight::get().reads(4))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -189,8 +189,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `99`
 		//  Estimated: `9999`
 		// Minimum execution time: 13_723 nanoseconds.
-		Weight::from_ref_time(14_166_000)
-			.saturating_add(Weight::from_proof_size(9999))
+		Weight::from_parts(14_166_000, 0)
+			.saturating_add(Weight::from_parts(0, 9999))
 			.saturating_add(T::DbWeight::get().reads(4))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -201,8 +201,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `106`
 		//  Estimated: `12481`
 		// Minimum execution time: 15_381 nanoseconds.
-		Weight::from_ref_time(16_770_000)
-			.saturating_add(Weight::from_proof_size(12481))
+		Weight::from_parts(16_770_000, 0)
+			.saturating_add(Weight::from_parts(0, 12481))
 			.saturating_add(T::DbWeight::get().reads(5))
 	}
 	/// Storage: PolkadotXcm VersionNotifyTargets (r:2 w:1)
@@ -222,8 +222,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `106`
 		//  Estimated: `10041`
 		// Minimum execution time: 27_952 nanoseconds.
-		Weight::from_ref_time(28_321_000)
-			.saturating_add(Weight::from_proof_size(10041))
+		Weight::from_parts(28_321_000, 0)
+			.saturating_add(Weight::from_parts(0, 10041))
 			.saturating_add(T::DbWeight::get().reads(7))
 			.saturating_add(T::DbWeight::get().writes(3))
 	}
@@ -234,8 +234,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `136`
 		//  Estimated: `7561`
 		// Minimum execution time: 8_516 nanoseconds.
-		Weight::from_ref_time(8_922_000)
-			.saturating_add(Weight::from_proof_size(7561))
+		Weight::from_parts(8_922_000, 0)
+			.saturating_add(Weight::from_parts(0, 7561))
 			.saturating_add(T::DbWeight::get().reads(3))
 	}
 	/// Storage: PolkadotXcm VersionNotifyTargets (r:4 w:2)
@@ -245,8 +245,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `106`
 		//  Estimated: `10006`
 		// Minimum execution time: 16_615 nanoseconds.
-		Weight::from_ref_time(17_074_000)
-			.saturating_add(Weight::from_proof_size(10006))
+		Weight::from_parts(17_074_000, 0)
+			.saturating_add(Weight::from_parts(0, 10006))
 			.saturating_add(T::DbWeight::get().reads(4))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -267,8 +267,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `112`
 		//  Estimated: `15027`
 		// Minimum execution time: 36_726 nanoseconds.
-		Weight::from_ref_time(37_319_000)
-			.saturating_add(Weight::from_proof_size(15027))
+		Weight::from_parts(37_319_000, 0)
+			.saturating_add(Weight::from_parts(0, 15027))
 			.saturating_add(T::DbWeight::get().reads(9))
 			.saturating_add(T::DbWeight::get().writes(4))
 	}

--- a/parachains/runtimes/bridge-hubs/bridge-hub-kusama/src/weights/xcm/mod.rs
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-kusama/src/weights/xcm/mod.rs
@@ -65,7 +65,7 @@ impl<Call> XcmWeightInfo<Call> for BridgeHubKusamaXcmWeight<Call> {
 	// Currently there is no trusted reserve
 	fn reserve_asset_deposited(_assets: &MultiAssets) -> Weight {
 		// TODO: hardcoded - fix https://github.com/paritytech/cumulus/issues/1974
-		Weight::from_ref_time(1_000_000_000 as u64)
+		Weight::from_parts(1_000_000_000 as u64, 0)
 	}
 	fn receive_teleported_asset(assets: &MultiAssets) -> Weight {
 		assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::receive_teleported_asset())
@@ -123,7 +123,7 @@ impl<Call> XcmWeightInfo<Call> for BridgeHubKusamaXcmWeight<Call> {
 
 	fn deposit_asset(assets: &MultiAssetFilter, _dest: &MultiLocation) -> Weight {
 		// Hardcoded till the XCM pallet is fixed
-		let hardcoded_weight = Weight::from_ref_time(1_000_000_000 as u64);
+		let hardcoded_weight = Weight::from_parts(1_000_000_000 as u64, 0);
 		let weight = assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::deposit_asset());
 		hardcoded_weight.min(weight)
 	}

--- a/parachains/runtimes/bridge-hubs/bridge-hub-kusama/src/weights/xcm/pallet_xcm_benchmarks_fungible.rs
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-kusama/src/weights/xcm/pallet_xcm_benchmarks_fungible.rs
@@ -51,14 +51,14 @@ impl<T: frame_system::Config> WeightInfo<T> {
 	// Storage: System Account (r:1 w:1)
 	// Proof: System Account (max_values: None, max_size: Some(128), added: 2603, mode: MaxEncodedLen)
 	pub(crate) fn withdraw_asset() -> Weight {
-		Weight::from_ref_time(18_301_000 as u64)
+		Weight::from_parts(18_301_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: System Account (r:2 w:2)
 	// Proof: System Account (max_values: None, max_size: Some(128), added: 2603, mode: MaxEncodedLen)
 	pub(crate) fn transfer_asset() -> Weight {
-		Weight::from_ref_time(29_321_000 as u64)
+		Weight::from_parts(29_321_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
@@ -77,17 +77,17 @@ impl<T: frame_system::Config> WeightInfo<T> {
 	// Storage: ParachainSystem PendingUpwardMessages (r:1 w:1)
 	// Proof Skipped: ParachainSystem PendingUpwardMessages (max_values: Some(1), max_size: None, mode: Measured)
 	pub(crate) fn transfer_reserve_asset() -> Weight {
-		Weight::from_ref_time(50_754_000 as u64)
+		Weight::from_parts(50_754_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(8 as u64))
 			.saturating_add(T::DbWeight::get().writes(4 as u64))
 	}
 	pub(crate) fn receive_teleported_asset() -> Weight {
-		Weight::from_ref_time(3_814_000 as u64)
+		Weight::from_parts(3_814_000 as u64, 0)
 	}
 	// Storage: System Account (r:1 w:1)
 	// Proof: System Account (max_values: None, max_size: Some(128), added: 2603, mode: MaxEncodedLen)
 	pub(crate) fn deposit_asset() -> Weight {
-		Weight::from_ref_time(21_596_000 as u64)
+		Weight::from_parts(21_596_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
@@ -106,7 +106,7 @@ impl<T: frame_system::Config> WeightInfo<T> {
 	// Storage: ParachainSystem PendingUpwardMessages (r:1 w:1)
 	// Proof Skipped: ParachainSystem PendingUpwardMessages (max_values: Some(1), max_size: None, mode: Measured)
 	pub(crate) fn deposit_reserve_asset() -> Weight {
-		Weight::from_ref_time(45_534_000 as u64)
+		Weight::from_parts(45_534_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(7 as u64))
 			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
@@ -123,7 +123,7 @@ impl<T: frame_system::Config> WeightInfo<T> {
 	// Storage: ParachainSystem PendingUpwardMessages (r:1 w:1)
 	// Proof Skipped: ParachainSystem PendingUpwardMessages (max_values: Some(1), max_size: None, mode: Measured)
 	pub(crate) fn initiate_teleport() -> Weight {
-		Weight::from_ref_time(26_876_000 as u64)
+		Weight::from_parts(26_876_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(6 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}

--- a/parachains/runtimes/bridge-hubs/bridge-hub-kusama/src/weights/xcm/pallet_xcm_benchmarks_generic.rs
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-kusama/src/weights/xcm/pallet_xcm_benchmarks_generic.rs
@@ -61,39 +61,39 @@ impl<T: frame_system::Config> WeightInfo<T> {
 	// Storage: ParachainSystem PendingUpwardMessages (r:1 w:1)
 	// Proof Skipped: ParachainSystem PendingUpwardMessages (max_values: Some(1), max_size: None, mode: Measured)
 	pub(crate) fn report_holding() -> Weight {
-		Weight::from_ref_time(30_320_000 as u64)
+		Weight::from_parts(30_320_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(6 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	pub(crate) fn buy_execution() -> Weight {
-		Weight::from_ref_time(2_776_000 as u64)
+		Weight::from_parts(2_776_000 as u64, 0)
 	}
 	// Storage: PolkadotXcm Queries (r:1 w:0)
 	// Proof Skipped: PolkadotXcm Queries (max_values: None, max_size: None, mode: Measured)
 	pub(crate) fn query_response() -> Weight {
-		Weight::from_ref_time(10_396_000 as u64)
+		Weight::from_parts(10_396_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 	}
 	pub(crate) fn transact() -> Weight {
-		Weight::from_ref_time(11_646_000 as u64)
+		Weight::from_parts(11_646_000 as u64, 0)
 	}
 	pub(crate) fn refund_surplus() -> Weight {
-		Weight::from_ref_time(2_853_000 as u64)
+		Weight::from_parts(2_853_000 as u64, 0)
 	}
 	pub(crate) fn set_error_handler() -> Weight {
-		Weight::from_ref_time(2_746_000 as u64)
+		Weight::from_parts(2_746_000 as u64, 0)
 	}
 	pub(crate) fn set_appendix() -> Weight {
-		Weight::from_ref_time(2_742_000 as u64)
+		Weight::from_parts(2_742_000 as u64, 0)
 	}
 	pub(crate) fn clear_error() -> Weight {
-		Weight::from_ref_time(2_750_000 as u64)
+		Weight::from_parts(2_750_000 as u64, 0)
 	}
 	pub(crate) fn descend_origin() -> Weight {
-		Weight::from_ref_time(3_512_000 as u64)
+		Weight::from_parts(3_512_000 as u64, 0)
 	}
 	pub(crate) fn clear_origin() -> Weight {
-		Weight::from_ref_time(2_710_000 as u64)
+		Weight::from_parts(2_710_000 as u64, 0)
 	}
 	// Storage: ParachainInfo ParachainId (r:1 w:0)
 	// Proof: ParachainInfo ParachainId (max_values: Some(1), max_size: Some(4), added: 499, mode: MaxEncodedLen)
@@ -108,19 +108,19 @@ impl<T: frame_system::Config> WeightInfo<T> {
 	// Storage: ParachainSystem PendingUpwardMessages (r:1 w:1)
 	// Proof Skipped: ParachainSystem PendingUpwardMessages (max_values: Some(1), max_size: None, mode: Measured)
 	pub(crate) fn report_error() -> Weight {
-		Weight::from_ref_time(23_834_000 as u64)
+		Weight::from_parts(23_834_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(6 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: PolkadotXcm AssetTraps (r:1 w:1)
 	// Proof Skipped: PolkadotXcm AssetTraps (max_values: None, max_size: None, mode: Measured)
 	pub(crate) fn claim_asset() -> Weight {
-		Weight::from_ref_time(14_091_000 as u64)
+		Weight::from_parts(14_091_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	pub(crate) fn trap() -> Weight {
-		Weight::from_ref_time(2_702_000 as u64)
+		Weight::from_parts(2_702_000 as u64, 0)
 	}
 	// Storage: PolkadotXcm VersionNotifyTargets (r:1 w:1)
 	// Proof Skipped: PolkadotXcm VersionNotifyTargets (max_values: None, max_size: None, mode: Measured)
@@ -135,14 +135,14 @@ impl<T: frame_system::Config> WeightInfo<T> {
 	// Storage: ParachainSystem PendingUpwardMessages (r:1 w:1)
 	// Proof Skipped: ParachainSystem PendingUpwardMessages (max_values: Some(1), max_size: None, mode: Measured)
 	pub(crate) fn subscribe_version() -> Weight {
-		Weight::from_ref_time(24_071_000 as u64)
+		Weight::from_parts(24_071_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(6 as u64))
 			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: PolkadotXcm VersionNotifyTargets (r:0 w:1)
 	// Proof Skipped: PolkadotXcm VersionNotifyTargets (max_values: None, max_size: None, mode: Measured)
 	pub(crate) fn unsubscribe_version() -> Weight {
-		Weight::from_ref_time(4_648_000 as u64)
+		Weight::from_parts(4_648_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: ParachainInfo ParachainId (r:1 w:0)
@@ -158,24 +158,24 @@ impl<T: frame_system::Config> WeightInfo<T> {
 	// Storage: ParachainSystem PendingUpwardMessages (r:1 w:1)
 	// Proof Skipped: ParachainSystem PendingUpwardMessages (max_values: Some(1), max_size: None, mode: Measured)
 	pub(crate) fn initiate_reserve_withdraw() -> Weight {
-		Weight::from_ref_time(26_772_000 as u64)
+		Weight::from_parts(26_772_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(6 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	pub(crate) fn burn_asset() -> Weight {
-		Weight::from_ref_time(4_249_000 as u64)
+		Weight::from_parts(4_249_000 as u64, 0)
 	}
 	pub(crate) fn expect_asset() -> Weight {
-		Weight::from_ref_time(2_860_000 as u64)
+		Weight::from_parts(2_860_000 as u64, 0)
 	}
 	pub(crate) fn expect_origin() -> Weight {
-		Weight::from_ref_time(2_849_000 as u64)
+		Weight::from_parts(2_849_000 as u64, 0)
 	}
 	pub(crate) fn expect_error() -> Weight {
-		Weight::from_ref_time(2_692_000 as u64)
+		Weight::from_parts(2_692_000 as u64, 0)
 	}
 	pub(crate) fn expect_transact_status() -> Weight {
-		Weight::from_ref_time(2_886_000 as u64)
+		Weight::from_parts(2_886_000 as u64, 0)
 	}
 	// Storage: ParachainInfo ParachainId (r:1 w:0)
 	// Proof: ParachainInfo ParachainId (max_values: Some(1), max_size: Some(4), added: 499, mode: MaxEncodedLen)
@@ -190,12 +190,12 @@ impl<T: frame_system::Config> WeightInfo<T> {
 	// Storage: ParachainSystem PendingUpwardMessages (r:1 w:1)
 	// Proof Skipped: ParachainSystem PendingUpwardMessages (max_values: Some(1), max_size: None, mode: Measured)
 	pub(crate) fn query_pallet() -> Weight {
-		Weight::from_ref_time(28_452_000 as u64)
+		Weight::from_parts(28_452_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(6 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	pub(crate) fn expect_pallet() -> Weight {
-		Weight::from_ref_time(4_257_000 as u64)
+		Weight::from_parts(4_257_000 as u64, 0)
 	}
 	// Storage: ParachainInfo ParachainId (r:1 w:0)
 	// Proof: ParachainInfo ParachainId (max_values: Some(1), max_size: Some(4), added: 499, mode: MaxEncodedLen)
@@ -210,23 +210,23 @@ impl<T: frame_system::Config> WeightInfo<T> {
 	// Storage: ParachainSystem PendingUpwardMessages (r:1 w:1)
 	// Proof Skipped: ParachainSystem PendingUpwardMessages (max_values: Some(1), max_size: None, mode: Measured)
 	pub(crate) fn report_transact_status() -> Weight {
-		Weight::from_ref_time(24_235_000 as u64)
+		Weight::from_parts(24_235_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(6 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	pub(crate) fn clear_transact_status() -> Weight {
-		Weight::from_ref_time(2_749_000 as u64)
+		Weight::from_parts(2_749_000 as u64, 0)
 	}
 	pub(crate) fn set_topic() -> Weight {
-		Weight::from_ref_time(2_718_000 as u64)
+		Weight::from_parts(2_718_000 as u64, 0)
 	}
 	pub(crate) fn clear_topic() -> Weight {
-		Weight::from_ref_time(2_685_000 as u64)
+		Weight::from_parts(2_685_000 as u64, 0)
 	}
 	pub(crate) fn set_fees_mode() -> Weight {
-		Weight::from_ref_time(2_735_000 as u64)
+		Weight::from_parts(2_735_000 as u64, 0)
 	}
 	pub(crate) fn unpaid_execution() -> Weight {
-		Weight::from_ref_time(2_842_000 as u64)
+		Weight::from_parts(2_842_000 as u64, 0)
 	}
 }

--- a/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/src/weights/block_weights.rs
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/src/weights/block_weights.rs
@@ -24,7 +24,7 @@ pub mod constants {
 	parameter_types! {
 		/// Importing a block with 0 Extrinsics.
 		pub const BlockExecutionWeight: Weight =
-			Weight::from_ref_time(constants::WEIGHT_REF_TIME_PER_NANOS.saturating_mul(5_000_000));
+			Weight::from_parts(constants::WEIGHT_REF_TIME_PER_NANOS.saturating_mul(5_000_000), 0);
 	}
 
 	#[cfg(test)]

--- a/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/src/weights/cumulus_pallet_xcmp_queue.rs
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/src/weights/cumulus_pallet_xcmp_queue.rs
@@ -54,8 +54,8 @@ impl<T: frame_system::Config> cumulus_pallet_xcmp_queue::WeightInfo for WeightIn
 		//  Measured:  `76`
 		//  Estimated: `571`
 		// Minimum execution time: 4_798 nanoseconds.
-		Weight::from_ref_time(5_139_000)
-			.saturating_add(Weight::from_proof_size(571))
+		Weight::from_parts(5_139_000, 0)
+			.saturating_add(Weight::from_parts(0, 571))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -66,8 +66,8 @@ impl<T: frame_system::Config> cumulus_pallet_xcmp_queue::WeightInfo for WeightIn
 		//  Measured:  `76`
 		//  Estimated: `571`
 		// Minimum execution time: 4_942 nanoseconds.
-		Weight::from_ref_time(5_056_000)
-			.saturating_add(Weight::from_proof_size(571))
+		Weight::from_parts(5_056_000, 0)
+			.saturating_add(Weight::from_parts(0, 571))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}

--- a/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/src/weights/extrinsic_weights.rs
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/src/weights/extrinsic_weights.rs
@@ -24,7 +24,7 @@ pub mod constants {
 	parameter_types! {
 		/// Executing a NO-OP `System::remarks` Extrinsic.
 		pub const ExtrinsicBaseWeight: Weight =
-			Weight::from_ref_time(constants::WEIGHT_REF_TIME_PER_NANOS.saturating_mul(125_000));
+			Weight::from_parts(constants::WEIGHT_REF_TIME_PER_NANOS.saturating_mul(125_000), 0);
 	}
 
 	#[cfg(test)]

--- a/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/src/weights/frame_system.rs
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/src/weights/frame_system.rs
@@ -53,10 +53,10 @@ impl<T: frame_system::Config> frame_system::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 1_628 nanoseconds.
-		Weight::from_ref_time(1_691_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(1_691_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			// Standard Error: 0
-			.saturating_add(Weight::from_ref_time(369).saturating_mul(b.into()))
+			.saturating_add(Weight::from_parts(369, 0).saturating_mul(b.into()))
 	}
 	/// The range of component `b` is `[0, 3932160]`.
 	fn remark_with_event(b: u32, ) -> Weight {
@@ -64,10 +64,10 @@ impl<T: frame_system::Config> frame_system::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 6_332 nanoseconds.
-		Weight::from_ref_time(6_564_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(6_564_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			// Standard Error: 0
-			.saturating_add(Weight::from_ref_time(1_714).saturating_mul(b.into()))
+			.saturating_add(Weight::from_parts(1_714, 0).saturating_mul(b.into()))
 	}
 	/// Storage: System Digest (r:1 w:1)
 	/// Proof Skipped: System Digest (max_values: Some(1), max_size: None, mode: Measured)
@@ -78,8 +78,8 @@ impl<T: frame_system::Config> frame_system::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `495`
 		// Minimum execution time: 3_441 nanoseconds.
-		Weight::from_ref_time(3_684_000)
-			.saturating_add(Weight::from_proof_size(495))
+		Weight::from_parts(3_684_000, 0)
+			.saturating_add(Weight::from_parts(0, 495))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -91,10 +91,10 @@ impl<T: frame_system::Config> frame_system::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 1_698 nanoseconds.
-		Weight::from_ref_time(1_802_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(1_802_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			// Standard Error: 1_738
-			.saturating_add(Weight::from_ref_time(576_825).saturating_mul(i.into()))
+			.saturating_add(Weight::from_parts(576_825, 0).saturating_mul(i.into()))
 			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(i.into())))
 	}
 	/// Storage: Skipped Metadata (r:0 w:0)
@@ -105,10 +105,10 @@ impl<T: frame_system::Config> frame_system::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 1_782 nanoseconds.
-		Weight::from_ref_time(1_826_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(1_826_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			// Standard Error: 808
-			.saturating_add(Weight::from_ref_time(446_795).saturating_mul(i.into()))
+			.saturating_add(Weight::from_parts(446_795, 0).saturating_mul(i.into()))
 			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(i.into())))
 	}
 	/// Storage: Skipped Metadata (r:0 w:0)
@@ -119,11 +119,11 @@ impl<T: frame_system::Config> frame_system::WeightInfo for WeightInfo<T> {
 		//  Measured:  `68 + p * (69 ±0)`
 		//  Estimated: `66 + p * (70 ±0)`
 		// Minimum execution time: 3_444 nanoseconds.
-		Weight::from_ref_time(3_538_000)
-			.saturating_add(Weight::from_proof_size(66))
+		Weight::from_parts(3_538_000, 0)
+			.saturating_add(Weight::from_parts(0, 66))
 			// Standard Error: 920
-			.saturating_add(Weight::from_ref_time(950_898).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(950_898, 0).saturating_mul(p.into()))
 			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(p.into())))
-			.saturating_add(Weight::from_proof_size(70).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(0, 70).saturating_mul(p.into()))
 	}
 }

--- a/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/src/weights/pallet_balances.rs
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/src/weights/pallet_balances.rs
@@ -54,8 +54,8 @@ impl<T: frame_system::Config> pallet_balances::WeightInfo for WeightInfo<T> {
 		//  Measured:  `1316`
 		//  Estimated: `2603`
 		// Minimum execution time: 44_427 nanoseconds.
-		Weight::from_ref_time(45_164_000)
-			.saturating_add(Weight::from_proof_size(2603))
+		Weight::from_parts(45_164_000, 0)
+			.saturating_add(Weight::from_parts(0, 2603))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -66,8 +66,8 @@ impl<T: frame_system::Config> pallet_balances::WeightInfo for WeightInfo<T> {
 		//  Measured:  `1200`
 		//  Estimated: `2603`
 		// Minimum execution time: 34_287 nanoseconds.
-		Weight::from_ref_time(34_918_000)
-			.saturating_add(Weight::from_proof_size(2603))
+		Weight::from_parts(34_918_000, 0)
+			.saturating_add(Weight::from_parts(0, 2603))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -78,8 +78,8 @@ impl<T: frame_system::Config> pallet_balances::WeightInfo for WeightInfo<T> {
 		//  Measured:  `1350`
 		//  Estimated: `2603`
 		// Minimum execution time: 25_850 nanoseconds.
-		Weight::from_ref_time(26_521_000)
-			.saturating_add(Weight::from_proof_size(2603))
+		Weight::from_parts(26_521_000, 0)
+			.saturating_add(Weight::from_parts(0, 2603))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -90,8 +90,8 @@ impl<T: frame_system::Config> pallet_balances::WeightInfo for WeightInfo<T> {
 		//  Measured:  `1350`
 		//  Estimated: `2603`
 		// Minimum execution time: 29_118 nanoseconds.
-		Weight::from_ref_time(29_706_000)
-			.saturating_add(Weight::from_proof_size(2603))
+		Weight::from_parts(29_706_000, 0)
+			.saturating_add(Weight::from_parts(0, 2603))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -102,8 +102,8 @@ impl<T: frame_system::Config> pallet_balances::WeightInfo for WeightInfo<T> {
 		//  Measured:  `1312`
 		//  Estimated: `5206`
 		// Minimum execution time: 45_010 nanoseconds.
-		Weight::from_ref_time(45_568_000)
-			.saturating_add(Weight::from_proof_size(5206))
+		Weight::from_parts(45_568_000, 0)
+			.saturating_add(Weight::from_parts(0, 5206))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -114,8 +114,8 @@ impl<T: frame_system::Config> pallet_balances::WeightInfo for WeightInfo<T> {
 		//  Measured:  `1200`
 		//  Estimated: `2603`
 		// Minimum execution time: 39_332 nanoseconds.
-		Weight::from_ref_time(40_015_000)
-			.saturating_add(Weight::from_proof_size(2603))
+		Weight::from_parts(40_015_000, 0)
+			.saturating_add(Weight::from_parts(0, 2603))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -126,8 +126,8 @@ impl<T: frame_system::Config> pallet_balances::WeightInfo for WeightInfo<T> {
 		//  Measured:  `1234`
 		//  Estimated: `2603`
 		// Minimum execution time: 22_710 nanoseconds.
-		Weight::from_ref_time(23_111_000)
-			.saturating_add(Weight::from_proof_size(2603))
+		Weight::from_parts(23_111_000, 0)
+			.saturating_add(Weight::from_parts(0, 2603))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}

--- a/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/src/weights/pallet_collator_selection.rs
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/src/weights/pallet_collator_selection.rs
@@ -57,13 +57,13 @@ impl<T: frame_system::Config> pallet_collator_selection::WeightInfo for WeightIn
 		//  Measured:  `214 + b * (78 ±0)`
 		//  Estimated: `213 + b * (2554 ±0)`
 		// Minimum execution time: 13_937 nanoseconds.
-		Weight::from_ref_time(14_498_919)
-			.saturating_add(Weight::from_proof_size(213))
+		Weight::from_parts(14_498_919, 0)
+			.saturating_add(Weight::from_parts(0, 213))
 			// Standard Error: 2_987
-			.saturating_add(Weight::from_ref_time(2_491_437).saturating_mul(b.into()))
+			.saturating_add(Weight::from_parts(2_491_437, 0).saturating_mul(b.into()))
 			.saturating_add(T::DbWeight::get().reads((1_u64).saturating_mul(b.into())))
 			.saturating_add(T::DbWeight::get().writes(1))
-			.saturating_add(Weight::from_proof_size(2554).saturating_mul(b.into()))
+			.saturating_add(Weight::from_parts(0, 2554).saturating_mul(b.into()))
 	}
 	/// Storage: CollatorSelection DesiredCandidates (r:0 w:1)
 	/// Proof: CollatorSelection DesiredCandidates (max_values: Some(1), max_size: Some(4), added: 499, mode: MaxEncodedLen)
@@ -72,8 +72,8 @@ impl<T: frame_system::Config> pallet_collator_selection::WeightInfo for WeightIn
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 6_465 nanoseconds.
-		Weight::from_ref_time(6_739_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(6_739_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
 	/// Storage: CollatorSelection CandidacyBond (r:0 w:1)
@@ -83,8 +83,8 @@ impl<T: frame_system::Config> pallet_collator_selection::WeightInfo for WeightIn
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 6_624 nanoseconds.
-		Weight::from_ref_time(6_822_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(6_822_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
 	/// Storage: CollatorSelection Candidates (r:1 w:1)
@@ -105,13 +105,13 @@ impl<T: frame_system::Config> pallet_collator_selection::WeightInfo for WeightIn
 		//  Measured:  `1167 + c * (48 ±0)`
 		//  Estimated: `56785 + c * (49 ±0)`
 		// Minimum execution time: 34_794 nanoseconds.
-		Weight::from_ref_time(27_197_409)
-			.saturating_add(Weight::from_proof_size(56785))
+		Weight::from_parts(27_197_409, 0)
+			.saturating_add(Weight::from_parts(0, 56785))
 			// Standard Error: 1_259
-			.saturating_add(Weight::from_ref_time(101_424).saturating_mul(c.into()))
+			.saturating_add(Weight::from_parts(101_424, 0).saturating_mul(c.into()))
 			.saturating_add(T::DbWeight::get().reads(5))
 			.saturating_add(T::DbWeight::get().writes(2))
-			.saturating_add(Weight::from_proof_size(49).saturating_mul(c.into()))
+			.saturating_add(Weight::from_parts(0, 49).saturating_mul(c.into()))
 	}
 	/// Storage: CollatorSelection Candidates (r:1 w:1)
 	/// Proof: CollatorSelection Candidates (max_values: Some(1), max_size: Some(48002), added: 48497, mode: MaxEncodedLen)
@@ -123,10 +123,10 @@ impl<T: frame_system::Config> pallet_collator_selection::WeightInfo for WeightIn
 		//  Measured:  `503 + c * (48 ±0)`
 		//  Estimated: `48497`
 		// Minimum execution time: 26_471 nanoseconds.
-		Weight::from_ref_time(16_092_836)
-			.saturating_add(Weight::from_proof_size(48497))
+		Weight::from_parts(16_092_836, 0)
+			.saturating_add(Weight::from_parts(0, 48497))
 			// Standard Error: 1_283
-			.saturating_add(Weight::from_ref_time(103_788).saturating_mul(c.into()))
+			.saturating_add(Weight::from_parts(103_788, 0).saturating_mul(c.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -141,8 +141,8 @@ impl<T: frame_system::Config> pallet_collator_selection::WeightInfo for WeightIn
 		//  Measured:  `187`
 		//  Estimated: `5749`
 		// Minimum execution time: 25_597 nanoseconds.
-		Weight::from_ref_time(25_981_000)
-			.saturating_add(Weight::from_proof_size(5749))
+		Weight::from_parts(25_981_000, 0)
+			.saturating_add(Weight::from_parts(0, 5749))
 			.saturating_add(T::DbWeight::get().reads(3))
 			.saturating_add(T::DbWeight::get().writes(4))
 	}
@@ -163,15 +163,15 @@ impl<T: frame_system::Config> pallet_collator_selection::WeightInfo for WeightIn
 		//  Measured:  `22878 + r * (148 ±0) + c * (97 ±0)`
 		//  Estimated: `52737 + c * (2519 ±0) + r * (2602 ±0)`
 		// Minimum execution time: 15_961 nanoseconds.
-		Weight::from_ref_time(16_207_000)
-			.saturating_add(Weight::from_proof_size(52737))
+		Weight::from_parts(16_207_000, 0)
+			.saturating_add(Weight::from_parts(0, 52737))
 			// Standard Error: 748_921
-			.saturating_add(Weight::from_ref_time(27_460_211).saturating_mul(c.into()))
+			.saturating_add(Weight::from_parts(27_460_211, 0).saturating_mul(c.into()))
 			.saturating_add(T::DbWeight::get().reads(4))
 			.saturating_add(T::DbWeight::get().reads((1_u64).saturating_mul(c.into())))
 			.saturating_add(T::DbWeight::get().writes(1))
 			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(c.into())))
-			.saturating_add(Weight::from_proof_size(2519).saturating_mul(c.into()))
-			.saturating_add(Weight::from_proof_size(2602).saturating_mul(r.into()))
+			.saturating_add(Weight::from_parts(0, 2519).saturating_mul(c.into()))
+			.saturating_add(Weight::from_parts(0, 2602).saturating_mul(r.into()))
 	}
 }

--- a/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/src/weights/pallet_multisig.rs
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/src/weights/pallet_multisig.rs
@@ -53,10 +53,10 @@ impl<T: frame_system::Config> pallet_multisig::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 11_693 nanoseconds.
-		Weight::from_ref_time(12_218_501)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(12_218_501, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			// Standard Error: 1
-			.saturating_add(Weight::from_ref_time(479).saturating_mul(z.into()))
+			.saturating_add(Weight::from_parts(479, 0).saturating_mul(z.into()))
 	}
 	/// Storage: Multisig Multisigs (r:1 w:1)
 	/// Proof: Multisig Multisigs (max_values: None, max_size: Some(3346), added: 5821, mode: MaxEncodedLen)
@@ -67,12 +67,12 @@ impl<T: frame_system::Config> pallet_multisig::WeightInfo for WeightInfo<T> {
 		//  Measured:  `314 + s * (2 ±0)`
 		//  Estimated: `5821`
 		// Minimum execution time: 35_181 nanoseconds.
-		Weight::from_ref_time(28_585_764)
-			.saturating_add(Weight::from_proof_size(5821))
+		Weight::from_parts(28_585_764, 0)
+			.saturating_add(Weight::from_parts(0, 5821))
 			// Standard Error: 609
-			.saturating_add(Weight::from_ref_time(72_658).saturating_mul(s.into()))
+			.saturating_add(Weight::from_parts(72_658, 0).saturating_mul(s.into()))
 			// Standard Error: 5
-			.saturating_add(Weight::from_ref_time(1_476).saturating_mul(z.into()))
+			.saturating_add(Weight::from_parts(1_476, 0).saturating_mul(z.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -85,12 +85,12 @@ impl<T: frame_system::Config> pallet_multisig::WeightInfo for WeightInfo<T> {
 		//  Measured:  `313`
 		//  Estimated: `5821`
 		// Minimum execution time: 26_110 nanoseconds.
-		Weight::from_ref_time(19_809_417)
-			.saturating_add(Weight::from_proof_size(5821))
+		Weight::from_parts(19_809_417, 0)
+			.saturating_add(Weight::from_parts(0, 5821))
 			// Standard Error: 448
-			.saturating_add(Weight::from_ref_time(69_542).saturating_mul(s.into()))
+			.saturating_add(Weight::from_parts(69_542, 0).saturating_mul(s.into()))
 			// Standard Error: 4
-			.saturating_add(Weight::from_ref_time(1_514).saturating_mul(z.into()))
+			.saturating_add(Weight::from_parts(1_514, 0).saturating_mul(z.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -105,12 +105,12 @@ impl<T: frame_system::Config> pallet_multisig::WeightInfo for WeightInfo<T> {
 		//  Measured:  `451 + s * (33 ±0)`
 		//  Estimated: `8424`
 		// Minimum execution time: 39_991 nanoseconds.
-		Weight::from_ref_time(31_329_529)
-			.saturating_add(Weight::from_proof_size(8424))
+		Weight::from_parts(31_329_529, 0)
+			.saturating_add(Weight::from_parts(0, 8424))
 			// Standard Error: 567
-			.saturating_add(Weight::from_ref_time(90_826).saturating_mul(s.into()))
+			.saturating_add(Weight::from_parts(90_826, 0).saturating_mul(s.into()))
 			// Standard Error: 5
-			.saturating_add(Weight::from_ref_time(1_527).saturating_mul(z.into()))
+			.saturating_add(Weight::from_parts(1_527, 0).saturating_mul(z.into()))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -122,10 +122,10 @@ impl<T: frame_system::Config> pallet_multisig::WeightInfo for WeightInfo<T> {
 		//  Measured:  `321 + s * (2 ±0)`
 		//  Estimated: `5821`
 		// Minimum execution time: 25_124 nanoseconds.
-		Weight::from_ref_time(26_655_548)
-			.saturating_add(Weight::from_proof_size(5821))
+		Weight::from_parts(26_655_548, 0)
+			.saturating_add(Weight::from_parts(0, 5821))
 			// Standard Error: 743
-			.saturating_add(Weight::from_ref_time(78_904).saturating_mul(s.into()))
+			.saturating_add(Weight::from_parts(78_904, 0).saturating_mul(s.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -137,10 +137,10 @@ impl<T: frame_system::Config> pallet_multisig::WeightInfo for WeightInfo<T> {
 		//  Measured:  `313`
 		//  Estimated: `5821`
 		// Minimum execution time: 16_950 nanoseconds.
-		Weight::from_ref_time(18_308_894)
-			.saturating_add(Weight::from_proof_size(5821))
+		Weight::from_parts(18_308_894, 0)
+			.saturating_add(Weight::from_parts(0, 5821))
 			// Standard Error: 676
-			.saturating_add(Weight::from_ref_time(71_574).saturating_mul(s.into()))
+			.saturating_add(Weight::from_parts(71_574, 0).saturating_mul(s.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -152,10 +152,10 @@ impl<T: frame_system::Config> pallet_multisig::WeightInfo for WeightInfo<T> {
 		//  Measured:  `517 + s * (1 ±0)`
 		//  Estimated: `5821`
 		// Minimum execution time: 26_127 nanoseconds.
-		Weight::from_ref_time(27_889_146)
-			.saturating_add(Weight::from_proof_size(5821))
+		Weight::from_parts(27_889_146, 0)
+			.saturating_add(Weight::from_parts(0, 5821))
 			// Standard Error: 729
-			.saturating_add(Weight::from_ref_time(78_618).saturating_mul(s.into()))
+			.saturating_add(Weight::from_parts(78_618, 0).saturating_mul(s.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}

--- a/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/src/weights/pallet_session.rs
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/src/weights/pallet_session.rs
@@ -56,8 +56,8 @@ impl<T: frame_system::Config> pallet_session::WeightInfo for WeightInfo<T> {
 		//  Measured:  `297`
 		//  Estimated: `5544`
 		// Minimum execution time: 15_314 nanoseconds.
-		Weight::from_ref_time(15_944_000)
-			.saturating_add(Weight::from_proof_size(5544))
+		Weight::from_parts(15_944_000, 0)
+			.saturating_add(Weight::from_parts(0, 5544))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -70,8 +70,8 @@ impl<T: frame_system::Config> pallet_session::WeightInfo for WeightInfo<T> {
 		//  Measured:  `279`
 		//  Estimated: `3033`
 		// Minimum execution time: 11_831 nanoseconds.
-		Weight::from_ref_time(12_113_000)
-			.saturating_add(Weight::from_proof_size(3033))
+		Weight::from_parts(12_113_000, 0)
+			.saturating_add(Weight::from_parts(0, 3033))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}

--- a/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/src/weights/pallet_timestamp.rs
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/src/weights/pallet_timestamp.rs
@@ -56,8 +56,8 @@ impl<T: frame_system::Config> pallet_timestamp::WeightInfo for WeightInfo<T> {
 		//  Measured:  `49`
 		//  Estimated: `1006`
 		// Minimum execution time: 6_885 nanoseconds.
-		Weight::from_ref_time(7_281_000)
-			.saturating_add(Weight::from_proof_size(1006))
+		Weight::from_parts(7_281_000, 0)
+			.saturating_add(Weight::from_parts(0, 1006))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -66,7 +66,7 @@ impl<T: frame_system::Config> pallet_timestamp::WeightInfo for WeightInfo<T> {
 		//  Measured:  `57`
 		//  Estimated: `0`
 		// Minimum execution time: 3_222 nanoseconds.
-		Weight::from_ref_time(3_321_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(3_321_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 	}
 }

--- a/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/src/weights/pallet_utility.rs
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/src/weights/pallet_utility.rs
@@ -53,18 +53,18 @@ impl<T: frame_system::Config> pallet_utility::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 5_910 nanoseconds.
-		Weight::from_ref_time(5_269_110)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(5_269_110, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			// Standard Error: 2_509
-			.saturating_add(Weight::from_ref_time(3_869_188).saturating_mul(c.into()))
+			.saturating_add(Weight::from_parts(3_869_188, 0).saturating_mul(c.into()))
 	}
 	fn as_derivative() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 4_304 nanoseconds.
-		Weight::from_ref_time(4_463_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(4_463_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 	}
 	/// The range of component `c` is `[0, 1000]`.
 	fn batch_all(c: u32, ) -> Weight {
@@ -72,18 +72,18 @@ impl<T: frame_system::Config> pallet_utility::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 5_985 nanoseconds.
-		Weight::from_ref_time(10_119_502)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(10_119_502, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			// Standard Error: 2_585
-			.saturating_add(Weight::from_ref_time(4_063_211).saturating_mul(c.into()))
+			.saturating_add(Weight::from_parts(4_063_211, 0).saturating_mul(c.into()))
 	}
 	fn dispatch_as() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 7_746 nanoseconds.
-		Weight::from_ref_time(8_027_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(8_027_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 	}
 	/// The range of component `c` is `[0, 1000]`.
 	fn force_batch(c: u32, ) -> Weight {
@@ -91,9 +91,9 @@ impl<T: frame_system::Config> pallet_utility::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 6_082 nanoseconds.
-		Weight::from_ref_time(10_385_233)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(10_385_233, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			// Standard Error: 2_217
-			.saturating_add(Weight::from_ref_time(3_855_940).saturating_mul(c.into()))
+			.saturating_add(Weight::from_parts(3_855_940, 0).saturating_mul(c.into()))
 	}
 }

--- a/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/src/weights/pallet_xcm.rs
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/src/weights/pallet_xcm.rs
@@ -62,8 +62,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `38`
 		//  Estimated: `4645`
 		// Minimum execution time: 24_136 nanoseconds.
-		Weight::from_ref_time(24_562_000)
-			.saturating_add(Weight::from_proof_size(4645))
+		Weight::from_parts(24_562_000, 0)
+			.saturating_add(Weight::from_parts(0, 4645))
 			.saturating_add(T::DbWeight::get().reads(5))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -74,8 +74,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `32`
 		//  Estimated: `499`
 		// Minimum execution time: 23_272 nanoseconds.
-		Weight::from_ref_time(23_644_000)
-			.saturating_add(Weight::from_proof_size(499))
+		Weight::from_parts(23_644_000, 0)
+			.saturating_add(Weight::from_parts(0, 499))
 			.saturating_add(T::DbWeight::get().reads(1))
 	}
 	/// Storage: Benchmark Override (r:0 w:0)
@@ -85,8 +85,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 18_446_744_073_709_551 nanoseconds.
-		Weight::from_ref_time(18_446_744_073_709_551_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(18_446_744_073_709_551_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 	}
 	/// Storage: Benchmark Override (r:0 w:0)
 	/// Proof Skipped: Benchmark Override (max_values: None, max_size: None, mode: Measured)
@@ -95,8 +95,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 18_446_744_073_709_551 nanoseconds.
-		Weight::from_ref_time(18_446_744_073_709_551_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(18_446_744_073_709_551_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 	}
 	/// Storage: PolkadotXcm SupportedVersion (r:0 w:1)
 	/// Proof Skipped: PolkadotXcm SupportedVersion (max_values: None, max_size: None, mode: Measured)
@@ -105,8 +105,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 8_377 nanoseconds.
-		Weight::from_ref_time(8_642_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(8_642_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
 	/// Storage: PolkadotXcm SafeXcmVersion (r:0 w:1)
@@ -116,8 +116,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 2_435 nanoseconds.
-		Weight::from_ref_time(2_556_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(2_556_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
 	/// Storage: PolkadotXcm VersionNotifiers (r:1 w:1)
@@ -141,8 +141,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `38`
 		//  Estimated: `7729`
 		// Minimum execution time: 28_539 nanoseconds.
-		Weight::from_ref_time(29_177_000)
-			.saturating_add(Weight::from_proof_size(7729))
+		Weight::from_parts(29_177_000, 0)
+			.saturating_add(Weight::from_parts(0, 7729))
 			.saturating_add(T::DbWeight::get().reads(7))
 			.saturating_add(T::DbWeight::get().writes(5))
 	}
@@ -165,8 +165,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `220`
 		//  Estimated: `8470`
 		// Minimum execution time: 30_607 nanoseconds.
-		Weight::from_ref_time(31_019_000)
-			.saturating_add(Weight::from_proof_size(8470))
+		Weight::from_parts(31_019_000, 0)
+			.saturating_add(Weight::from_parts(0, 8470))
 			.saturating_add(T::DbWeight::get().reads(6))
 			.saturating_add(T::DbWeight::get().writes(4))
 	}
@@ -177,8 +177,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `95`
 		//  Estimated: `9995`
 		// Minimum execution time: 13_842 nanoseconds.
-		Weight::from_ref_time(14_281_000)
-			.saturating_add(Weight::from_proof_size(9995))
+		Weight::from_parts(14_281_000, 0)
+			.saturating_add(Weight::from_parts(0, 9995))
 			.saturating_add(T::DbWeight::get().reads(4))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -189,8 +189,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `99`
 		//  Estimated: `9999`
 		// Minimum execution time: 13_505 nanoseconds.
-		Weight::from_ref_time(13_981_000)
-			.saturating_add(Weight::from_proof_size(9999))
+		Weight::from_parts(13_981_000, 0)
+			.saturating_add(Weight::from_parts(0, 9999))
 			.saturating_add(T::DbWeight::get().reads(4))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -201,8 +201,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `106`
 		//  Estimated: `12481`
 		// Minimum execution time: 16_415 nanoseconds.
-		Weight::from_ref_time(16_752_000)
-			.saturating_add(Weight::from_proof_size(12481))
+		Weight::from_parts(16_752_000, 0)
+			.saturating_add(Weight::from_parts(0, 12481))
 			.saturating_add(T::DbWeight::get().reads(5))
 	}
 	/// Storage: PolkadotXcm VersionNotifyTargets (r:2 w:1)
@@ -222,8 +222,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `106`
 		//  Estimated: `10041`
 		// Minimum execution time: 29_952 nanoseconds.
-		Weight::from_ref_time(30_592_000)
-			.saturating_add(Weight::from_proof_size(10041))
+		Weight::from_parts(30_592_000, 0)
+			.saturating_add(Weight::from_parts(0, 10041))
 			.saturating_add(T::DbWeight::get().reads(7))
 			.saturating_add(T::DbWeight::get().writes(3))
 	}
@@ -234,8 +234,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `136`
 		//  Estimated: `7561`
 		// Minimum execution time: 8_259 nanoseconds.
-		Weight::from_ref_time(8_608_000)
-			.saturating_add(Weight::from_proof_size(7561))
+		Weight::from_parts(8_608_000, 0)
+			.saturating_add(Weight::from_parts(0, 7561))
 			.saturating_add(T::DbWeight::get().reads(3))
 	}
 	/// Storage: PolkadotXcm VersionNotifyTargets (r:4 w:2)
@@ -245,8 +245,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `106`
 		//  Estimated: `10006`
 		// Minimum execution time: 16_259 nanoseconds.
-		Weight::from_ref_time(16_574_000)
-			.saturating_add(Weight::from_proof_size(10006))
+		Weight::from_parts(16_574_000, 0)
+			.saturating_add(Weight::from_parts(0, 10006))
 			.saturating_add(T::DbWeight::get().reads(4))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -267,8 +267,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `112`
 		//  Estimated: `15027`
 		// Minimum execution time: 35_748 nanoseconds.
-		Weight::from_ref_time(36_667_000)
-			.saturating_add(Weight::from_proof_size(15027))
+		Weight::from_parts(36_667_000, 0)
+			.saturating_add(Weight::from_parts(0, 15027))
 			.saturating_add(T::DbWeight::get().reads(9))
 			.saturating_add(T::DbWeight::get().writes(4))
 	}

--- a/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/src/weights/xcm/mod.rs
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/src/weights/xcm/mod.rs
@@ -65,7 +65,7 @@ impl<Call> XcmWeightInfo<Call> for BridgeHubPolkadotXcmWeight<Call> {
 	// Currently there is no trusted reserve
 	fn reserve_asset_deposited(_assets: &MultiAssets) -> Weight {
 		// TODO: hardcoded - fix https://github.com/paritytech/cumulus/issues/1974
-		Weight::from_ref_time(1_000_000_000 as u64)
+		Weight::from_parts(1_000_000_000 as u64, 0)
 	}
 	fn receive_teleported_asset(assets: &MultiAssets) -> Weight {
 		assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::receive_teleported_asset())
@@ -123,7 +123,7 @@ impl<Call> XcmWeightInfo<Call> for BridgeHubPolkadotXcmWeight<Call> {
 
 	fn deposit_asset(assets: &MultiAssetFilter, _dest: &MultiLocation) -> Weight {
 		// Hardcoded till the XCM pallet is fixed
-		let hardcoded_weight = Weight::from_ref_time(1_000_000_000 as u64);
+		let hardcoded_weight = Weight::from_parts(1_000_000_000 as u64, 0);
 		let weight = assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::deposit_asset());
 		hardcoded_weight.min(weight)
 	}
@@ -150,7 +150,7 @@ impl<Call> XcmWeightInfo<Call> for BridgeHubPolkadotXcmWeight<Call> {
 		_xcm: &Xcm<()>,
 	) -> Weight {
 		// Hardcoded till the XCM pallet is fixed
-		let hardcoded_weight = Weight::from_ref_time(200_000_000 as u64);
+		let hardcoded_weight = Weight::from_parts(200_000_000 as u64, 0);
 		let weight = assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::initiate_teleport());
 		hardcoded_weight.min(weight)
 	}

--- a/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/src/weights/xcm/pallet_xcm_benchmarks_fungible.rs
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/src/weights/xcm/pallet_xcm_benchmarks_fungible.rs
@@ -51,14 +51,14 @@ impl<T: frame_system::Config> WeightInfo<T> {
 	// Storage: System Account (r:1 w:1)
 	// Proof: System Account (max_values: None, max_size: Some(128), added: 2603, mode: MaxEncodedLen)
 	pub(crate) fn withdraw_asset() -> Weight {
-		Weight::from_ref_time(18_910_000 as u64)
+		Weight::from_parts(18_910_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: System Account (r:2 w:2)
 	// Proof: System Account (max_values: None, max_size: Some(128), added: 2603, mode: MaxEncodedLen)
 	pub(crate) fn transfer_asset() -> Weight {
-		Weight::from_ref_time(29_462_000 as u64)
+		Weight::from_parts(29_462_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
@@ -77,17 +77,17 @@ impl<T: frame_system::Config> WeightInfo<T> {
 	// Storage: ParachainSystem PendingUpwardMessages (r:1 w:1)
 	// Proof Skipped: ParachainSystem PendingUpwardMessages (max_values: Some(1), max_size: None, mode: Measured)
 	pub(crate) fn transfer_reserve_asset() -> Weight {
-		Weight::from_ref_time(51_265_000 as u64)
+		Weight::from_parts(51_265_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(8 as u64))
 			.saturating_add(T::DbWeight::get().writes(4 as u64))
 	}
 	pub(crate) fn receive_teleported_asset() -> Weight {
-		Weight::from_ref_time(3_874_000 as u64)
+		Weight::from_parts(3_874_000 as u64, 0)
 	}
 	// Storage: System Account (r:1 w:1)
 	// Proof: System Account (max_values: None, max_size: Some(128), added: 2603, mode: MaxEncodedLen)
 	pub(crate) fn deposit_asset() -> Weight {
-		Weight::from_ref_time(23_139_000 as u64)
+		Weight::from_parts(23_139_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
@@ -106,7 +106,7 @@ impl<T: frame_system::Config> WeightInfo<T> {
 	// Storage: ParachainSystem PendingUpwardMessages (r:1 w:1)
 	// Proof Skipped: ParachainSystem PendingUpwardMessages (max_values: Some(1), max_size: None, mode: Measured)
 	pub(crate) fn deposit_reserve_asset() -> Weight {
-		Weight::from_ref_time(49_375_000 as u64)
+		Weight::from_parts(49_375_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(7 as u64))
 			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
@@ -123,7 +123,7 @@ impl<T: frame_system::Config> WeightInfo<T> {
 	// Storage: ParachainSystem PendingUpwardMessages (r:1 w:1)
 	// Proof Skipped: ParachainSystem PendingUpwardMessages (max_values: Some(1), max_size: None, mode: Measured)
 	pub(crate) fn initiate_teleport() -> Weight {
-		Weight::from_ref_time(28_809_000 as u64)
+		Weight::from_parts(28_809_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(6 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}

--- a/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/src/weights/xcm/pallet_xcm_benchmarks_generic.rs
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/src/weights/xcm/pallet_xcm_benchmarks_generic.rs
@@ -61,39 +61,39 @@ impl<T: frame_system::Config> WeightInfo<T> {
 	// Storage: ParachainSystem PendingUpwardMessages (r:1 w:1)
 	// Proof Skipped: ParachainSystem PendingUpwardMessages (max_values: Some(1), max_size: None, mode: Measured)
 	pub(crate) fn report_holding() -> Weight {
-		Weight::from_ref_time(30_138_000 as u64)
+		Weight::from_parts(30_138_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(6 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	pub(crate) fn buy_execution() -> Weight {
-		Weight::from_ref_time(2_860_000 as u64)
+		Weight::from_parts(2_860_000 as u64, 0)
 	}
 	// Storage: PolkadotXcm Queries (r:1 w:0)
 	// Proof Skipped: PolkadotXcm Queries (max_values: None, max_size: None, mode: Measured)
 	pub(crate) fn query_response() -> Weight {
-		Weight::from_ref_time(10_421_000 as u64)
+		Weight::from_parts(10_421_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 	}
 	pub(crate) fn transact() -> Weight {
-		Weight::from_ref_time(11_744_000 as u64)
+		Weight::from_parts(11_744_000 as u64, 0)
 	}
 	pub(crate) fn refund_surplus() -> Weight {
-		Weight::from_ref_time(3_024_000 as u64)
+		Weight::from_parts(3_024_000 as u64, 0)
 	}
 	pub(crate) fn set_error_handler() -> Weight {
-		Weight::from_ref_time(2_820_000 as u64)
+		Weight::from_parts(2_820_000 as u64, 0)
 	}
 	pub(crate) fn set_appendix() -> Weight {
-		Weight::from_ref_time(2_869_000 as u64)
+		Weight::from_parts(2_869_000 as u64, 0)
 	}
 	pub(crate) fn clear_error() -> Weight {
-		Weight::from_ref_time(2_838_000 as u64)
+		Weight::from_parts(2_838_000 as u64, 0)
 	}
 	pub(crate) fn descend_origin() -> Weight {
-		Weight::from_ref_time(3_620_000 as u64)
+		Weight::from_parts(3_620_000 as u64, 0)
 	}
 	pub(crate) fn clear_origin() -> Weight {
-		Weight::from_ref_time(2_819_000 as u64)
+		Weight::from_parts(2_819_000 as u64, 0)
 	}
 	// Storage: ParachainInfo ParachainId (r:1 w:0)
 	// Proof: ParachainInfo ParachainId (max_values: Some(1), max_size: Some(4), added: 499, mode: MaxEncodedLen)
@@ -108,19 +108,19 @@ impl<T: frame_system::Config> WeightInfo<T> {
 	// Storage: ParachainSystem PendingUpwardMessages (r:1 w:1)
 	// Proof Skipped: ParachainSystem PendingUpwardMessages (max_values: Some(1), max_size: None, mode: Measured)
 	pub(crate) fn report_error() -> Weight {
-		Weight::from_ref_time(23_931_000 as u64)
+		Weight::from_parts(23_931_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(6 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: PolkadotXcm AssetTraps (r:1 w:1)
 	// Proof Skipped: PolkadotXcm AssetTraps (max_values: None, max_size: None, mode: Measured)
 	pub(crate) fn claim_asset() -> Weight {
-		Weight::from_ref_time(13_776_000 as u64)
+		Weight::from_parts(13_776_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	pub(crate) fn trap() -> Weight {
-		Weight::from_ref_time(2_784_000 as u64)
+		Weight::from_parts(2_784_000 as u64, 0)
 	}
 	// Storage: PolkadotXcm VersionNotifyTargets (r:1 w:1)
 	// Proof Skipped: PolkadotXcm VersionNotifyTargets (max_values: None, max_size: None, mode: Measured)
@@ -135,14 +135,14 @@ impl<T: frame_system::Config> WeightInfo<T> {
 	// Storage: ParachainSystem PendingUpwardMessages (r:1 w:1)
 	// Proof Skipped: ParachainSystem PendingUpwardMessages (max_values: Some(1), max_size: None, mode: Measured)
 	pub(crate) fn subscribe_version() -> Weight {
-		Weight::from_ref_time(23_940_000 as u64)
+		Weight::from_parts(23_940_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(6 as u64))
 			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: PolkadotXcm VersionNotifyTargets (r:0 w:1)
 	// Proof Skipped: PolkadotXcm VersionNotifyTargets (max_values: None, max_size: None, mode: Measured)
 	pub(crate) fn unsubscribe_version() -> Weight {
-		Weight::from_ref_time(4_676_000 as u64)
+		Weight::from_parts(4_676_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: ParachainInfo ParachainId (r:1 w:0)
@@ -158,24 +158,24 @@ impl<T: frame_system::Config> WeightInfo<T> {
 	// Storage: ParachainSystem PendingUpwardMessages (r:1 w:1)
 	// Proof Skipped: ParachainSystem PendingUpwardMessages (max_values: Some(1), max_size: None, mode: Measured)
 	pub(crate) fn initiate_reserve_withdraw() -> Weight {
-		Weight::from_ref_time(26_390_000 as u64)
+		Weight::from_parts(26_390_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(6 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	pub(crate) fn burn_asset() -> Weight {
-		Weight::from_ref_time(4_435_000 as u64)
+		Weight::from_parts(4_435_000 as u64, 0)
 	}
 	pub(crate) fn expect_asset() -> Weight {
-		Weight::from_ref_time(2_940_000 as u64)
+		Weight::from_parts(2_940_000 as u64, 0)
 	}
 	pub(crate) fn expect_origin() -> Weight {
-		Weight::from_ref_time(2_898_000 as u64)
+		Weight::from_parts(2_898_000 as u64, 0)
 	}
 	pub(crate) fn expect_error() -> Weight {
-		Weight::from_ref_time(2_795_000 as u64)
+		Weight::from_parts(2_795_000 as u64, 0)
 	}
 	pub(crate) fn expect_transact_status() -> Weight {
-		Weight::from_ref_time(2_908_000 as u64)
+		Weight::from_parts(2_908_000 as u64, 0)
 	}
 	// Storage: ParachainInfo ParachainId (r:1 w:0)
 	// Proof: ParachainInfo ParachainId (max_values: Some(1), max_size: Some(4), added: 499, mode: MaxEncodedLen)
@@ -190,12 +190,12 @@ impl<T: frame_system::Config> WeightInfo<T> {
 	// Storage: ParachainSystem PendingUpwardMessages (r:1 w:1)
 	// Proof Skipped: ParachainSystem PendingUpwardMessages (max_values: Some(1), max_size: None, mode: Measured)
 	pub(crate) fn query_pallet() -> Weight {
-		Weight::from_ref_time(26_452_000 as u64)
+		Weight::from_parts(26_452_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(6 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	pub(crate) fn expect_pallet() -> Weight {
-		Weight::from_ref_time(4_303_000 as u64)
+		Weight::from_parts(4_303_000 as u64, 0)
 	}
 	// Storage: ParachainInfo ParachainId (r:1 w:0)
 	// Proof: ParachainInfo ParachainId (max_values: Some(1), max_size: Some(4), added: 499, mode: MaxEncodedLen)
@@ -210,23 +210,23 @@ impl<T: frame_system::Config> WeightInfo<T> {
 	// Storage: ParachainSystem PendingUpwardMessages (r:1 w:1)
 	// Proof Skipped: ParachainSystem PendingUpwardMessages (max_values: Some(1), max_size: None, mode: Measured)
 	pub(crate) fn report_transact_status() -> Weight {
-		Weight::from_ref_time(23_994_000 as u64)
+		Weight::from_parts(23_994_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(6 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	pub(crate) fn clear_transact_status() -> Weight {
-		Weight::from_ref_time(2_789_000 as u64)
+		Weight::from_parts(2_789_000 as u64, 0)
 	}
 	pub(crate) fn set_topic() -> Weight {
-		Weight::from_ref_time(2_789_000 as u64)
+		Weight::from_parts(2_789_000 as u64, 0)
 	}
 	pub(crate) fn clear_topic() -> Weight {
-		Weight::from_ref_time(2_836_000 as u64)
+		Weight::from_parts(2_836_000 as u64, 0)
 	}
 	pub(crate) fn set_fees_mode() -> Weight {
-		Weight::from_ref_time(2_763_000 as u64)
+		Weight::from_parts(2_763_000 as u64, 0)
 	}
 	pub(crate) fn unpaid_execution() -> Weight {
-		Weight::from_ref_time(2_872_000 as u64)
+		Weight::from_parts(2_872_000 as u64, 0)
 	}
 }

--- a/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/weights/block_weights.rs
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/weights/block_weights.rs
@@ -24,7 +24,7 @@ pub mod constants {
 	parameter_types! {
 		/// Importing a block with 0 Extrinsics.
 		pub const BlockExecutionWeight: Weight =
-			Weight::from_ref_time(constants::WEIGHT_REF_TIME_PER_NANOS.saturating_mul(5_000_000));
+			Weight::from_parts(constants::WEIGHT_REF_TIME_PER_NANOS.saturating_mul(5_000_000), 0);
 	}
 
 	#[cfg(test)]

--- a/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/weights/cumulus_pallet_xcmp_queue.rs
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/weights/cumulus_pallet_xcmp_queue.rs
@@ -54,8 +54,8 @@ impl<T: frame_system::Config> cumulus_pallet_xcmp_queue::WeightInfo for WeightIn
 		//  Measured:  `76`
 		//  Estimated: `571`
 		// Minimum execution time: 4_865 nanoseconds.
-		Weight::from_ref_time(5_007_000)
-			.saturating_add(Weight::from_proof_size(571))
+		Weight::from_parts(5_007_000, 0)
+			.saturating_add(Weight::from_parts(0, 571))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -66,8 +66,8 @@ impl<T: frame_system::Config> cumulus_pallet_xcmp_queue::WeightInfo for WeightIn
 		//  Measured:  `76`
 		//  Estimated: `571`
 		// Minimum execution time: 4_893 nanoseconds.
-		Weight::from_ref_time(5_198_000)
-			.saturating_add(Weight::from_proof_size(571))
+		Weight::from_parts(5_198_000, 0)
+			.saturating_add(Weight::from_parts(0, 571))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}

--- a/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/weights/extrinsic_weights.rs
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/weights/extrinsic_weights.rs
@@ -24,7 +24,7 @@ pub mod constants {
 	parameter_types! {
 		/// Executing a NO-OP `System::remarks` Extrinsic.
 		pub const ExtrinsicBaseWeight: Weight =
-			Weight::from_ref_time(constants::WEIGHT_REF_TIME_PER_NANOS.saturating_mul(125_000));
+			Weight::from_parts(constants::WEIGHT_REF_TIME_PER_NANOS.saturating_mul(125_000), 0);
 	}
 
 	#[cfg(test)]

--- a/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/weights/frame_system.rs
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/weights/frame_system.rs
@@ -53,10 +53,10 @@ impl<T: frame_system::Config> frame_system::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 1_592 nanoseconds.
-		Weight::from_ref_time(679_524)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(679_524, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			// Standard Error: 0
-			.saturating_add(Weight::from_ref_time(367).saturating_mul(b.into()))
+			.saturating_add(Weight::from_parts(367, 0).saturating_mul(b.into()))
 	}
 	/// The range of component `b` is `[0, 3932160]`.
 	fn remark_with_event(b: u32, ) -> Weight {
@@ -64,10 +64,10 @@ impl<T: frame_system::Config> frame_system::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 6_673 nanoseconds.
-		Weight::from_ref_time(6_751_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(6_751_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			// Standard Error: 0
-			.saturating_add(Weight::from_ref_time(1_715).saturating_mul(b.into()))
+			.saturating_add(Weight::from_parts(1_715, 0).saturating_mul(b.into()))
 	}
 	/// Storage: System Digest (r:1 w:1)
 	/// Proof Skipped: System Digest (max_values: Some(1), max_size: None, mode: Measured)
@@ -78,8 +78,8 @@ impl<T: frame_system::Config> frame_system::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `495`
 		// Minimum execution time: 3_408 nanoseconds.
-		Weight::from_ref_time(3_633_000)
-			.saturating_add(Weight::from_proof_size(495))
+		Weight::from_parts(3_633_000, 0)
+			.saturating_add(Weight::from_parts(0, 495))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -91,10 +91,10 @@ impl<T: frame_system::Config> frame_system::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 1_727 nanoseconds.
-		Weight::from_ref_time(1_753_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(1_753_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			// Standard Error: 1_876
-			.saturating_add(Weight::from_ref_time(581_935).saturating_mul(i.into()))
+			.saturating_add(Weight::from_parts(581_935, 0).saturating_mul(i.into()))
 			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(i.into())))
 	}
 	/// Storage: Skipped Metadata (r:0 w:0)
@@ -105,10 +105,10 @@ impl<T: frame_system::Config> frame_system::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 1_743 nanoseconds.
-		Weight::from_ref_time(1_769_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(1_769_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			// Standard Error: 803
-			.saturating_add(Weight::from_ref_time(446_779).saturating_mul(i.into()))
+			.saturating_add(Weight::from_parts(446_779, 0).saturating_mul(i.into()))
 			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(i.into())))
 	}
 	/// Storage: Skipped Metadata (r:0 w:0)
@@ -119,11 +119,11 @@ impl<T: frame_system::Config> frame_system::WeightInfo for WeightInfo<T> {
 		//  Measured:  `68 + p * (69 ±0)`
 		//  Estimated: `66 + p * (70 ±0)`
 		// Minimum execution time: 3_536 nanoseconds.
-		Weight::from_ref_time(3_649_000)
-			.saturating_add(Weight::from_proof_size(66))
+		Weight::from_parts(3_649_000, 0)
+			.saturating_add(Weight::from_parts(0, 66))
 			// Standard Error: 949
-			.saturating_add(Weight::from_ref_time(986_632).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(986_632, 0).saturating_mul(p.into()))
 			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(p.into())))
-			.saturating_add(Weight::from_proof_size(70).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(0, 70).saturating_mul(p.into()))
 	}
 }

--- a/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/weights/pallet_balances.rs
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/weights/pallet_balances.rs
@@ -54,8 +54,8 @@ impl<T: frame_system::Config> pallet_balances::WeightInfo for WeightInfo<T> {
 		//  Measured:  `1314`
 		//  Estimated: `2603`
 		// Minimum execution time: 47_893 nanoseconds.
-		Weight::from_ref_time(48_384_000)
-			.saturating_add(Weight::from_proof_size(2603))
+		Weight::from_parts(48_384_000, 0)
+			.saturating_add(Weight::from_parts(0, 2603))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -66,8 +66,8 @@ impl<T: frame_system::Config> pallet_balances::WeightInfo for WeightInfo<T> {
 		//  Measured:  `1198`
 		//  Estimated: `2603`
 		// Minimum execution time: 35_027 nanoseconds.
-		Weight::from_ref_time(35_675_000)
-			.saturating_add(Weight::from_proof_size(2603))
+		Weight::from_parts(35_675_000, 0)
+			.saturating_add(Weight::from_parts(0, 2603))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -78,8 +78,8 @@ impl<T: frame_system::Config> pallet_balances::WeightInfo for WeightInfo<T> {
 		//  Measured:  `1348`
 		//  Estimated: `2603`
 		// Minimum execution time: 26_009 nanoseconds.
-		Weight::from_ref_time(26_448_000)
-			.saturating_add(Weight::from_proof_size(2603))
+		Weight::from_parts(26_448_000, 0)
+			.saturating_add(Weight::from_parts(0, 2603))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -90,8 +90,8 @@ impl<T: frame_system::Config> pallet_balances::WeightInfo for WeightInfo<T> {
 		//  Measured:  `1348`
 		//  Estimated: `2603`
 		// Minimum execution time: 30_006 nanoseconds.
-		Weight::from_ref_time(30_501_000)
-			.saturating_add(Weight::from_proof_size(2603))
+		Weight::from_parts(30_501_000, 0)
+			.saturating_add(Weight::from_parts(0, 2603))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -102,8 +102,8 @@ impl<T: frame_system::Config> pallet_balances::WeightInfo for WeightInfo<T> {
 		//  Measured:  `1310`
 		//  Estimated: `5206`
 		// Minimum execution time: 46_787 nanoseconds.
-		Weight::from_ref_time(47_700_000)
-			.saturating_add(Weight::from_proof_size(5206))
+		Weight::from_parts(47_700_000, 0)
+			.saturating_add(Weight::from_parts(0, 5206))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -114,8 +114,8 @@ impl<T: frame_system::Config> pallet_balances::WeightInfo for WeightInfo<T> {
 		//  Measured:  `1198`
 		//  Estimated: `2603`
 		// Minimum execution time: 43_890 nanoseconds.
-		Weight::from_ref_time(44_914_000)
-			.saturating_add(Weight::from_proof_size(2603))
+		Weight::from_parts(44_914_000, 0)
+			.saturating_add(Weight::from_parts(0, 2603))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -126,8 +126,8 @@ impl<T: frame_system::Config> pallet_balances::WeightInfo for WeightInfo<T> {
 		//  Measured:  `1232`
 		//  Estimated: `2603`
 		// Minimum execution time: 26_785 nanoseconds.
-		Weight::from_ref_time(27_404_000)
-			.saturating_add(Weight::from_proof_size(2603))
+		Weight::from_parts(27_404_000, 0)
+			.saturating_add(Weight::from_parts(0, 2603))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}

--- a/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/weights/pallet_collator_selection.rs
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/weights/pallet_collator_selection.rs
@@ -57,13 +57,13 @@ impl<T: frame_system::Config> pallet_collator_selection::WeightInfo for WeightIn
 		//  Measured:  `214 + b * (78 ±0)`
 		//  Estimated: `213 + b * (2554 ±0)`
 		// Minimum execution time: 14_254 nanoseconds.
-		Weight::from_ref_time(15_028_628)
-			.saturating_add(Weight::from_proof_size(213))
+		Weight::from_parts(15_028_628, 0)
+			.saturating_add(Weight::from_parts(0, 213))
 			// Standard Error: 3_094
-			.saturating_add(Weight::from_ref_time(2_490_219).saturating_mul(b.into()))
+			.saturating_add(Weight::from_parts(2_490_219, 0).saturating_mul(b.into()))
 			.saturating_add(T::DbWeight::get().reads((1_u64).saturating_mul(b.into())))
 			.saturating_add(T::DbWeight::get().writes(1))
-			.saturating_add(Weight::from_proof_size(2554).saturating_mul(b.into()))
+			.saturating_add(Weight::from_parts(0, 2554).saturating_mul(b.into()))
 	}
 	/// Storage: CollatorSelection DesiredCandidates (r:0 w:1)
 	/// Proof: CollatorSelection DesiredCandidates (max_values: Some(1), max_size: Some(4), added: 499, mode: MaxEncodedLen)
@@ -72,8 +72,8 @@ impl<T: frame_system::Config> pallet_collator_selection::WeightInfo for WeightIn
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 6_548 nanoseconds.
-		Weight::from_ref_time(6_775_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(6_775_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
 	/// Storage: CollatorSelection CandidacyBond (r:0 w:1)
@@ -83,8 +83,8 @@ impl<T: frame_system::Config> pallet_collator_selection::WeightInfo for WeightIn
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 6_922 nanoseconds.
-		Weight::from_ref_time(7_184_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(7_184_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
 	/// Storage: CollatorSelection Candidates (r:1 w:1)
@@ -105,13 +105,13 @@ impl<T: frame_system::Config> pallet_collator_selection::WeightInfo for WeightIn
 		//  Measured:  `1167 + c * (48 ±0)`
 		//  Estimated: `56785 + c * (49 ±0)`
 		// Minimum execution time: 35_329 nanoseconds.
-		Weight::from_ref_time(27_879_325)
-			.saturating_add(Weight::from_proof_size(56785))
+		Weight::from_parts(27_879_325, 0)
+			.saturating_add(Weight::from_parts(0, 56785))
 			// Standard Error: 1_269
-			.saturating_add(Weight::from_ref_time(108_458).saturating_mul(c.into()))
+			.saturating_add(Weight::from_parts(108_458, 0).saturating_mul(c.into()))
 			.saturating_add(T::DbWeight::get().reads(5))
 			.saturating_add(T::DbWeight::get().writes(2))
-			.saturating_add(Weight::from_proof_size(49).saturating_mul(c.into()))
+			.saturating_add(Weight::from_parts(0, 49).saturating_mul(c.into()))
 	}
 	/// Storage: CollatorSelection Candidates (r:1 w:1)
 	/// Proof: CollatorSelection Candidates (max_values: Some(1), max_size: Some(48002), added: 48497, mode: MaxEncodedLen)
@@ -123,10 +123,10 @@ impl<T: frame_system::Config> pallet_collator_selection::WeightInfo for WeightIn
 		//  Measured:  `503 + c * (48 ±0)`
 		//  Estimated: `48497`
 		// Minimum execution time: 27_322 nanoseconds.
-		Weight::from_ref_time(16_354_913)
-			.saturating_add(Weight::from_proof_size(48497))
+		Weight::from_parts(16_354_913, 0)
+			.saturating_add(Weight::from_parts(0, 48497))
 			// Standard Error: 1_399
-			.saturating_add(Weight::from_ref_time(108_840).saturating_mul(c.into()))
+			.saturating_add(Weight::from_parts(108_840, 0).saturating_mul(c.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -141,8 +141,8 @@ impl<T: frame_system::Config> pallet_collator_selection::WeightInfo for WeightIn
 		//  Measured:  `187`
 		//  Estimated: `5749`
 		// Minimum execution time: 26_074 nanoseconds.
-		Weight::from_ref_time(26_574_000)
-			.saturating_add(Weight::from_proof_size(5749))
+		Weight::from_parts(26_574_000, 0)
+			.saturating_add(Weight::from_parts(0, 5749))
 			.saturating_add(T::DbWeight::get().reads(3))
 			.saturating_add(T::DbWeight::get().writes(4))
 	}
@@ -163,15 +163,15 @@ impl<T: frame_system::Config> pallet_collator_selection::WeightInfo for WeightIn
 		//  Measured:  `22878 + r * (148 ±0) + c * (97 ±0)`
 		//  Estimated: `52737 + r * (2602 ±0) + c * (2519 ±0)`
 		// Minimum execution time: 15_727 nanoseconds.
-		Weight::from_ref_time(16_001_000)
-			.saturating_add(Weight::from_proof_size(52737))
+		Weight::from_parts(16_001_000, 0)
+			.saturating_add(Weight::from_parts(0, 52737))
 			// Standard Error: 792_964
-			.saturating_add(Weight::from_ref_time(28_827_951).saturating_mul(c.into()))
+			.saturating_add(Weight::from_parts(28_827_951, 0).saturating_mul(c.into()))
 			.saturating_add(T::DbWeight::get().reads(4))
 			.saturating_add(T::DbWeight::get().reads((1_u64).saturating_mul(c.into())))
 			.saturating_add(T::DbWeight::get().writes(1))
 			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(c.into())))
-			.saturating_add(Weight::from_proof_size(2602).saturating_mul(r.into()))
-			.saturating_add(Weight::from_proof_size(2519).saturating_mul(c.into()))
+			.saturating_add(Weight::from_parts(0, 2602).saturating_mul(r.into()))
+			.saturating_add(Weight::from_parts(0, 2519).saturating_mul(c.into()))
 	}
 }

--- a/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/weights/pallet_multisig.rs
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/weights/pallet_multisig.rs
@@ -53,10 +53,10 @@ impl<T: frame_system::Config> pallet_multisig::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 11_903 nanoseconds.
-		Weight::from_ref_time(12_398_025)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(12_398_025, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			// Standard Error: 1
-			.saturating_add(Weight::from_ref_time(550).saturating_mul(z.into()))
+			.saturating_add(Weight::from_parts(550, 0).saturating_mul(z.into()))
 	}
 	/// Storage: Multisig Multisigs (r:1 w:1)
 	/// Proof: Multisig Multisigs (max_values: None, max_size: Some(3346), added: 5821, mode: MaxEncodedLen)
@@ -67,12 +67,12 @@ impl<T: frame_system::Config> pallet_multisig::WeightInfo for WeightInfo<T> {
 		//  Measured:  `314 + s * (2 ±0)`
 		//  Estimated: `5821`
 		// Minimum execution time: 35_780 nanoseconds.
-		Weight::from_ref_time(29_310_705)
-			.saturating_add(Weight::from_proof_size(5821))
+		Weight::from_parts(29_310_705, 0)
+			.saturating_add(Weight::from_parts(0, 5821))
 			// Standard Error: 602
-			.saturating_add(Weight::from_ref_time(70_837).saturating_mul(s.into()))
+			.saturating_add(Weight::from_parts(70_837, 0).saturating_mul(s.into()))
 			// Standard Error: 5
-			.saturating_add(Weight::from_ref_time(1_545).saturating_mul(z.into()))
+			.saturating_add(Weight::from_parts(1_545, 0).saturating_mul(z.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -85,12 +85,12 @@ impl<T: frame_system::Config> pallet_multisig::WeightInfo for WeightInfo<T> {
 		//  Measured:  `313`
 		//  Estimated: `5821`
 		// Minimum execution time: 26_552 nanoseconds.
-		Weight::from_ref_time(19_998_713)
-			.saturating_add(Weight::from_proof_size(5821))
+		Weight::from_parts(19_998_713, 0)
+			.saturating_add(Weight::from_parts(0, 5821))
 			// Standard Error: 711
-			.saturating_add(Weight::from_ref_time(72_463).saturating_mul(s.into()))
+			.saturating_add(Weight::from_parts(72_463, 0).saturating_mul(s.into()))
 			// Standard Error: 6
-			.saturating_add(Weight::from_ref_time(1_573).saturating_mul(z.into()))
+			.saturating_add(Weight::from_parts(1_573, 0).saturating_mul(z.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -105,12 +105,12 @@ impl<T: frame_system::Config> pallet_multisig::WeightInfo for WeightInfo<T> {
 		//  Measured:  `451 + s * (33 ±0)`
 		//  Estimated: `8424`
 		// Minimum execution time: 40_836 nanoseconds.
-		Weight::from_ref_time(32_275_692)
-			.saturating_add(Weight::from_proof_size(8424))
+		Weight::from_parts(32_275_692, 0)
+			.saturating_add(Weight::from_parts(0, 8424))
 			// Standard Error: 673
-			.saturating_add(Weight::from_ref_time(92_895).saturating_mul(s.into()))
+			.saturating_add(Weight::from_parts(92_895, 0).saturating_mul(s.into()))
 			// Standard Error: 6
-			.saturating_add(Weight::from_ref_time(1_569).saturating_mul(z.into()))
+			.saturating_add(Weight::from_parts(1_569, 0).saturating_mul(z.into()))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -122,10 +122,10 @@ impl<T: frame_system::Config> pallet_multisig::WeightInfo for WeightInfo<T> {
 		//  Measured:  `321 + s * (2 ±0)`
 		//  Estimated: `5821`
 		// Minimum execution time: 26_440 nanoseconds.
-		Weight::from_ref_time(27_434_937)
-			.saturating_add(Weight::from_proof_size(5821))
+		Weight::from_parts(27_434_937, 0)
+			.saturating_add(Weight::from_parts(0, 5821))
 			// Standard Error: 725
-			.saturating_add(Weight::from_ref_time(80_283).saturating_mul(s.into()))
+			.saturating_add(Weight::from_parts(80_283, 0).saturating_mul(s.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -137,10 +137,10 @@ impl<T: frame_system::Config> pallet_multisig::WeightInfo for WeightInfo<T> {
 		//  Measured:  `313`
 		//  Estimated: `5821`
 		// Minimum execution time: 17_335 nanoseconds.
-		Weight::from_ref_time(18_873_349)
-			.saturating_add(Weight::from_proof_size(5821))
+		Weight::from_parts(18_873_349, 0)
+			.saturating_add(Weight::from_parts(0, 5821))
 			// Standard Error: 490
-			.saturating_add(Weight::from_ref_time(74_017).saturating_mul(s.into()))
+			.saturating_add(Weight::from_parts(74_017, 0).saturating_mul(s.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -152,10 +152,10 @@ impl<T: frame_system::Config> pallet_multisig::WeightInfo for WeightInfo<T> {
 		//  Measured:  `517 + s * (1 ±0)`
 		//  Estimated: `5821`
 		// Minimum execution time: 26_731 nanoseconds.
-		Weight::from_ref_time(28_534_422)
-			.saturating_add(Weight::from_proof_size(5821))
+		Weight::from_parts(28_534_422, 0)
+			.saturating_add(Weight::from_parts(0, 5821))
 			// Standard Error: 740
-			.saturating_add(Weight::from_ref_time(78_223).saturating_mul(s.into()))
+			.saturating_add(Weight::from_parts(78_223, 0).saturating_mul(s.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}

--- a/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/weights/pallet_session.rs
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/weights/pallet_session.rs
@@ -56,8 +56,8 @@ impl<T: frame_system::Config> pallet_session::WeightInfo for WeightInfo<T> {
 		//  Measured:  `297`
 		//  Estimated: `5544`
 		// Minimum execution time: 15_721 nanoseconds.
-		Weight::from_ref_time(16_081_000)
-			.saturating_add(Weight::from_proof_size(5544))
+		Weight::from_parts(16_081_000, 0)
+			.saturating_add(Weight::from_parts(0, 5544))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -70,8 +70,8 @@ impl<T: frame_system::Config> pallet_session::WeightInfo for WeightInfo<T> {
 		//  Measured:  `279`
 		//  Estimated: `3033`
 		// Minimum execution time: 12_031 nanoseconds.
-		Weight::from_ref_time(12_339_000)
-			.saturating_add(Weight::from_proof_size(3033))
+		Weight::from_parts(12_339_000, 0)
+			.saturating_add(Weight::from_parts(0, 3033))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}

--- a/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/weights/pallet_timestamp.rs
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/weights/pallet_timestamp.rs
@@ -56,8 +56,8 @@ impl<T: frame_system::Config> pallet_timestamp::WeightInfo for WeightInfo<T> {
 		//  Measured:  `49`
 		//  Estimated: `1006`
 		// Minimum execution time: 7_216 nanoseconds.
-		Weight::from_ref_time(7_445_000)
-			.saturating_add(Weight::from_proof_size(1006))
+		Weight::from_parts(7_445_000, 0)
+			.saturating_add(Weight::from_parts(0, 1006))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -66,7 +66,7 @@ impl<T: frame_system::Config> pallet_timestamp::WeightInfo for WeightInfo<T> {
 		//  Measured:  `57`
 		//  Estimated: `0`
 		// Minimum execution time: 3_181 nanoseconds.
-		Weight::from_ref_time(3_322_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(3_322_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 	}
 }

--- a/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/weights/pallet_utility.rs
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/weights/pallet_utility.rs
@@ -53,18 +53,18 @@ impl<T: frame_system::Config> pallet_utility::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 6_179 nanoseconds.
-		Weight::from_ref_time(19_315_482)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(19_315_482, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			// Standard Error: 3_383
-			.saturating_add(Weight::from_ref_time(4_126_811).saturating_mul(c.into()))
+			.saturating_add(Weight::from_parts(4_126_811, 0).saturating_mul(c.into()))
 	}
 	fn as_derivative() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 4_474 nanoseconds.
-		Weight::from_ref_time(4_666_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(4_666_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 	}
 	/// The range of component `c` is `[0, 1000]`.
 	fn batch_all(c: u32, ) -> Weight {
@@ -72,18 +72,18 @@ impl<T: frame_system::Config> pallet_utility::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 6_210 nanoseconds.
-		Weight::from_ref_time(12_190_913)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(12_190_913, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			// Standard Error: 2_328
-			.saturating_add(Weight::from_ref_time(4_370_533).saturating_mul(c.into()))
+			.saturating_add(Weight::from_parts(4_370_533, 0).saturating_mul(c.into()))
 	}
 	fn dispatch_as() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 8_194 nanoseconds.
-		Weight::from_ref_time(8_300_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(8_300_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 	}
 	/// The range of component `c` is `[0, 1000]`.
 	fn force_batch(c: u32, ) -> Weight {
@@ -91,9 +91,9 @@ impl<T: frame_system::Config> pallet_utility::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 6_207 nanoseconds.
-		Weight::from_ref_time(9_704_236)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(9_704_236, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			// Standard Error: 4_155
-			.saturating_add(Weight::from_ref_time(4_130_222).saturating_mul(c.into()))
+			.saturating_add(Weight::from_parts(4_130_222, 0).saturating_mul(c.into()))
 	}
 }

--- a/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/weights/pallet_xcm.rs
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/weights/pallet_xcm.rs
@@ -62,8 +62,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `38`
 		//  Estimated: `4645`
 		// Minimum execution time: 25_656 nanoseconds.
-		Weight::from_ref_time(25_942_000)
-			.saturating_add(Weight::from_proof_size(4645))
+		Weight::from_parts(25_942_000, 0)
+			.saturating_add(Weight::from_parts(0, 4645))
 			.saturating_add(T::DbWeight::get().reads(5))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -74,8 +74,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `32`
 		//  Estimated: `499`
 		// Minimum execution time: 26_559 nanoseconds.
-		Weight::from_ref_time(27_040_000)
-			.saturating_add(Weight::from_proof_size(499))
+		Weight::from_parts(27_040_000, 0)
+			.saturating_add(Weight::from_parts(0, 499))
 			.saturating_add(T::DbWeight::get().reads(1))
 	}
 	/// Storage: Benchmark Override (r:0 w:0)
@@ -85,8 +85,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 18_446_744_073_709_551 nanoseconds.
-		Weight::from_ref_time(18_446_744_073_709_551_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(18_446_744_073_709_551_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 	}
 	/// Storage: Benchmark Override (r:0 w:0)
 	/// Proof Skipped: Benchmark Override (max_values: None, max_size: None, mode: Measured)
@@ -95,8 +95,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 18_446_744_073_709_551 nanoseconds.
-		Weight::from_ref_time(18_446_744_073_709_551_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(18_446_744_073_709_551_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 	}
 	/// Storage: PolkadotXcm SupportedVersion (r:0 w:1)
 	/// Proof Skipped: PolkadotXcm SupportedVersion (max_values: None, max_size: None, mode: Measured)
@@ -105,8 +105,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 9_204 nanoseconds.
-		Weight::from_ref_time(9_400_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(9_400_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
 	/// Storage: PolkadotXcm SafeXcmVersion (r:0 w:1)
@@ -116,8 +116,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 2_652 nanoseconds.
-		Weight::from_ref_time(2_790_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(2_790_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
 	/// Storage: PolkadotXcm VersionNotifiers (r:1 w:1)
@@ -141,8 +141,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `38`
 		//  Estimated: `7729`
 		// Minimum execution time: 29_636 nanoseconds.
-		Weight::from_ref_time(30_041_000)
-			.saturating_add(Weight::from_proof_size(7729))
+		Weight::from_parts(30_041_000, 0)
+			.saturating_add(Weight::from_parts(0, 7729))
 			.saturating_add(T::DbWeight::get().reads(7))
 			.saturating_add(T::DbWeight::get().writes(5))
 	}
@@ -165,8 +165,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `220`
 		//  Estimated: `8470`
 		// Minimum execution time: 31_854 nanoseconds.
-		Weight::from_ref_time(32_416_000)
-			.saturating_add(Weight::from_proof_size(8470))
+		Weight::from_parts(32_416_000, 0)
+			.saturating_add(Weight::from_parts(0, 8470))
 			.saturating_add(T::DbWeight::get().reads(6))
 			.saturating_add(T::DbWeight::get().writes(4))
 	}
@@ -177,8 +177,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `95`
 		//  Estimated: `9995`
 		// Minimum execution time: 13_994 nanoseconds.
-		Weight::from_ref_time(14_361_000)
-			.saturating_add(Weight::from_proof_size(9995))
+		Weight::from_parts(14_361_000, 0)
+			.saturating_add(Weight::from_parts(0, 9995))
 			.saturating_add(T::DbWeight::get().reads(4))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -189,8 +189,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `99`
 		//  Estimated: `9999`
 		// Minimum execution time: 14_337 nanoseconds.
-		Weight::from_ref_time(14_651_000)
-			.saturating_add(Weight::from_proof_size(9999))
+		Weight::from_parts(14_651_000, 0)
+			.saturating_add(Weight::from_parts(0, 9999))
 			.saturating_add(T::DbWeight::get().reads(4))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -201,8 +201,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `106`
 		//  Estimated: `12481`
 		// Minimum execution time: 15_624 nanoseconds.
-		Weight::from_ref_time(15_936_000)
-			.saturating_add(Weight::from_proof_size(12481))
+		Weight::from_parts(15_936_000, 0)
+			.saturating_add(Weight::from_parts(0, 12481))
 			.saturating_add(T::DbWeight::get().reads(5))
 	}
 	/// Storage: PolkadotXcm VersionNotifyTargets (r:2 w:1)
@@ -222,8 +222,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `106`
 		//  Estimated: `10041`
 		// Minimum execution time: 26_774 nanoseconds.
-		Weight::from_ref_time(27_140_000)
-			.saturating_add(Weight::from_proof_size(10041))
+		Weight::from_parts(27_140_000, 0)
+			.saturating_add(Weight::from_parts(0, 10041))
 			.saturating_add(T::DbWeight::get().reads(7))
 			.saturating_add(T::DbWeight::get().writes(3))
 	}
@@ -234,8 +234,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `136`
 		//  Estimated: `7561`
 		// Minimum execution time: 7_233 nanoseconds.
-		Weight::from_ref_time(7_487_000)
-			.saturating_add(Weight::from_proof_size(7561))
+		Weight::from_parts(7_487_000, 0)
+			.saturating_add(Weight::from_parts(0, 7561))
 			.saturating_add(T::DbWeight::get().reads(3))
 	}
 	/// Storage: PolkadotXcm VersionNotifyTargets (r:4 w:2)
@@ -245,8 +245,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `106`
 		//  Estimated: `10006`
 		// Minimum execution time: 14_801 nanoseconds.
-		Weight::from_ref_time(15_090_000)
-			.saturating_add(Weight::from_proof_size(10006))
+		Weight::from_parts(15_090_000, 0)
+			.saturating_add(Weight::from_parts(0, 10006))
 			.saturating_add(T::DbWeight::get().reads(4))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -267,8 +267,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `112`
 		//  Estimated: `15027`
 		// Minimum execution time: 32_613 nanoseconds.
-		Weight::from_ref_time(32_978_000)
-			.saturating_add(Weight::from_proof_size(15027))
+		Weight::from_parts(32_978_000, 0)
+			.saturating_add(Weight::from_parts(0, 15027))
 			.saturating_add(T::DbWeight::get().reads(9))
 			.saturating_add(T::DbWeight::get().writes(4))
 	}

--- a/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/weights/xcm/mod.rs
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/weights/xcm/mod.rs
@@ -65,7 +65,7 @@ impl<Call> XcmWeightInfo<Call> for BridgeHubRococoXcmWeight<Call> {
 	// Currently there is no trusted reserve
 	fn reserve_asset_deposited(_assets: &MultiAssets) -> Weight {
 		// TODO: hardcoded - fix https://github.com/paritytech/cumulus/issues/1974
-		Weight::from_ref_time(1_000_000_000 as u64)
+		Weight::from_parts(1_000_000_000 as u64, 0)
 	}
 	fn receive_teleported_asset(assets: &MultiAssets) -> Weight {
 		assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::receive_teleported_asset())
@@ -123,7 +123,7 @@ impl<Call> XcmWeightInfo<Call> for BridgeHubRococoXcmWeight<Call> {
 
 	fn deposit_asset(assets: &MultiAssetFilter, _dest: &MultiLocation) -> Weight {
 		// Hardcoded till the XCM pallet is fixed
-		let hardcoded_weight = Weight::from_ref_time(1_000_000_000 as u64);
+		let hardcoded_weight = Weight::from_parts(1_000_000_000 as u64, 0);
 		let weight = assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::deposit_asset());
 		hardcoded_weight.min(weight)
 	}

--- a/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/weights/xcm/pallet_xcm_benchmarks_fungible.rs
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/weights/xcm/pallet_xcm_benchmarks_fungible.rs
@@ -51,14 +51,14 @@ impl<T: frame_system::Config> WeightInfo<T> {
 	// Storage: System Account (r:1 w:1)
 	// Proof: System Account (max_values: None, max_size: Some(128), added: 2603, mode: MaxEncodedLen)
 	pub(crate) fn withdraw_asset() -> Weight {
-		Weight::from_ref_time(20_377_000 as u64)
+		Weight::from_parts(20_377_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: System Account (r:2 w:2)
 	// Proof: System Account (max_values: None, max_size: Some(128), added: 2603, mode: MaxEncodedLen)
 	pub(crate) fn transfer_asset() -> Weight {
-		Weight::from_ref_time(31_004_000 as u64)
+		Weight::from_parts(31_004_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(2 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
@@ -77,17 +77,17 @@ impl<T: frame_system::Config> WeightInfo<T> {
 	// Storage: ParachainSystem PendingUpwardMessages (r:1 w:1)
 	// Proof Skipped: ParachainSystem PendingUpwardMessages (max_values: Some(1), max_size: None, mode: Measured)
 	pub(crate) fn transfer_reserve_asset() -> Weight {
-		Weight::from_ref_time(54_173_000 as u64)
+		Weight::from_parts(54_173_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(8 as u64))
 			.saturating_add(T::DbWeight::get().writes(4 as u64))
 	}
 	pub(crate) fn receive_teleported_asset() -> Weight {
-		Weight::from_ref_time(4_635_000 as u64)
+		Weight::from_parts(4_635_000 as u64, 0)
 	}
 	// Storage: System Account (r:1 w:1)
 	// Proof: System Account (max_values: None, max_size: Some(128), added: 2603, mode: MaxEncodedLen)
 	pub(crate) fn deposit_asset() -> Weight {
-		Weight::from_ref_time(23_155_000 as u64)
+		Weight::from_parts(23_155_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
@@ -106,7 +106,7 @@ impl<T: frame_system::Config> WeightInfo<T> {
 	// Storage: ParachainSystem PendingUpwardMessages (r:1 w:1)
 	// Proof Skipped: ParachainSystem PendingUpwardMessages (max_values: Some(1), max_size: None, mode: Measured)
 	pub(crate) fn deposit_reserve_asset() -> Weight {
-		Weight::from_ref_time(52_599_000 as u64)
+		Weight::from_parts(52_599_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(7 as u64))
 			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
@@ -123,7 +123,7 @@ impl<T: frame_system::Config> WeightInfo<T> {
 	// Storage: ParachainSystem PendingUpwardMessages (r:1 w:1)
 	// Proof Skipped: ParachainSystem PendingUpwardMessages (max_values: Some(1), max_size: None, mode: Measured)
 	pub(crate) fn initiate_teleport() -> Weight {
-		Weight::from_ref_time(34_004_000 as u64)
+		Weight::from_parts(34_004_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(6 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}

--- a/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/weights/xcm/pallet_xcm_benchmarks_generic.rs
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/weights/xcm/pallet_xcm_benchmarks_generic.rs
@@ -61,39 +61,39 @@ impl<T: frame_system::Config> WeightInfo<T> {
 	// Storage: ParachainSystem PendingUpwardMessages (r:1 w:1)
 	// Proof Skipped: ParachainSystem PendingUpwardMessages (max_values: Some(1), max_size: None, mode: Measured)
 	pub(crate) fn report_holding() -> Weight {
-		Weight::from_ref_time(32_598_000 as u64)
+		Weight::from_parts(32_598_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(6 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	pub(crate) fn buy_execution() -> Weight {
-		Weight::from_ref_time(3_195_000 as u64)
+		Weight::from_parts(3_195_000 as u64, 0)
 	}
 	// Storage: PolkadotXcm Queries (r:1 w:0)
 	// Proof Skipped: PolkadotXcm Queries (max_values: None, max_size: None, mode: Measured)
 	pub(crate) fn query_response() -> Weight {
-		Weight::from_ref_time(10_939_000 as u64)
+		Weight::from_parts(10_939_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 	}
 	pub(crate) fn transact() -> Weight {
-		Weight::from_ref_time(12_473_000 as u64)
+		Weight::from_parts(12_473_000 as u64, 0)
 	}
 	pub(crate) fn refund_surplus() -> Weight {
-		Weight::from_ref_time(3_458_000 as u64)
+		Weight::from_parts(3_458_000 as u64, 0)
 	}
 	pub(crate) fn set_error_handler() -> Weight {
-		Weight::from_ref_time(3_252_000 as u64)
+		Weight::from_parts(3_252_000 as u64, 0)
 	}
 	pub(crate) fn set_appendix() -> Weight {
-		Weight::from_ref_time(3_249_000 as u64)
+		Weight::from_parts(3_249_000 as u64, 0)
 	}
 	pub(crate) fn clear_error() -> Weight {
-		Weight::from_ref_time(3_190_000 as u64)
+		Weight::from_parts(3_190_000 as u64, 0)
 	}
 	pub(crate) fn descend_origin() -> Weight {
-		Weight::from_ref_time(4_268_000 as u64)
+		Weight::from_parts(4_268_000 as u64, 0)
 	}
 	pub(crate) fn clear_origin() -> Weight {
-		Weight::from_ref_time(3_255_000 as u64)
+		Weight::from_parts(3_255_000 as u64, 0)
 	}
 	// Storage: ParachainInfo ParachainId (r:1 w:0)
 	// Proof: ParachainInfo ParachainId (max_values: Some(1), max_size: Some(4), added: 499, mode: MaxEncodedLen)
@@ -108,19 +108,19 @@ impl<T: frame_system::Config> WeightInfo<T> {
 	// Storage: ParachainSystem PendingUpwardMessages (r:1 w:1)
 	// Proof Skipped: ParachainSystem PendingUpwardMessages (max_values: Some(1), max_size: None, mode: Measured)
 	pub(crate) fn report_error() -> Weight {
-		Weight::from_ref_time(25_755_000 as u64)
+		Weight::from_parts(25_755_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(6 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	// Storage: PolkadotXcm AssetTraps (r:1 w:1)
 	// Proof Skipped: PolkadotXcm AssetTraps (max_values: None, max_size: None, mode: Measured)
 	pub(crate) fn claim_asset() -> Weight {
-		Weight::from_ref_time(15_124_000 as u64)
+		Weight::from_parts(15_124_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(1 as u64))
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	pub(crate) fn trap() -> Weight {
-		Weight::from_ref_time(3_164_000 as u64)
+		Weight::from_parts(3_164_000 as u64, 0)
 	}
 	// Storage: PolkadotXcm VersionNotifyTargets (r:1 w:1)
 	// Proof Skipped: PolkadotXcm VersionNotifyTargets (max_values: None, max_size: None, mode: Measured)
@@ -135,14 +135,14 @@ impl<T: frame_system::Config> WeightInfo<T> {
 	// Storage: ParachainSystem PendingUpwardMessages (r:1 w:1)
 	// Proof Skipped: ParachainSystem PendingUpwardMessages (max_values: Some(1), max_size: None, mode: Measured)
 	pub(crate) fn subscribe_version() -> Weight {
-		Weight::from_ref_time(25_329_000 as u64)
+		Weight::from_parts(25_329_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(6 as u64))
 			.saturating_add(T::DbWeight::get().writes(3 as u64))
 	}
 	// Storage: PolkadotXcm VersionNotifyTargets (r:0 w:1)
 	// Proof Skipped: PolkadotXcm VersionNotifyTargets (max_values: None, max_size: None, mode: Measured)
 	pub(crate) fn unsubscribe_version() -> Weight {
-		Weight::from_ref_time(5_253_000 as u64)
+		Weight::from_parts(5_253_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().writes(1 as u64))
 	}
 	// Storage: ParachainInfo ParachainId (r:1 w:0)
@@ -158,24 +158,24 @@ impl<T: frame_system::Config> WeightInfo<T> {
 	// Storage: ParachainSystem PendingUpwardMessages (r:1 w:1)
 	// Proof Skipped: ParachainSystem PendingUpwardMessages (max_values: Some(1), max_size: None, mode: Measured)
 	pub(crate) fn initiate_reserve_withdraw() -> Weight {
-		Weight::from_ref_time(29_304_000 as u64)
+		Weight::from_parts(29_304_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(6 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	pub(crate) fn burn_asset() -> Weight {
-		Weight::from_ref_time(5_275_000 as u64)
+		Weight::from_parts(5_275_000 as u64, 0)
 	}
 	pub(crate) fn expect_asset() -> Weight {
-		Weight::from_ref_time(3_355_000 as u64)
+		Weight::from_parts(3_355_000 as u64, 0)
 	}
 	pub(crate) fn expect_origin() -> Weight {
-		Weight::from_ref_time(3_391_000 as u64)
+		Weight::from_parts(3_391_000 as u64, 0)
 	}
 	pub(crate) fn expect_error() -> Weight {
-		Weight::from_ref_time(3_192_000 as u64)
+		Weight::from_parts(3_192_000 as u64, 0)
 	}
 	pub(crate) fn expect_transact_status() -> Weight {
-		Weight::from_ref_time(3_342_000 as u64)
+		Weight::from_parts(3_342_000 as u64, 0)
 	}
 	// Storage: ParachainInfo ParachainId (r:1 w:0)
 	// Proof: ParachainInfo ParachainId (max_values: Some(1), max_size: Some(4), added: 499, mode: MaxEncodedLen)
@@ -190,12 +190,12 @@ impl<T: frame_system::Config> WeightInfo<T> {
 	// Storage: ParachainSystem PendingUpwardMessages (r:1 w:1)
 	// Proof Skipped: ParachainSystem PendingUpwardMessages (max_values: Some(1), max_size: None, mode: Measured)
 	pub(crate) fn query_pallet() -> Weight {
-		Weight::from_ref_time(28_426_000 as u64)
+		Weight::from_parts(28_426_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(6 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	pub(crate) fn expect_pallet() -> Weight {
-		Weight::from_ref_time(4_826_000 as u64)
+		Weight::from_parts(4_826_000 as u64, 0)
 	}
 	// Storage: ParachainInfo ParachainId (r:1 w:0)
 	// Proof: ParachainInfo ParachainId (max_values: Some(1), max_size: Some(4), added: 499, mode: MaxEncodedLen)
@@ -210,23 +210,23 @@ impl<T: frame_system::Config> WeightInfo<T> {
 	// Storage: ParachainSystem PendingUpwardMessages (r:1 w:1)
 	// Proof Skipped: ParachainSystem PendingUpwardMessages (max_values: Some(1), max_size: None, mode: Measured)
 	pub(crate) fn report_transact_status() -> Weight {
-		Weight::from_ref_time(26_238_000 as u64)
+		Weight::from_parts(26_238_000 as u64, 0)
 			.saturating_add(T::DbWeight::get().reads(6 as u64))
 			.saturating_add(T::DbWeight::get().writes(2 as u64))
 	}
 	pub(crate) fn clear_transact_status() -> Weight {
-		Weight::from_ref_time(3_240_000 as u64)
+		Weight::from_parts(3_240_000 as u64, 0)
 	}
 	pub(crate) fn set_topic() -> Weight {
-		Weight::from_ref_time(3_181_000 as u64)
+		Weight::from_parts(3_181_000 as u64, 0)
 	}
 	pub(crate) fn clear_topic() -> Weight {
-		Weight::from_ref_time(3_142_000 as u64)
+		Weight::from_parts(3_142_000 as u64, 0)
 	}
 	pub(crate) fn set_fees_mode() -> Weight {
-		Weight::from_ref_time(3_216_000 as u64)
+		Weight::from_parts(3_216_000 as u64, 0)
 	}
 	pub(crate) fn unpaid_execution() -> Weight {
-		Weight::from_ref_time(3_394_000 as u64)
+		Weight::from_parts(3_394_000 as u64, 0)
 	}
 }

--- a/parachains/runtimes/collectives/collectives-polkadot/src/weights/block_weights.rs
+++ b/parachains/runtimes/collectives/collectives-polkadot/src/weights/block_weights.rs
@@ -24,7 +24,7 @@ pub mod constants {
 	parameter_types! {
 		/// Importing a block with 0 Extrinsics.
 		pub const BlockExecutionWeight: Weight =
-			Weight::from_ref_time(constants::WEIGHT_REF_TIME_PER_NANOS.saturating_mul(5_000_000));
+			Weight::from_parts(constants::WEIGHT_REF_TIME_PER_NANOS.saturating_mul(5_000_000), 0);
 	}
 
 	#[cfg(test)]

--- a/parachains/runtimes/collectives/collectives-polkadot/src/weights/cumulus_pallet_xcmp_queue.rs
+++ b/parachains/runtimes/collectives/collectives-polkadot/src/weights/cumulus_pallet_xcmp_queue.rs
@@ -54,8 +54,8 @@ impl<T: frame_system::Config> cumulus_pallet_xcmp_queue::WeightInfo for WeightIn
 		//  Measured:  `76`
 		//  Estimated: `571`
 		// Minimum execution time: 4_808 nanoseconds.
-		Weight::from_ref_time(4_966_000)
-			.saturating_add(Weight::from_proof_size(571))
+		Weight::from_parts(4_966_000, 0)
+			.saturating_add(Weight::from_parts(0, 571))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -66,8 +66,8 @@ impl<T: frame_system::Config> cumulus_pallet_xcmp_queue::WeightInfo for WeightIn
 		//  Measured:  `76`
 		//  Estimated: `571`
 		// Minimum execution time: 5_014 nanoseconds.
-		Weight::from_ref_time(5_135_000)
-			.saturating_add(Weight::from_proof_size(571))
+		Weight::from_parts(5_135_000, 0)
+			.saturating_add(Weight::from_parts(0, 571))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}

--- a/parachains/runtimes/collectives/collectives-polkadot/src/weights/extrinsic_weights.rs
+++ b/parachains/runtimes/collectives/collectives-polkadot/src/weights/extrinsic_weights.rs
@@ -24,7 +24,7 @@ pub mod constants {
 	parameter_types! {
 		/// Executing a NO-OP `System::remarks` Extrinsic.
 		pub const ExtrinsicBaseWeight: Weight =
-			Weight::from_ref_time(constants::WEIGHT_REF_TIME_PER_NANOS.saturating_mul(125_000));
+			Weight::from_parts(constants::WEIGHT_REF_TIME_PER_NANOS.saturating_mul(125_000), 0);
 	}
 
 	#[cfg(test)]

--- a/parachains/runtimes/collectives/collectives-polkadot/src/weights/frame_system.rs
+++ b/parachains/runtimes/collectives/collectives-polkadot/src/weights/frame_system.rs
@@ -53,10 +53,10 @@ impl<T: frame_system::Config> frame_system::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 1_643 nanoseconds.
-		Weight::from_ref_time(1_672_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(1_672_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			// Standard Error: 0
-			.saturating_add(Weight::from_ref_time(368).saturating_mul(b.into()))
+			.saturating_add(Weight::from_parts(368, 0).saturating_mul(b.into()))
 	}
 	/// The range of component `b` is `[0, 3932160]`.
 	fn remark_with_event(b: u32, ) -> Weight {
@@ -64,10 +64,10 @@ impl<T: frame_system::Config> frame_system::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 6_679 nanoseconds.
-		Weight::from_ref_time(6_737_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(6_737_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			// Standard Error: 0
-			.saturating_add(Weight::from_ref_time(1_714).saturating_mul(b.into()))
+			.saturating_add(Weight::from_parts(1_714, 0).saturating_mul(b.into()))
 	}
 	/// Storage: System Digest (r:1 w:1)
 	/// Proof Skipped: System Digest (max_values: Some(1), max_size: None, mode: Measured)
@@ -78,8 +78,8 @@ impl<T: frame_system::Config> frame_system::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `495`
 		// Minimum execution time: 3_675 nanoseconds.
-		Weight::from_ref_time(3_915_000)
-			.saturating_add(Weight::from_proof_size(495))
+		Weight::from_parts(3_915_000, 0)
+			.saturating_add(Weight::from_parts(0, 495))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -91,10 +91,10 @@ impl<T: frame_system::Config> frame_system::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 1_789 nanoseconds.
-		Weight::from_ref_time(1_840_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(1_840_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			// Standard Error: 2_081
-			.saturating_add(Weight::from_ref_time(587_667).saturating_mul(i.into()))
+			.saturating_add(Weight::from_parts(587_667, 0).saturating_mul(i.into()))
 			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(i.into())))
 	}
 	/// Storage: Skipped Metadata (r:0 w:0)
@@ -105,10 +105,10 @@ impl<T: frame_system::Config> frame_system::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 1_849 nanoseconds.
-		Weight::from_ref_time(1_915_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(1_915_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			// Standard Error: 798
-			.saturating_add(Weight::from_ref_time(446_723).saturating_mul(i.into()))
+			.saturating_add(Weight::from_parts(446_723, 0).saturating_mul(i.into()))
 			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(i.into())))
 	}
 	/// Storage: Skipped Metadata (r:0 w:0)
@@ -119,11 +119,11 @@ impl<T: frame_system::Config> frame_system::WeightInfo for WeightInfo<T> {
 		//  Measured:  `68 + p * (69 ±0)`
 		//  Estimated: `69 + p * (70 ±0)`
 		// Minimum execution time: 3_503 nanoseconds.
-		Weight::from_ref_time(3_574_000)
-			.saturating_add(Weight::from_proof_size(69))
+		Weight::from_parts(3_574_000, 0)
+			.saturating_add(Weight::from_parts(0, 69))
 			// Standard Error: 948
-			.saturating_add(Weight::from_ref_time(949_091).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(949_091, 0).saturating_mul(p.into()))
 			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(p.into())))
-			.saturating_add(Weight::from_proof_size(70).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(0, 70).saturating_mul(p.into()))
 	}
 }

--- a/parachains/runtimes/collectives/collectives-polkadot/src/weights/pallet_alliance.rs
+++ b/parachains/runtimes/collectives/collectives-polkadot/src/weights/pallet_alliance.rs
@@ -65,18 +65,18 @@ impl<T: frame_system::Config> pallet_alliance::WeightInfo for WeightInfo<T> {
 		//  Measured:  `502 + m * (32 ±0) + p * (36 ±0)`
 		//  Estimated: `10983 + m * (128 ±0) + p * (144 ±0)`
 		// Minimum execution time: 26_997 nanoseconds.
-		Weight::from_ref_time(28_875_691)
-			.saturating_add(Weight::from_proof_size(10983))
+		Weight::from_parts(28_875_691, 0)
+			.saturating_add(Weight::from_parts(0, 10983))
 			// Standard Error: 65
-			.saturating_add(Weight::from_ref_time(235).saturating_mul(b.into()))
+			.saturating_add(Weight::from_parts(235, 0).saturating_mul(b.into()))
 			// Standard Error: 683
-			.saturating_add(Weight::from_ref_time(17_740).saturating_mul(m.into()))
+			.saturating_add(Weight::from_parts(17_740, 0).saturating_mul(m.into()))
 			// Standard Error: 675
-			.saturating_add(Weight::from_ref_time(88_731).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(88_731, 0).saturating_mul(p.into()))
 			.saturating_add(T::DbWeight::get().reads(4))
 			.saturating_add(T::DbWeight::get().writes(4))
-			.saturating_add(Weight::from_proof_size(128).saturating_mul(m.into()))
-			.saturating_add(Weight::from_proof_size(144).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(0, 128).saturating_mul(m.into()))
+			.saturating_add(Weight::from_parts(0, 144).saturating_mul(p.into()))
 	}
 	/// Storage: Alliance Members (r:1 w:0)
 	/// Proof: Alliance Members (max_values: None, max_size: Some(3211), added: 5686, mode: MaxEncodedLen)
@@ -88,13 +88,13 @@ impl<T: frame_system::Config> pallet_alliance::WeightInfo for WeightInfo<T> {
 		//  Measured:  `932 + m * (64 ±0)`
 		//  Estimated: `9092 + m * (64 ±0)`
 		// Minimum execution time: 23_241 nanoseconds.
-		Weight::from_ref_time(23_786_275)
-			.saturating_add(Weight::from_proof_size(9092))
+		Weight::from_parts(23_786_275, 0)
+			.saturating_add(Weight::from_parts(0, 9092))
 			// Standard Error: 563
-			.saturating_add(Weight::from_ref_time(44_164).saturating_mul(m.into()))
+			.saturating_add(Weight::from_parts(44_164, 0).saturating_mul(m.into()))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
-			.saturating_add(Weight::from_proof_size(64).saturating_mul(m.into()))
+			.saturating_add(Weight::from_parts(0, 64).saturating_mul(m.into()))
 	}
 	/// Storage: Alliance Members (r:1 w:0)
 	/// Proof: Alliance Members (max_values: None, max_size: Some(3211), added: 5686, mode: MaxEncodedLen)
@@ -113,16 +113,16 @@ impl<T: frame_system::Config> pallet_alliance::WeightInfo for WeightInfo<T> {
 		//  Measured:  `438 + m * (96 ±0) + p * (36 ±0)`
 		//  Estimated: `11067 + m * (388 ±0) + p * (144 ±0)`
 		// Minimum execution time: 32_551 nanoseconds.
-		Weight::from_ref_time(30_322_236)
-			.saturating_add(Weight::from_proof_size(11067))
+		Weight::from_parts(30_322_236, 0)
+			.saturating_add(Weight::from_parts(0, 11067))
 			// Standard Error: 695
-			.saturating_add(Weight::from_ref_time(44_336).saturating_mul(m.into()))
+			.saturating_add(Weight::from_parts(44_336, 0).saturating_mul(m.into()))
 			// Standard Error: 678
-			.saturating_add(Weight::from_ref_time(83_273).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(83_273, 0).saturating_mul(p.into()))
 			.saturating_add(T::DbWeight::get().reads(4))
 			.saturating_add(T::DbWeight::get().writes(3))
-			.saturating_add(Weight::from_proof_size(388).saturating_mul(m.into()))
-			.saturating_add(Weight::from_proof_size(144).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(0, 388).saturating_mul(m.into()))
+			.saturating_add(Weight::from_parts(0, 144).saturating_mul(p.into()))
 	}
 	/// Storage: Alliance Members (r:1 w:0)
 	/// Proof: Alliance Members (max_values: None, max_size: Some(3211), added: 5686, mode: MaxEncodedLen)
@@ -142,16 +142,16 @@ impl<T: frame_system::Config> pallet_alliance::WeightInfo for WeightInfo<T> {
 		//  Measured:  `923 + m * (96 ±0) + p * (41 ±0)`
 		//  Estimated: `15422 + m * (388 ±0) + p * (160 ±0)`
 		// Minimum execution time: 42_592 nanoseconds.
-		Weight::from_ref_time(42_349_696)
-			.saturating_add(Weight::from_proof_size(15422))
+		Weight::from_parts(42_349_696, 0)
+			.saturating_add(Weight::from_parts(0, 15422))
 			// Standard Error: 1_776
-			.saturating_add(Weight::from_ref_time(53_830).saturating_mul(m.into()))
+			.saturating_add(Weight::from_parts(53_830, 0).saturating_mul(m.into()))
 			// Standard Error: 1_731
-			.saturating_add(Weight::from_ref_time(94_827).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(94_827, 0).saturating_mul(p.into()))
 			.saturating_add(T::DbWeight::get().reads(5))
 			.saturating_add(T::DbWeight::get().writes(3))
-			.saturating_add(Weight::from_proof_size(388).saturating_mul(m.into()))
-			.saturating_add(Weight::from_proof_size(160).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(0, 388).saturating_mul(m.into()))
+			.saturating_add(Weight::from_parts(0, 160).saturating_mul(p.into()))
 	}
 	/// Storage: Alliance Members (r:1 w:0)
 	/// Proof: Alliance Members (max_values: None, max_size: Some(3211), added: 5686, mode: MaxEncodedLen)
@@ -174,16 +174,16 @@ impl<T: frame_system::Config> pallet_alliance::WeightInfo for WeightInfo<T> {
 		//  Measured:  `677 + m * (96 ±0) + p * (41 ±0)`
 		//  Estimated: `14232 + m * (507 ±0) + p * (202 ±0)`
 		// Minimum execution time: 39_735 nanoseconds.
-		Weight::from_ref_time(42_276_266)
-			.saturating_add(Weight::from_proof_size(14232))
+		Weight::from_parts(42_276_266, 0)
+			.saturating_add(Weight::from_parts(0, 14232))
 			// Standard Error: 3_451
-			.saturating_add(Weight::from_ref_time(94_755).saturating_mul(m.into()))
+			.saturating_add(Weight::from_parts(94_755, 0).saturating_mul(m.into()))
 			// Standard Error: 3_409
-			.saturating_add(Weight::from_ref_time(108_485).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(108_485, 0).saturating_mul(p.into()))
 			.saturating_add(T::DbWeight::get().reads(6))
 			.saturating_add(T::DbWeight::get().writes(4))
-			.saturating_add(Weight::from_proof_size(507).saturating_mul(m.into()))
-			.saturating_add(Weight::from_proof_size(202).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(0, 507).saturating_mul(m.into()))
+			.saturating_add(Weight::from_parts(0, 202).saturating_mul(p.into()))
 	}
 	/// Storage: Alliance Members (r:1 w:0)
 	/// Proof: Alliance Members (max_values: None, max_size: Some(3211), added: 5686, mode: MaxEncodedLen)
@@ -205,16 +205,16 @@ impl<T: frame_system::Config> pallet_alliance::WeightInfo for WeightInfo<T> {
 		//  Measured:  `545 + m * (96 ±0) + p * (36 ±0)`
 		//  Estimated: `12436 + m * (480 ±0) + p * (180 ±0)`
 		// Minimum execution time: 33_604 nanoseconds.
-		Weight::from_ref_time(32_382_610)
-			.saturating_add(Weight::from_proof_size(12436))
+		Weight::from_parts(32_382_610, 0)
+			.saturating_add(Weight::from_parts(0, 12436))
 			// Standard Error: 564
-			.saturating_add(Weight::from_ref_time(41_625).saturating_mul(m.into()))
+			.saturating_add(Weight::from_parts(41_625, 0).saturating_mul(m.into()))
 			// Standard Error: 544
-			.saturating_add(Weight::from_ref_time(80_954).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(80_954, 0).saturating_mul(p.into()))
 			.saturating_add(T::DbWeight::get().reads(5))
 			.saturating_add(T::DbWeight::get().writes(3))
-			.saturating_add(Weight::from_proof_size(480).saturating_mul(m.into()))
-			.saturating_add(Weight::from_proof_size(180).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(0, 480).saturating_mul(m.into()))
+			.saturating_add(Weight::from_parts(0, 180).saturating_mul(p.into()))
 	}
 	/// Storage: Alliance Members (r:2 w:2)
 	/// Proof: Alliance Members (max_values: None, max_size: Some(3211), added: 5686, mode: MaxEncodedLen)
@@ -227,12 +227,12 @@ impl<T: frame_system::Config> pallet_alliance::WeightInfo for WeightInfo<T> {
 		//  Measured:  `12`
 		//  Estimated: `11879`
 		// Minimum execution time: 27_970 nanoseconds.
-		Weight::from_ref_time(16_763_631)
-			.saturating_add(Weight::from_proof_size(11879))
+		Weight::from_parts(16_763_631, 0)
+			.saturating_add(Weight::from_parts(0, 11879))
 			// Standard Error: 496
-			.saturating_add(Weight::from_ref_time(130_747).saturating_mul(m.into()))
+			.saturating_add(Weight::from_parts(130_747, 0).saturating_mul(m.into()))
 			// Standard Error: 490
-			.saturating_add(Weight::from_ref_time(112_074).saturating_mul(z.into()))
+			.saturating_add(Weight::from_parts(112_074, 0).saturating_mul(z.into()))
 			.saturating_add(T::DbWeight::get().reads(3))
 			.saturating_add(T::DbWeight::get().writes(3))
 	}
@@ -256,23 +256,23 @@ impl<T: frame_system::Config> pallet_alliance::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0 + x * (52 ±0) + y * (53 ±0) + z * (282 ±0)`
 		//  Estimated: `31580 + x * (2590 ±0) + y * (2590 ±0) + z * (3200 ±1)`
 		// Minimum execution time: 221_464 nanoseconds.
-		Weight::from_ref_time(223_114_000)
-			.saturating_add(Weight::from_proof_size(31580))
+		Weight::from_parts(223_114_000, 0)
+			.saturating_add(Weight::from_parts(0, 31580))
 			// Standard Error: 19_600
-			.saturating_add(Weight::from_ref_time(471_527).saturating_mul(x.into()))
+			.saturating_add(Weight::from_parts(471_527, 0).saturating_mul(x.into()))
 			// Standard Error: 19_506
-			.saturating_add(Weight::from_ref_time(424_033).saturating_mul(y.into()))
+			.saturating_add(Weight::from_parts(424_033, 0).saturating_mul(y.into()))
 			// Standard Error: 38_976
-			.saturating_add(Weight::from_ref_time(9_666_599).saturating_mul(z.into()))
+			.saturating_add(Weight::from_parts(9_666_599, 0).saturating_mul(z.into()))
 			.saturating_add(T::DbWeight::get().reads(3))
 			.saturating_add(T::DbWeight::get().reads((1_u64).saturating_mul(x.into())))
 			.saturating_add(T::DbWeight::get().reads((1_u64).saturating_mul(y.into())))
 			.saturating_add(T::DbWeight::get().reads((1_u64).saturating_mul(z.into())))
 			.saturating_add(T::DbWeight::get().writes(4))
 			.saturating_add(T::DbWeight::get().writes((2_u64).saturating_mul(z.into())))
-			.saturating_add(Weight::from_proof_size(2590).saturating_mul(x.into()))
-			.saturating_add(Weight::from_proof_size(2590).saturating_mul(y.into()))
-			.saturating_add(Weight::from_proof_size(3200).saturating_mul(z.into()))
+			.saturating_add(Weight::from_parts(0, 2590).saturating_mul(x.into()))
+			.saturating_add(Weight::from_parts(0, 2590).saturating_mul(y.into()))
+			.saturating_add(Weight::from_parts(0, 3200).saturating_mul(z.into()))
 	}
 	/// Storage: Alliance Rule (r:0 w:1)
 	/// Proof: Alliance Rule (max_values: Some(1), max_size: Some(87), added: 582, mode: MaxEncodedLen)
@@ -281,8 +281,8 @@ impl<T: frame_system::Config> pallet_alliance::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 8_585 nanoseconds.
-		Weight::from_ref_time(8_746_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(8_746_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
 	/// Storage: Alliance Announcements (r:1 w:1)
@@ -292,8 +292,8 @@ impl<T: frame_system::Config> pallet_alliance::WeightInfo for WeightInfo<T> {
 		//  Measured:  `76`
 		//  Estimated: `9197`
 		// Minimum execution time: 10_728 nanoseconds.
-		Weight::from_ref_time(10_974_000)
-			.saturating_add(Weight::from_proof_size(9197))
+		Weight::from_parts(10_974_000, 0)
+			.saturating_add(Weight::from_parts(0, 9197))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -304,8 +304,8 @@ impl<T: frame_system::Config> pallet_alliance::WeightInfo for WeightInfo<T> {
 		//  Measured:  `181`
 		//  Estimated: `9197`
 		// Minimum execution time: 11_751 nanoseconds.
-		Weight::from_ref_time(12_205_000)
-			.saturating_add(Weight::from_proof_size(9197))
+		Weight::from_parts(12_205_000, 0)
+			.saturating_add(Weight::from_parts(0, 9197))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -322,8 +322,8 @@ impl<T: frame_system::Config> pallet_alliance::WeightInfo for WeightInfo<T> {
 		//  Measured:  `388`
 		//  Estimated: `23358`
 		// Minimum execution time: 38_798 nanoseconds.
-		Weight::from_ref_time(39_255_000)
-			.saturating_add(Weight::from_proof_size(23358))
+		Weight::from_parts(39_255_000, 0)
+			.saturating_add(Weight::from_parts(0, 23358))
 			.saturating_add(T::DbWeight::get().reads(5))
 			.saturating_add(T::DbWeight::get().writes(3))
 	}
@@ -336,8 +336,8 @@ impl<T: frame_system::Config> pallet_alliance::WeightInfo for WeightInfo<T> {
 		//  Measured:  `255`
 		//  Estimated: `20755`
 		// Minimum execution time: 27_702 nanoseconds.
-		Weight::from_ref_time(28_189_000)
-			.saturating_add(Weight::from_proof_size(20755))
+		Weight::from_parts(28_189_000, 0)
+			.saturating_add(Weight::from_parts(0, 20755))
 			.saturating_add(T::DbWeight::get().reads(4))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -354,8 +354,8 @@ impl<T: frame_system::Config> pallet_alliance::WeightInfo for WeightInfo<T> {
 		//  Measured:  `298`
 		//  Estimated: `12761`
 		// Minimum execution time: 23_033 nanoseconds.
-		Weight::from_ref_time(23_589_000)
-			.saturating_add(Weight::from_proof_size(12761))
+		Weight::from_parts(23_589_000, 0)
+			.saturating_add(Weight::from_parts(0, 12761))
 			.saturating_add(T::DbWeight::get().reads(3))
 			.saturating_add(T::DbWeight::get().writes(4))
 	}
@@ -374,8 +374,8 @@ impl<T: frame_system::Config> pallet_alliance::WeightInfo for WeightInfo<T> {
 		//  Measured:  `298`
 		//  Estimated: `24133`
 		// Minimum execution time: 31_352 nanoseconds.
-		Weight::from_ref_time(31_848_000)
-			.saturating_add(Weight::from_proof_size(24133))
+		Weight::from_parts(31_848_000, 0)
+			.saturating_add(Weight::from_parts(0, 24133))
 			.saturating_add(T::DbWeight::get().reads(5))
 			.saturating_add(T::DbWeight::get().writes(5))
 	}
@@ -392,8 +392,8 @@ impl<T: frame_system::Config> pallet_alliance::WeightInfo for WeightInfo<T> {
 		//  Measured:  `580`
 		//  Estimated: `13355`
 		// Minimum execution time: 31_872 nanoseconds.
-		Weight::from_ref_time(32_156_000)
-			.saturating_add(Weight::from_proof_size(13355))
+		Weight::from_parts(32_156_000, 0)
+			.saturating_add(Weight::from_parts(0, 13355))
 			.saturating_add(T::DbWeight::get().reads(4))
 			.saturating_add(T::DbWeight::get().writes(4))
 	}
@@ -426,8 +426,8 @@ impl<T: frame_system::Config> pallet_alliance::WeightInfo for WeightInfo<T> {
 		//  Measured:  `716`
 		//  Estimated: `35980`
 		// Minimum execution time: 115_869 nanoseconds.
-		Weight::from_ref_time(116_954_000)
-			.saturating_add(Weight::from_proof_size(35980))
+		Weight::from_parts(116_954_000, 0)
+			.saturating_add(Weight::from_parts(0, 35980))
 			.saturating_add(T::DbWeight::get().reads(13))
 			.saturating_add(T::DbWeight::get().writes(8))
 	}
@@ -442,12 +442,12 @@ impl<T: frame_system::Config> pallet_alliance::WeightInfo for WeightInfo<T> {
 		//  Measured:  `76`
 		//  Estimated: `29894`
 		// Minimum execution time: 6_956 nanoseconds.
-		Weight::from_ref_time(7_074_000)
-			.saturating_add(Weight::from_proof_size(29894))
+		Weight::from_parts(7_074_000, 0)
+			.saturating_add(Weight::from_parts(0, 29894))
 			// Standard Error: 2_782
-			.saturating_add(Weight::from_ref_time(1_178_647).saturating_mul(n.into()))
+			.saturating_add(Weight::from_parts(1_178_647, 0).saturating_mul(n.into()))
 			// Standard Error: 1_089
-			.saturating_add(Weight::from_ref_time(65_684).saturating_mul(l.into()))
+			.saturating_add(Weight::from_parts(65_684, 0).saturating_mul(l.into()))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -462,12 +462,12 @@ impl<T: frame_system::Config> pallet_alliance::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0 + n * (289 ±0) + l * (100 ±0)`
 		//  Estimated: `29894`
 		// Minimum execution time: 6_939 nanoseconds.
-		Weight::from_ref_time(7_100_000)
-			.saturating_add(Weight::from_proof_size(29894))
+		Weight::from_parts(7_100_000, 0)
+			.saturating_add(Weight::from_parts(0, 29894))
 			// Standard Error: 170_977
-			.saturating_add(Weight::from_ref_time(13_668_797).saturating_mul(n.into()))
+			.saturating_add(Weight::from_parts(13_668_797, 0).saturating_mul(n.into()))
 			// Standard Error: 66_962
-			.saturating_add(Weight::from_ref_time(451_782).saturating_mul(l.into()))
+			.saturating_add(Weight::from_parts(451_782, 0).saturating_mul(l.into()))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -484,8 +484,8 @@ impl<T: frame_system::Config> pallet_alliance::WeightInfo for WeightInfo<T> {
 		//  Measured:  `298`
 		//  Estimated: `18447`
 		// Minimum execution time: 29_564 nanoseconds.
-		Weight::from_ref_time(30_313_000)
-			.saturating_add(Weight::from_proof_size(18447))
+		Weight::from_parts(30_313_000, 0)
+			.saturating_add(Weight::from_parts(0, 18447))
 			.saturating_add(T::DbWeight::get().reads(4))
 			.saturating_add(T::DbWeight::get().writes(4))
 	}

--- a/parachains/runtimes/collectives/collectives-polkadot/src/weights/pallet_balances.rs
+++ b/parachains/runtimes/collectives/collectives-polkadot/src/weights/pallet_balances.rs
@@ -54,8 +54,8 @@ impl<T: frame_system::Config> pallet_balances::WeightInfo for WeightInfo<T> {
 		//  Measured:  `1176`
 		//  Estimated: `2603`
 		// Minimum execution time: 45_207 nanoseconds.
-		Weight::from_ref_time(45_620_000)
-			.saturating_add(Weight::from_proof_size(2603))
+		Weight::from_parts(45_620_000, 0)
+			.saturating_add(Weight::from_parts(0, 2603))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -66,8 +66,8 @@ impl<T: frame_system::Config> pallet_balances::WeightInfo for WeightInfo<T> {
 		//  Measured:  `1060`
 		//  Estimated: `2603`
 		// Minimum execution time: 35_103 nanoseconds.
-		Weight::from_ref_time(35_730_000)
-			.saturating_add(Weight::from_proof_size(2603))
+		Weight::from_parts(35_730_000, 0)
+			.saturating_add(Weight::from_parts(0, 2603))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -78,8 +78,8 @@ impl<T: frame_system::Config> pallet_balances::WeightInfo for WeightInfo<T> {
 		//  Measured:  `1172`
 		//  Estimated: `2603`
 		// Minimum execution time: 26_007 nanoseconds.
-		Weight::from_ref_time(26_347_000)
-			.saturating_add(Weight::from_proof_size(2603))
+		Weight::from_parts(26_347_000, 0)
+			.saturating_add(Weight::from_parts(0, 2603))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -90,8 +90,8 @@ impl<T: frame_system::Config> pallet_balances::WeightInfo for WeightInfo<T> {
 		//  Measured:  `1172`
 		//  Estimated: `2603`
 		// Minimum execution time: 28_971 nanoseconds.
-		Weight::from_ref_time(29_435_000)
-			.saturating_add(Weight::from_proof_size(2603))
+		Weight::from_parts(29_435_000, 0)
+			.saturating_add(Weight::from_parts(0, 2603))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -102,8 +102,8 @@ impl<T: frame_system::Config> pallet_balances::WeightInfo for WeightInfo<T> {
 		//  Measured:  `1172`
 		//  Estimated: `5206`
 		// Minimum execution time: 45_554 nanoseconds.
-		Weight::from_ref_time(46_156_000)
-			.saturating_add(Weight::from_proof_size(5206))
+		Weight::from_parts(46_156_000, 0)
+			.saturating_add(Weight::from_parts(0, 5206))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -114,8 +114,8 @@ impl<T: frame_system::Config> pallet_balances::WeightInfo for WeightInfo<T> {
 		//  Measured:  `1060`
 		//  Estimated: `2603`
 		// Minimum execution time: 40_290 nanoseconds.
-		Weight::from_ref_time(40_805_000)
-			.saturating_add(Weight::from_proof_size(2603))
+		Weight::from_parts(40_805_000, 0)
+			.saturating_add(Weight::from_parts(0, 2603))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -126,8 +126,8 @@ impl<T: frame_system::Config> pallet_balances::WeightInfo for WeightInfo<T> {
 		//  Measured:  `1056`
 		//  Estimated: `2603`
 		// Minimum execution time: 22_459 nanoseconds.
-		Weight::from_ref_time(23_037_000)
-			.saturating_add(Weight::from_proof_size(2603))
+		Weight::from_parts(23_037_000, 0)
+			.saturating_add(Weight::from_parts(0, 2603))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}

--- a/parachains/runtimes/collectives/collectives-polkadot/src/weights/pallet_collator_selection.rs
+++ b/parachains/runtimes/collectives/collectives-polkadot/src/weights/pallet_collator_selection.rs
@@ -57,13 +57,13 @@ impl<T: frame_system::Config> pallet_collator_selection::WeightInfo for WeightIn
 		//  Measured:  `178 + b * (78 ±0)`
 		//  Estimated: `178 + b * (2554 ±0)`
 		// Minimum execution time: 13_471 nanoseconds.
-		Weight::from_ref_time(13_949_440)
-			.saturating_add(Weight::from_proof_size(178))
+		Weight::from_parts(13_949_440, 0)
+			.saturating_add(Weight::from_parts(0, 178))
 			// Standard Error: 3_549
-			.saturating_add(Weight::from_ref_time(2_497_077).saturating_mul(b.into()))
+			.saturating_add(Weight::from_parts(2_497_077, 0).saturating_mul(b.into()))
 			.saturating_add(T::DbWeight::get().reads((1_u64).saturating_mul(b.into())))
 			.saturating_add(T::DbWeight::get().writes(1))
-			.saturating_add(Weight::from_proof_size(2554).saturating_mul(b.into()))
+			.saturating_add(Weight::from_parts(0, 2554).saturating_mul(b.into()))
 	}
 	/// Storage: CollatorSelection DesiredCandidates (r:0 w:1)
 	/// Proof: CollatorSelection DesiredCandidates (max_values: Some(1), max_size: Some(4), added: 499, mode: MaxEncodedLen)
@@ -72,8 +72,8 @@ impl<T: frame_system::Config> pallet_collator_selection::WeightInfo for WeightIn
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 6_444 nanoseconds.
-		Weight::from_ref_time(6_763_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(6_763_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
 	/// Storage: CollatorSelection CandidacyBond (r:0 w:1)
@@ -83,8 +83,8 @@ impl<T: frame_system::Config> pallet_collator_selection::WeightInfo for WeightIn
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 6_610 nanoseconds.
-		Weight::from_ref_time(6_807_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(6_807_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
 	/// Storage: CollatorSelection Candidates (r:1 w:1)
@@ -105,13 +105,13 @@ impl<T: frame_system::Config> pallet_collator_selection::WeightInfo for WeightIn
 		//  Measured:  `1171 + c * (48 ±0)`
 		//  Estimated: `56784 + c * (49 ±0)`
 		// Minimum execution time: 35_411 nanoseconds.
-		Weight::from_ref_time(26_990_808)
-			.saturating_add(Weight::from_proof_size(56784))
+		Weight::from_parts(26_990_808, 0)
+			.saturating_add(Weight::from_parts(0, 56784))
 			// Standard Error: 1_294
-			.saturating_add(Weight::from_ref_time(107_975).saturating_mul(c.into()))
+			.saturating_add(Weight::from_parts(107_975, 0).saturating_mul(c.into()))
 			.saturating_add(T::DbWeight::get().reads(5))
 			.saturating_add(T::DbWeight::get().writes(2))
-			.saturating_add(Weight::from_proof_size(49).saturating_mul(c.into()))
+			.saturating_add(Weight::from_parts(0, 49).saturating_mul(c.into()))
 	}
 	/// Storage: CollatorSelection Candidates (r:1 w:1)
 	/// Proof: CollatorSelection Candidates (max_values: Some(1), max_size: Some(48002), added: 48497, mode: MaxEncodedLen)
@@ -123,10 +123,10 @@ impl<T: frame_system::Config> pallet_collator_selection::WeightInfo for WeightIn
 		//  Measured:  `536 + c * (48 ±0)`
 		//  Estimated: `48497`
 		// Minimum execution time: 25_912 nanoseconds.
-		Weight::from_ref_time(15_664_296)
-			.saturating_add(Weight::from_proof_size(48497))
+		Weight::from_parts(15_664_296, 0)
+			.saturating_add(Weight::from_parts(0, 48497))
 			// Standard Error: 1_292
-			.saturating_add(Weight::from_ref_time(105_672).saturating_mul(c.into()))
+			.saturating_add(Weight::from_parts(105_672, 0).saturating_mul(c.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -141,8 +141,8 @@ impl<T: frame_system::Config> pallet_collator_selection::WeightInfo for WeightIn
 		//  Measured:  `135`
 		//  Estimated: `5749`
 		// Minimum execution time: 24_773 nanoseconds.
-		Weight::from_ref_time(25_088_000)
-			.saturating_add(Weight::from_proof_size(5749))
+		Weight::from_parts(25_088_000, 0)
+			.saturating_add(Weight::from_parts(0, 5749))
 			.saturating_add(T::DbWeight::get().reads(3))
 			.saturating_add(T::DbWeight::get().writes(4))
 	}
@@ -163,15 +163,15 @@ impl<T: frame_system::Config> pallet_collator_selection::WeightInfo for WeightIn
 		//  Measured:  `22784 + r * (148 ±0) + c * (97 ±0)`
 		//  Estimated: `52737 + c * (2519 ±0) + r * (2602 ±0)`
 		// Minimum execution time: 16_174 nanoseconds.
-		Weight::from_ref_time(16_337_000)
-			.saturating_add(Weight::from_proof_size(52737))
+		Weight::from_parts(16_337_000, 0)
+			.saturating_add(Weight::from_parts(0, 52737))
 			// Standard Error: 759_621
-			.saturating_add(Weight::from_ref_time(27_780_906).saturating_mul(c.into()))
+			.saturating_add(Weight::from_parts(27_780_906, 0).saturating_mul(c.into()))
 			.saturating_add(T::DbWeight::get().reads(4))
 			.saturating_add(T::DbWeight::get().reads((1_u64).saturating_mul(c.into())))
 			.saturating_add(T::DbWeight::get().writes(1))
 			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(c.into())))
-			.saturating_add(Weight::from_proof_size(2519).saturating_mul(c.into()))
-			.saturating_add(Weight::from_proof_size(2602).saturating_mul(r.into()))
+			.saturating_add(Weight::from_parts(0, 2519).saturating_mul(c.into()))
+			.saturating_add(Weight::from_parts(0, 2602).saturating_mul(r.into()))
 	}
 }

--- a/parachains/runtimes/collectives/collectives-polkadot/src/weights/pallet_collective.rs
+++ b/parachains/runtimes/collectives/collectives-polkadot/src/weights/pallet_collective.rs
@@ -63,18 +63,18 @@ impl<T: frame_system::Config> pallet_collective::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0 + m * (3233 ±0) + p * (3223 ±0)`
 		//  Estimated: `15906 + m * (7809 ±23) + p * (10238 ±23)`
 		// Minimum execution time: 15_797 nanoseconds.
-		Weight::from_ref_time(16_028_000)
-			.saturating_add(Weight::from_proof_size(15906))
+		Weight::from_parts(16_028_000, 0)
+			.saturating_add(Weight::from_parts(0, 15906))
 			// Standard Error: 70_308
-			.saturating_add(Weight::from_ref_time(5_642_347).saturating_mul(m.into()))
+			.saturating_add(Weight::from_parts(5_642_347, 0).saturating_mul(m.into()))
 			// Standard Error: 70_308
-			.saturating_add(Weight::from_ref_time(8_133_950).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(8_133_950, 0).saturating_mul(p.into()))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().reads((1_u64).saturating_mul(p.into())))
 			.saturating_add(T::DbWeight::get().writes(2))
 			.saturating_add(T::DbWeight::get().writes((1_u64).saturating_mul(p.into())))
-			.saturating_add(Weight::from_proof_size(7809).saturating_mul(m.into()))
-			.saturating_add(Weight::from_proof_size(10238).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(0, 7809).saturating_mul(m.into()))
+			.saturating_add(Weight::from_parts(0, 10238).saturating_mul(p.into()))
 	}
 	/// Storage: AllianceMotion Members (r:1 w:0)
 	/// Proof Skipped: AllianceMotion Members (max_values: Some(1), max_size: None, mode: Measured)
@@ -85,14 +85,14 @@ impl<T: frame_system::Config> pallet_collective::WeightInfo for WeightInfo<T> {
 		//  Measured:  `64 + m * (32 ±0)`
 		//  Estimated: `560 + m * (32 ±0)`
 		// Minimum execution time: 14_039 nanoseconds.
-		Weight::from_ref_time(13_145_821)
-			.saturating_add(Weight::from_proof_size(560))
+		Weight::from_parts(13_145_821, 0)
+			.saturating_add(Weight::from_parts(0, 560))
 			// Standard Error: 24
-			.saturating_add(Weight::from_ref_time(1_434).saturating_mul(b.into()))
+			.saturating_add(Weight::from_parts(1_434, 0).saturating_mul(b.into()))
 			// Standard Error: 248
-			.saturating_add(Weight::from_ref_time(14_559).saturating_mul(m.into()))
+			.saturating_add(Weight::from_parts(14_559, 0).saturating_mul(m.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
-			.saturating_add(Weight::from_proof_size(32).saturating_mul(m.into()))
+			.saturating_add(Weight::from_parts(0, 32).saturating_mul(m.into()))
 	}
 	/// Storage: AllianceMotion Members (r:1 w:0)
 	/// Proof Skipped: AllianceMotion Members (max_values: Some(1), max_size: None, mode: Measured)
@@ -105,14 +105,14 @@ impl<T: frame_system::Config> pallet_collective::WeightInfo for WeightInfo<T> {
 		//  Measured:  `64 + m * (32 ±0)`
 		//  Estimated: `3100 + m * (64 ±0)`
 		// Minimum execution time: 16_235 nanoseconds.
-		Weight::from_ref_time(14_913_854)
-			.saturating_add(Weight::from_proof_size(3100))
+		Weight::from_parts(14_913_854, 0)
+			.saturating_add(Weight::from_parts(0, 3100))
 			// Standard Error: 26
-			.saturating_add(Weight::from_ref_time(1_744).saturating_mul(b.into()))
+			.saturating_add(Weight::from_parts(1_744, 0).saturating_mul(b.into()))
 			// Standard Error: 273
-			.saturating_add(Weight::from_ref_time(23_908).saturating_mul(m.into()))
+			.saturating_add(Weight::from_parts(23_908, 0).saturating_mul(m.into()))
 			.saturating_add(T::DbWeight::get().reads(2))
-			.saturating_add(Weight::from_proof_size(64).saturating_mul(m.into()))
+			.saturating_add(Weight::from_parts(0, 64).saturating_mul(m.into()))
 	}
 	/// Storage: AllianceMotion Members (r:1 w:0)
 	/// Proof Skipped: AllianceMotion Members (max_values: Some(1), max_size: None, mode: Measured)
@@ -132,18 +132,18 @@ impl<T: frame_system::Config> pallet_collective::WeightInfo for WeightInfo<T> {
 		//  Measured:  `386 + m * (32 ±0) + p * (36 ±0)`
 		//  Estimated: `5505 + m * (165 ±0) + p * (180 ±0)`
 		// Minimum execution time: 21_595 nanoseconds.
-		Weight::from_ref_time(23_162_876)
-			.saturating_add(Weight::from_proof_size(5505))
+		Weight::from_parts(23_162_876, 0)
+			.saturating_add(Weight::from_parts(0, 5505))
 			// Standard Error: 76
-			.saturating_add(Weight::from_ref_time(2_647).saturating_mul(b.into()))
+			.saturating_add(Weight::from_parts(2_647, 0).saturating_mul(b.into()))
 			// Standard Error: 797
-			.saturating_add(Weight::from_ref_time(19_673).saturating_mul(m.into()))
+			.saturating_add(Weight::from_parts(19_673, 0).saturating_mul(m.into()))
 			// Standard Error: 787
-			.saturating_add(Weight::from_ref_time(95_242).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(95_242, 0).saturating_mul(p.into()))
 			.saturating_add(T::DbWeight::get().reads(4))
 			.saturating_add(T::DbWeight::get().writes(4))
-			.saturating_add(Weight::from_proof_size(165).saturating_mul(m.into()))
-			.saturating_add(Weight::from_proof_size(180).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(0, 165).saturating_mul(m.into()))
+			.saturating_add(Weight::from_parts(0, 180).saturating_mul(p.into()))
 	}
 	/// Storage: AllianceMotion Members (r:1 w:0)
 	/// Proof Skipped: AllianceMotion Members (max_values: Some(1), max_size: None, mode: Measured)
@@ -155,13 +155,13 @@ impl<T: frame_system::Config> pallet_collective::WeightInfo for WeightInfo<T> {
 		//  Measured:  `836 + m * (64 ±0)`
 		//  Estimated: `4640 + m * (128 ±0)`
 		// Minimum execution time: 20_793 nanoseconds.
-		Weight::from_ref_time(21_342_865)
-			.saturating_add(Weight::from_proof_size(4640))
+		Weight::from_parts(21_342_865, 0)
+			.saturating_add(Weight::from_parts(0, 4640))
 			// Standard Error: 394
-			.saturating_add(Weight::from_ref_time(43_236).saturating_mul(m.into()))
+			.saturating_add(Weight::from_parts(43_236, 0).saturating_mul(m.into()))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
-			.saturating_add(Weight::from_proof_size(128).saturating_mul(m.into()))
+			.saturating_add(Weight::from_parts(0, 128).saturating_mul(m.into()))
 	}
 	/// Storage: AllianceMotion Voting (r:1 w:1)
 	/// Proof Skipped: AllianceMotion Voting (max_values: None, max_size: None, mode: Measured)
@@ -178,16 +178,16 @@ impl<T: frame_system::Config> pallet_collective::WeightInfo for WeightInfo<T> {
 		//  Measured:  `456 + m * (64 ±0) + p * (36 ±0)`
 		//  Estimated: `5213 + m * (260 ±0) + p * (144 ±0)`
 		// Minimum execution time: 24_859 nanoseconds.
-		Weight::from_ref_time(26_156_065)
-			.saturating_add(Weight::from_proof_size(5213))
+		Weight::from_parts(26_156_065, 0)
+			.saturating_add(Weight::from_parts(0, 5213))
 			// Standard Error: 737
-			.saturating_add(Weight::from_ref_time(20_578).saturating_mul(m.into()))
+			.saturating_add(Weight::from_parts(20_578, 0).saturating_mul(m.into()))
 			// Standard Error: 718
-			.saturating_add(Weight::from_ref_time(86_327).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(86_327, 0).saturating_mul(p.into()))
 			.saturating_add(T::DbWeight::get().reads(3))
 			.saturating_add(T::DbWeight::get().writes(3))
-			.saturating_add(Weight::from_proof_size(260).saturating_mul(m.into()))
-			.saturating_add(Weight::from_proof_size(144).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(0, 260).saturating_mul(m.into()))
+			.saturating_add(Weight::from_parts(0, 144).saturating_mul(p.into()))
 	}
 	/// Storage: AllianceMotion Voting (r:1 w:1)
 	/// Proof Skipped: AllianceMotion Voting (max_values: None, max_size: None, mode: Measured)
@@ -205,19 +205,19 @@ impl<T: frame_system::Config> pallet_collective::WeightInfo for WeightInfo<T> {
 		//  Measured:  `792 + b * (1 ±0) + m * (64 ±0) + p * (40 ±0)`
 		//  Estimated: `8484 + b * (4 ±0) + m * (264 ±0) + p * (160 ±0)`
 		// Minimum execution time: 34_729 nanoseconds.
-		Weight::from_ref_time(36_499_058)
-			.saturating_add(Weight::from_proof_size(8484))
+		Weight::from_parts(36_499_058, 0)
+			.saturating_add(Weight::from_parts(0, 8484))
 			// Standard Error: 84
-			.saturating_add(Weight::from_ref_time(1_409).saturating_mul(b.into()))
+			.saturating_add(Weight::from_parts(1_409, 0).saturating_mul(b.into()))
 			// Standard Error: 893
-			.saturating_add(Weight::from_ref_time(14_167).saturating_mul(m.into()))
+			.saturating_add(Weight::from_parts(14_167, 0).saturating_mul(m.into()))
 			// Standard Error: 871
-			.saturating_add(Weight::from_ref_time(101_999).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(101_999, 0).saturating_mul(p.into()))
 			.saturating_add(T::DbWeight::get().reads(4))
 			.saturating_add(T::DbWeight::get().writes(3))
-			.saturating_add(Weight::from_proof_size(4).saturating_mul(b.into()))
-			.saturating_add(Weight::from_proof_size(264).saturating_mul(m.into()))
-			.saturating_add(Weight::from_proof_size(160).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(0, 4).saturating_mul(b.into()))
+			.saturating_add(Weight::from_parts(0, 264).saturating_mul(m.into()))
+			.saturating_add(Weight::from_parts(0, 160).saturating_mul(p.into()))
 	}
 	/// Storage: AllianceMotion Voting (r:1 w:1)
 	/// Proof Skipped: AllianceMotion Voting (max_values: None, max_size: None, mode: Measured)
@@ -236,16 +236,16 @@ impl<T: frame_system::Config> pallet_collective::WeightInfo for WeightInfo<T> {
 		//  Measured:  `553 + m * (48 ±0) + p * (36 ±0)`
 		//  Estimated: `6605 + m * (245 ±0) + p * (180 ±0)`
 		// Minimum execution time: 27_113 nanoseconds.
-		Weight::from_ref_time(28_105_174)
-			.saturating_add(Weight::from_proof_size(6605))
+		Weight::from_parts(28_105_174, 0)
+			.saturating_add(Weight::from_parts(0, 6605))
 			// Standard Error: 686
-			.saturating_add(Weight::from_ref_time(20_379).saturating_mul(m.into()))
+			.saturating_add(Weight::from_parts(20_379, 0).saturating_mul(m.into()))
 			// Standard Error: 669
-			.saturating_add(Weight::from_ref_time(89_284).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(89_284, 0).saturating_mul(p.into()))
 			.saturating_add(T::DbWeight::get().reads(4))
 			.saturating_add(T::DbWeight::get().writes(3))
-			.saturating_add(Weight::from_proof_size(245).saturating_mul(m.into()))
-			.saturating_add(Weight::from_proof_size(180).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(0, 245).saturating_mul(m.into()))
+			.saturating_add(Weight::from_parts(0, 180).saturating_mul(p.into()))
 	}
 	/// Storage: AllianceMotion Voting (r:1 w:1)
 	/// Proof Skipped: AllianceMotion Voting (max_values: None, max_size: None, mode: Measured)
@@ -265,19 +265,19 @@ impl<T: frame_system::Config> pallet_collective::WeightInfo for WeightInfo<T> {
 		//  Measured:  `812 + b * (1 ±0) + m * (64 ±0) + p * (40 ±0)`
 		//  Estimated: `9715 + b * (5 ±0) + m * (330 ±0) + p * (200 ±0)`
 		// Minimum execution time: 37_242 nanoseconds.
-		Weight::from_ref_time(38_722_168)
-			.saturating_add(Weight::from_proof_size(9715))
+		Weight::from_parts(38_722_168, 0)
+			.saturating_add(Weight::from_parts(0, 9715))
 			// Standard Error: 89
-			.saturating_add(Weight::from_ref_time(1_419).saturating_mul(b.into()))
+			.saturating_add(Weight::from_parts(1_419, 0).saturating_mul(b.into()))
 			// Standard Error: 947
-			.saturating_add(Weight::from_ref_time(15_417).saturating_mul(m.into()))
+			.saturating_add(Weight::from_parts(15_417, 0).saturating_mul(m.into()))
 			// Standard Error: 923
-			.saturating_add(Weight::from_ref_time(103_094).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(103_094, 0).saturating_mul(p.into()))
 			.saturating_add(T::DbWeight::get().reads(5))
 			.saturating_add(T::DbWeight::get().writes(3))
-			.saturating_add(Weight::from_proof_size(5).saturating_mul(b.into()))
-			.saturating_add(Weight::from_proof_size(330).saturating_mul(m.into()))
-			.saturating_add(Weight::from_proof_size(200).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(0, 5).saturating_mul(b.into()))
+			.saturating_add(Weight::from_parts(0, 330).saturating_mul(m.into()))
+			.saturating_add(Weight::from_parts(0, 200).saturating_mul(p.into()))
 	}
 	/// Storage: AllianceMotion Proposals (r:1 w:1)
 	/// Proof Skipped: AllianceMotion Proposals (max_values: Some(1), max_size: None, mode: Measured)
@@ -291,12 +291,12 @@ impl<T: frame_system::Config> pallet_collective::WeightInfo for WeightInfo<T> {
 		//  Measured:  `221 + p * (32 ±0)`
 		//  Estimated: `1158 + p * (96 ±0)`
 		// Minimum execution time: 13_173 nanoseconds.
-		Weight::from_ref_time(14_787_145)
-			.saturating_add(Weight::from_proof_size(1158))
+		Weight::from_parts(14_787_145, 0)
+			.saturating_add(Weight::from_parts(0, 1158))
 			// Standard Error: 614
-			.saturating_add(Weight::from_ref_time(81_286).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(81_286, 0).saturating_mul(p.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(3))
-			.saturating_add(Weight::from_proof_size(96).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(0, 96).saturating_mul(p.into()))
 	}
 }

--- a/parachains/runtimes/collectives/collectives-polkadot/src/weights/pallet_multisig.rs
+++ b/parachains/runtimes/collectives/collectives-polkadot/src/weights/pallet_multisig.rs
@@ -53,10 +53,10 @@ impl<T: frame_system::Config> pallet_multisig::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 11_628 nanoseconds.
-		Weight::from_ref_time(12_058_313)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(12_058_313, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			// Standard Error: 3
-			.saturating_add(Weight::from_ref_time(500).saturating_mul(z.into()))
+			.saturating_add(Weight::from_parts(500, 0).saturating_mul(z.into()))
 	}
 	/// Storage: Multisig Multisigs (r:1 w:1)
 	/// Proof: Multisig Multisigs (max_values: None, max_size: Some(3346), added: 5821, mode: MaxEncodedLen)
@@ -67,12 +67,12 @@ impl<T: frame_system::Config> pallet_multisig::WeightInfo for WeightInfo<T> {
 		//  Measured:  `311 + s * (2 ±0)`
 		//  Estimated: `5821`
 		// Minimum execution time: 34_764 nanoseconds.
-		Weight::from_ref_time(27_813_109)
-			.saturating_add(Weight::from_proof_size(5821))
+		Weight::from_parts(27_813_109, 0)
+			.saturating_add(Weight::from_parts(0, 5821))
 			// Standard Error: 630
-			.saturating_add(Weight::from_ref_time(73_821).saturating_mul(s.into()))
+			.saturating_add(Weight::from_parts(73_821, 0).saturating_mul(s.into()))
 			// Standard Error: 6
-			.saturating_add(Weight::from_ref_time(1_542).saturating_mul(z.into()))
+			.saturating_add(Weight::from_parts(1_542, 0).saturating_mul(z.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -85,12 +85,12 @@ impl<T: frame_system::Config> pallet_multisig::WeightInfo for WeightInfo<T> {
 		//  Measured:  `313`
 		//  Estimated: `5821`
 		// Minimum execution time: 25_932 nanoseconds.
-		Weight::from_ref_time(19_364_026)
-			.saturating_add(Weight::from_proof_size(5821))
+		Weight::from_parts(19_364_026, 0)
+			.saturating_add(Weight::from_parts(0, 5821))
 			// Standard Error: 490
-			.saturating_add(Weight::from_ref_time(69_834).saturating_mul(s.into()))
+			.saturating_add(Weight::from_parts(69_834, 0).saturating_mul(s.into()))
 			// Standard Error: 4
-			.saturating_add(Weight::from_ref_time(1_520).saturating_mul(z.into()))
+			.saturating_add(Weight::from_parts(1_520, 0).saturating_mul(z.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -105,12 +105,12 @@ impl<T: frame_system::Config> pallet_multisig::WeightInfo for WeightInfo<T> {
 		//  Measured:  `448 + s * (33 ±0)`
 		//  Estimated: `8424`
 		// Minimum execution time: 39_495 nanoseconds.
-		Weight::from_ref_time(31_235_649)
-			.saturating_add(Weight::from_proof_size(8424))
+		Weight::from_parts(31_235_649, 0)
+			.saturating_add(Weight::from_parts(0, 8424))
 			// Standard Error: 570
-			.saturating_add(Weight::from_ref_time(88_719).saturating_mul(s.into()))
+			.saturating_add(Weight::from_parts(88_719, 0).saturating_mul(s.into()))
 			// Standard Error: 5
-			.saturating_add(Weight::from_ref_time(1_523).saturating_mul(z.into()))
+			.saturating_add(Weight::from_parts(1_523, 0).saturating_mul(z.into()))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -122,10 +122,10 @@ impl<T: frame_system::Config> pallet_multisig::WeightInfo for WeightInfo<T> {
 		//  Measured:  `318 + s * (2 ±0)`
 		//  Estimated: `5821`
 		// Minimum execution time: 24_708 nanoseconds.
-		Weight::from_ref_time(26_673_173)
-			.saturating_add(Weight::from_proof_size(5821))
+		Weight::from_parts(26_673_173, 0)
+			.saturating_add(Weight::from_parts(0, 5821))
 			// Standard Error: 863
-			.saturating_add(Weight::from_ref_time(81_459).saturating_mul(s.into()))
+			.saturating_add(Weight::from_parts(81_459, 0).saturating_mul(s.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -137,10 +137,10 @@ impl<T: frame_system::Config> pallet_multisig::WeightInfo for WeightInfo<T> {
 		//  Measured:  `313`
 		//  Estimated: `5821`
 		// Minimum execution time: 16_520 nanoseconds.
-		Weight::from_ref_time(18_123_705)
-			.saturating_add(Weight::from_proof_size(5821))
+		Weight::from_parts(18_123_705, 0)
+			.saturating_add(Weight::from_parts(0, 5821))
 			// Standard Error: 661
-			.saturating_add(Weight::from_ref_time(74_405).saturating_mul(s.into()))
+			.saturating_add(Weight::from_parts(74_405, 0).saturating_mul(s.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -152,10 +152,10 @@ impl<T: frame_system::Config> pallet_multisig::WeightInfo for WeightInfo<T> {
 		//  Measured:  `517 + s * (1 ±0)`
 		//  Estimated: `5821`
 		// Minimum execution time: 25_476 nanoseconds.
-		Weight::from_ref_time(27_845_581)
-			.saturating_add(Weight::from_proof_size(5821))
+		Weight::from_parts(27_845_581, 0)
+			.saturating_add(Weight::from_parts(0, 5821))
 			// Standard Error: 868
-			.saturating_add(Weight::from_ref_time(77_797).saturating_mul(s.into()))
+			.saturating_add(Weight::from_parts(77_797, 0).saturating_mul(s.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}

--- a/parachains/runtimes/collectives/collectives-polkadot/src/weights/pallet_proxy.rs
+++ b/parachains/runtimes/collectives/collectives-polkadot/src/weights/pallet_proxy.rs
@@ -55,10 +55,10 @@ impl<T: frame_system::Config> pallet_proxy::WeightInfo for WeightInfo<T> {
 		//  Measured:  `159 + p * (37 ±0)`
 		//  Estimated: `3716`
 		// Minimum execution time: 14_443 nanoseconds.
-		Weight::from_ref_time(15_158_969)
-			.saturating_add(Weight::from_proof_size(3716))
+		Weight::from_parts(15_158_969, 0)
+			.saturating_add(Weight::from_parts(0, 3716))
 			// Standard Error: 1_249
-			.saturating_add(Weight::from_ref_time(33_941).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(33_941, 0).saturating_mul(p.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 	}
 	/// Storage: Proxy Proxies (r:1 w:0)
@@ -74,12 +74,12 @@ impl<T: frame_system::Config> pallet_proxy::WeightInfo for WeightInfo<T> {
 		//  Measured:  `550 + a * (68 ±0) + p * (37 ±0)`
 		//  Estimated: `11027`
 		// Minimum execution time: 32_060 nanoseconds.
-		Weight::from_ref_time(32_192_294)
-			.saturating_add(Weight::from_proof_size(11027))
+		Weight::from_parts(32_192_294, 0)
+			.saturating_add(Weight::from_parts(0, 11027))
 			// Standard Error: 1_900
-			.saturating_add(Weight::from_ref_time(109_332).saturating_mul(a.into()))
+			.saturating_add(Weight::from_parts(109_332, 0).saturating_mul(a.into()))
 			// Standard Error: 1_963
-			.saturating_add(Weight::from_ref_time(39_154).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(39_154, 0).saturating_mul(p.into()))
 			.saturating_add(T::DbWeight::get().reads(3))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -94,12 +94,12 @@ impl<T: frame_system::Config> pallet_proxy::WeightInfo for WeightInfo<T> {
 		//  Measured:  `433 + a * (68 ±0)`
 		//  Estimated: `7311`
 		// Minimum execution time: 20_084 nanoseconds.
-		Weight::from_ref_time(21_187_531)
-			.saturating_add(Weight::from_proof_size(7311))
+		Weight::from_parts(21_187_531, 0)
+			.saturating_add(Weight::from_parts(0, 7311))
 			// Standard Error: 1_412
-			.saturating_add(Weight::from_ref_time(112_601).saturating_mul(a.into()))
+			.saturating_add(Weight::from_parts(112_601, 0).saturating_mul(a.into()))
 			// Standard Error: 1_458
-			.saturating_add(Weight::from_ref_time(6_862).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(6_862, 0).saturating_mul(p.into()))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -114,12 +114,12 @@ impl<T: frame_system::Config> pallet_proxy::WeightInfo for WeightInfo<T> {
 		//  Measured:  `433 + a * (68 ±0)`
 		//  Estimated: `7311`
 		// Minimum execution time: 20_658 nanoseconds.
-		Weight::from_ref_time(21_184_810)
-			.saturating_add(Weight::from_proof_size(7311))
+		Weight::from_parts(21_184_810, 0)
+			.saturating_add(Weight::from_parts(0, 7311))
 			// Standard Error: 1_259
-			.saturating_add(Weight::from_ref_time(112_012).saturating_mul(a.into()))
+			.saturating_add(Weight::from_parts(112_012, 0).saturating_mul(a.into()))
 			// Standard Error: 1_301
-			.saturating_add(Weight::from_ref_time(10_767).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(10_767, 0).saturating_mul(p.into()))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -136,12 +136,12 @@ impl<T: frame_system::Config> pallet_proxy::WeightInfo for WeightInfo<T> {
 		//  Measured:  `482 + a * (68 ±0) + p * (37 ±0)`
 		//  Estimated: `11027`
 		// Minimum execution time: 28_670 nanoseconds.
-		Weight::from_ref_time(29_411_875)
-			.saturating_add(Weight::from_proof_size(11027))
+		Weight::from_parts(29_411_875, 0)
+			.saturating_add(Weight::from_parts(0, 11027))
 			// Standard Error: 1_864
-			.saturating_add(Weight::from_ref_time(94_146).saturating_mul(a.into()))
+			.saturating_add(Weight::from_parts(94_146, 0).saturating_mul(a.into()))
 			// Standard Error: 1_926
-			.saturating_add(Weight::from_ref_time(36_523).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(36_523, 0).saturating_mul(p.into()))
 			.saturating_add(T::DbWeight::get().reads(3))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -153,10 +153,10 @@ impl<T: frame_system::Config> pallet_proxy::WeightInfo for WeightInfo<T> {
 		//  Measured:  `159 + p * (37 ±0)`
 		//  Estimated: `3716`
 		// Minimum execution time: 21_273 nanoseconds.
-		Weight::from_ref_time(22_137_672)
-			.saturating_add(Weight::from_proof_size(3716))
+		Weight::from_parts(22_137_672, 0)
+			.saturating_add(Weight::from_parts(0, 3716))
 			// Standard Error: 1_345
-			.saturating_add(Weight::from_ref_time(44_075).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(44_075, 0).saturating_mul(p.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -168,10 +168,10 @@ impl<T: frame_system::Config> pallet_proxy::WeightInfo for WeightInfo<T> {
 		//  Measured:  `159 + p * (37 ±0)`
 		//  Estimated: `3716`
 		// Minimum execution time: 20_888 nanoseconds.
-		Weight::from_ref_time(22_120_940)
-			.saturating_add(Weight::from_proof_size(3716))
+		Weight::from_parts(22_120_940, 0)
+			.saturating_add(Weight::from_parts(0, 3716))
 			// Standard Error: 1_516
-			.saturating_add(Weight::from_ref_time(55_407).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(55_407, 0).saturating_mul(p.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -183,10 +183,10 @@ impl<T: frame_system::Config> pallet_proxy::WeightInfo for WeightInfo<T> {
 		//  Measured:  `159 + p * (37 ±0)`
 		//  Estimated: `3716`
 		// Minimum execution time: 17_007 nanoseconds.
-		Weight::from_ref_time(17_746_585)
-			.saturating_add(Weight::from_proof_size(3716))
+		Weight::from_parts(17_746_585, 0)
+			.saturating_add(Weight::from_parts(0, 3716))
 			// Standard Error: 1_201
-			.saturating_add(Weight::from_ref_time(22_307).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(22_307, 0).saturating_mul(p.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -198,10 +198,10 @@ impl<T: frame_system::Config> pallet_proxy::WeightInfo for WeightInfo<T> {
 		//  Measured:  `139`
 		//  Estimated: `3716`
 		// Minimum execution time: 22_625 nanoseconds.
-		Weight::from_ref_time(23_598_172)
-			.saturating_add(Weight::from_proof_size(3716))
+		Weight::from_parts(23_598_172, 0)
+			.saturating_add(Weight::from_parts(0, 3716))
 			// Standard Error: 1_668
-			.saturating_add(Weight::from_ref_time(113).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(113, 0).saturating_mul(p.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -213,10 +213,10 @@ impl<T: frame_system::Config> pallet_proxy::WeightInfo for WeightInfo<T> {
 		//  Measured:  `196 + p * (37 ±0)`
 		//  Estimated: `3716`
 		// Minimum execution time: 17_969 nanoseconds.
-		Weight::from_ref_time(18_830_934)
-			.saturating_add(Weight::from_proof_size(3716))
+		Weight::from_parts(18_830_934, 0)
+			.saturating_add(Weight::from_parts(0, 3716))
 			// Standard Error: 1_340
-			.saturating_add(Weight::from_ref_time(23_749).saturating_mul(p.into()))
+			.saturating_add(Weight::from_parts(23_749, 0).saturating_mul(p.into()))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}

--- a/parachains/runtimes/collectives/collectives-polkadot/src/weights/pallet_session.rs
+++ b/parachains/runtimes/collectives/collectives-polkadot/src/weights/pallet_session.rs
@@ -56,8 +56,8 @@ impl<T: frame_system::Config> pallet_session::WeightInfo for WeightInfo<T> {
 		//  Measured:  `270`
 		//  Estimated: `5490`
 		// Minimum execution time: 15_653 nanoseconds.
-		Weight::from_ref_time(16_004_000)
-			.saturating_add(Weight::from_proof_size(5490))
+		Weight::from_parts(16_004_000, 0)
+			.saturating_add(Weight::from_parts(0, 5490))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -70,8 +70,8 @@ impl<T: frame_system::Config> pallet_session::WeightInfo for WeightInfo<T> {
 		//  Measured:  `242`
 		//  Estimated: `2959`
 		// Minimum execution time: 11_729 nanoseconds.
-		Weight::from_ref_time(12_081_000)
-			.saturating_add(Weight::from_proof_size(2959))
+		Weight::from_parts(12_081_000, 0)
+			.saturating_add(Weight::from_parts(0, 2959))
 			.saturating_add(T::DbWeight::get().reads(1))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}

--- a/parachains/runtimes/collectives/collectives-polkadot/src/weights/pallet_timestamp.rs
+++ b/parachains/runtimes/collectives/collectives-polkadot/src/weights/pallet_timestamp.rs
@@ -56,8 +56,8 @@ impl<T: frame_system::Config> pallet_timestamp::WeightInfo for WeightInfo<T> {
 		//  Measured:  `49`
 		//  Estimated: `1006`
 		// Minimum execution time: 6_995 nanoseconds.
-		Weight::from_ref_time(7_169_000)
-			.saturating_add(Weight::from_proof_size(1006))
+		Weight::from_parts(7_169_000, 0)
+			.saturating_add(Weight::from_parts(0, 1006))
 			.saturating_add(T::DbWeight::get().reads(2))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
@@ -66,7 +66,7 @@ impl<T: frame_system::Config> pallet_timestamp::WeightInfo for WeightInfo<T> {
 		//  Measured:  `57`
 		//  Estimated: `0`
 		// Minimum execution time: 3_166 nanoseconds.
-		Weight::from_ref_time(3_331_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(3_331_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 	}
 }

--- a/parachains/runtimes/collectives/collectives-polkadot/src/weights/pallet_utility.rs
+++ b/parachains/runtimes/collectives/collectives-polkadot/src/weights/pallet_utility.rs
@@ -53,18 +53,18 @@ impl<T: frame_system::Config> pallet_utility::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 5_987 nanoseconds.
-		Weight::from_ref_time(19_221_047)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(19_221_047, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			// Standard Error: 2_233
-			.saturating_add(Weight::from_ref_time(3_808_598).saturating_mul(c.into()))
+			.saturating_add(Weight::from_parts(3_808_598, 0).saturating_mul(c.into()))
 	}
 	fn as_derivative() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 4_203 nanoseconds.
-		Weight::from_ref_time(4_337_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(4_337_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 	}
 	/// The range of component `c` is `[0, 1000]`.
 	fn batch_all(c: u32, ) -> Weight {
@@ -72,18 +72,18 @@ impl<T: frame_system::Config> pallet_utility::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 5_986 nanoseconds.
-		Weight::from_ref_time(14_991_349)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(14_991_349, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			// Standard Error: 2_440
-			.saturating_add(Weight::from_ref_time(4_032_363).saturating_mul(c.into()))
+			.saturating_add(Weight::from_parts(4_032_363, 0).saturating_mul(c.into()))
 	}
 	fn dispatch_as() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 7_768 nanoseconds.
-		Weight::from_ref_time(7_998_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(7_998_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 	}
 	/// The range of component `c` is `[0, 1000]`.
 	fn force_batch(c: u32, ) -> Weight {
@@ -91,9 +91,9 @@ impl<T: frame_system::Config> pallet_utility::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 5_906 nanoseconds.
-		Weight::from_ref_time(16_782_253)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(16_782_253, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			// Standard Error: 2_131
-			.saturating_add(Weight::from_ref_time(3_780_339).saturating_mul(c.into()))
+			.saturating_add(Weight::from_parts(3_780_339, 0).saturating_mul(c.into()))
 	}
 }

--- a/parachains/runtimes/collectives/collectives-polkadot/src/weights/pallet_xcm.rs
+++ b/parachains/runtimes/collectives/collectives-polkadot/src/weights/pallet_xcm.rs
@@ -62,8 +62,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `38`
 		//  Estimated: `4645`
 		// Minimum execution time: 23_618 nanoseconds.
-		Weight::from_ref_time(24_118_000)
-			.saturating_add(Weight::from_proof_size(4645))
+		Weight::from_parts(24_118_000, 0)
+			.saturating_add(Weight::from_parts(0, 4645))
 			.saturating_add(T::DbWeight::get().reads(5))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -74,8 +74,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `32`
 		//  Estimated: `499`
 		// Minimum execution time: 23_764 nanoseconds.
-		Weight::from_ref_time(24_114_000)
-			.saturating_add(Weight::from_proof_size(499))
+		Weight::from_parts(24_114_000, 0)
+			.saturating_add(Weight::from_parts(0, 499))
 			.saturating_add(T::DbWeight::get().reads(1))
 	}
 	/// Storage: Benchmark Override (r:0 w:0)
@@ -85,8 +85,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 18_446_744_073_709_551 nanoseconds.
-		Weight::from_ref_time(18_446_744_073_709_551_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(18_446_744_073_709_551_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 	}
 	/// Storage: Benchmark Override (r:0 w:0)
 	/// Proof Skipped: Benchmark Override (max_values: None, max_size: None, mode: Measured)
@@ -95,8 +95,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 18_446_744_073_709_551 nanoseconds.
-		Weight::from_ref_time(18_446_744_073_709_551_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(18_446_744_073_709_551_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 	}
 	/// Storage: PolkadotXcm SupportedVersion (r:0 w:1)
 	/// Proof Skipped: PolkadotXcm SupportedVersion (max_values: None, max_size: None, mode: Measured)
@@ -105,8 +105,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 8_266 nanoseconds.
-		Weight::from_ref_time(8_578_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(8_578_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
 	/// Storage: PolkadotXcm SafeXcmVersion (r:0 w:1)
@@ -116,8 +116,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `0`
 		//  Estimated: `0`
 		// Minimum execution time: 2_289 nanoseconds.
-		Weight::from_ref_time(2_382_000)
-			.saturating_add(Weight::from_proof_size(0))
+		Weight::from_parts(2_382_000, 0)
+			.saturating_add(Weight::from_parts(0, 0))
 			.saturating_add(T::DbWeight::get().writes(1))
 	}
 	/// Storage: PolkadotXcm VersionNotifiers (r:1 w:1)
@@ -141,8 +141,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `38`
 		//  Estimated: `7729`
 		// Minimum execution time: 28_592 nanoseconds.
-		Weight::from_ref_time(29_116_000)
-			.saturating_add(Weight::from_proof_size(7729))
+		Weight::from_parts(29_116_000, 0)
+			.saturating_add(Weight::from_parts(0, 7729))
 			.saturating_add(T::DbWeight::get().reads(7))
 			.saturating_add(T::DbWeight::get().writes(5))
 	}
@@ -165,8 +165,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `220`
 		//  Estimated: `8470`
 		// Minimum execution time: 30_604 nanoseconds.
-		Weight::from_ref_time(31_361_000)
-			.saturating_add(Weight::from_proof_size(8470))
+		Weight::from_parts(31_361_000, 0)
+			.saturating_add(Weight::from_parts(0, 8470))
 			.saturating_add(T::DbWeight::get().reads(6))
 			.saturating_add(T::DbWeight::get().writes(4))
 	}
@@ -177,8 +177,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `95`
 		//  Estimated: `9995`
 		// Minimum execution time: 13_750 nanoseconds.
-		Weight::from_ref_time(14_051_000)
-			.saturating_add(Weight::from_proof_size(9995))
+		Weight::from_parts(14_051_000, 0)
+			.saturating_add(Weight::from_parts(0, 9995))
 			.saturating_add(T::DbWeight::get().reads(4))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -189,8 +189,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `99`
 		//  Estimated: `9999`
 		// Minimum execution time: 13_897 nanoseconds.
-		Weight::from_ref_time(14_080_000)
-			.saturating_add(Weight::from_proof_size(9999))
+		Weight::from_parts(14_080_000, 0)
+			.saturating_add(Weight::from_parts(0, 9999))
 			.saturating_add(T::DbWeight::get().reads(4))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -201,8 +201,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `106`
 		//  Estimated: `12481`
 		// Minimum execution time: 16_364 nanoseconds.
-		Weight::from_ref_time(16_867_000)
-			.saturating_add(Weight::from_proof_size(12481))
+		Weight::from_parts(16_867_000, 0)
+			.saturating_add(Weight::from_parts(0, 12481))
 			.saturating_add(T::DbWeight::get().reads(5))
 	}
 	/// Storage: PolkadotXcm VersionNotifyTargets (r:2 w:1)
@@ -222,8 +222,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `106`
 		//  Estimated: `10041`
 		// Minimum execution time: 27_372 nanoseconds.
-		Weight::from_ref_time(28_128_000)
-			.saturating_add(Weight::from_proof_size(10041))
+		Weight::from_parts(28_128_000, 0)
+			.saturating_add(Weight::from_parts(0, 10041))
 			.saturating_add(T::DbWeight::get().reads(7))
 			.saturating_add(T::DbWeight::get().writes(3))
 	}
@@ -234,8 +234,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `136`
 		//  Estimated: `7561`
 		// Minimum execution time: 7_804 nanoseconds.
-		Weight::from_ref_time(8_096_000)
-			.saturating_add(Weight::from_proof_size(7561))
+		Weight::from_parts(8_096_000, 0)
+			.saturating_add(Weight::from_parts(0, 7561))
 			.saturating_add(T::DbWeight::get().reads(3))
 	}
 	/// Storage: PolkadotXcm VersionNotifyTargets (r:4 w:2)
@@ -245,8 +245,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `106`
 		//  Estimated: `10006`
 		// Minimum execution time: 14_948 nanoseconds.
-		Weight::from_ref_time(15_422_000)
-			.saturating_add(Weight::from_proof_size(10006))
+		Weight::from_parts(15_422_000, 0)
+			.saturating_add(Weight::from_parts(0, 10006))
 			.saturating_add(T::DbWeight::get().reads(4))
 			.saturating_add(T::DbWeight::get().writes(2))
 	}
@@ -267,8 +267,8 @@ impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 		//  Measured:  `112`
 		//  Estimated: `15027`
 		// Minimum execution time: 33_791 nanoseconds.
-		Weight::from_ref_time(34_282_000)
-			.saturating_add(Weight::from_proof_size(15027))
+		Weight::from_parts(34_282_000, 0)
+			.saturating_add(Weight::from_parts(0, 15027))
 			.saturating_add(T::DbWeight::get().reads(9))
 			.saturating_add(T::DbWeight::get().writes(4))
 	}

--- a/parachains/runtimes/contracts/contracts-rococo/src/weights/block_weights.rs
+++ b/parachains/runtimes/contracts/contracts-rococo/src/weights/block_weights.rs
@@ -24,7 +24,7 @@ pub mod constants {
 	parameter_types! {
 		/// Importing a block with 0 Extrinsics.
 		pub const BlockExecutionWeight: Weight =
-			Weight::from_ref_time(constants::WEIGHT_REF_TIME_PER_NANOS.saturating_mul(5_000_000));
+			Weight::from_parts(constants::WEIGHT_REF_TIME_PER_NANOS.saturating_mul(5_000_000), 0);
 	}
 
 	#[cfg(test)]

--- a/parachains/runtimes/contracts/contracts-rococo/src/weights/extrinsic_weights.rs
+++ b/parachains/runtimes/contracts/contracts-rococo/src/weights/extrinsic_weights.rs
@@ -24,7 +24,7 @@ pub mod constants {
 	parameter_types! {
 		/// Executing a NO-OP `System::remarks` Extrinsic.
 		pub const ExtrinsicBaseWeight: Weight =
-			Weight::from_ref_time(constants::WEIGHT_REF_TIME_PER_NANOS.saturating_mul(125_000));
+			Weight::from_parts(constants::WEIGHT_REF_TIME_PER_NANOS.saturating_mul(125_000), 0);
 	}
 
 	#[cfg(test)]

--- a/parachains/runtimes/testing/penpal/src/weights/block_weights.rs
+++ b/parachains/runtimes/testing/penpal/src/weights/block_weights.rs
@@ -24,7 +24,7 @@ pub mod constants {
 	parameter_types! {
 		/// Importing a block with 0 Extrinsics.
 		pub const BlockExecutionWeight: Weight =
-			Weight::from_ref_time(constants::WEIGHT_REF_TIME_PER_NANOS.saturating_mul(5_000_000));
+			Weight::from_parts(constants::WEIGHT_REF_TIME_PER_NANOS.saturating_mul(5_000_000), 0);
 	}
 
 	#[cfg(test)]

--- a/parachains/runtimes/testing/penpal/src/weights/extrinsic_weights.rs
+++ b/parachains/runtimes/testing/penpal/src/weights/extrinsic_weights.rs
@@ -24,7 +24,7 @@ pub mod constants {
 	parameter_types! {
 		/// Executing a NO-OP `System::remarks` Extrinsic.
 		pub const ExtrinsicBaseWeight: Weight =
-			Weight::from_ref_time(constants::WEIGHT_REF_TIME_PER_NANOS.saturating_mul(125_000));
+			Weight::from_parts(constants::WEIGHT_REF_TIME_PER_NANOS.saturating_mul(125_000), 0);
 	}
 
 	#[cfg(test)]

--- a/test/runtime/src/lib.rs
+++ b/test/runtime/src/lib.rs
@@ -352,7 +352,7 @@ pub struct TestOnRuntimeUpgrade;
 impl OnRuntimeUpgrade for TestOnRuntimeUpgrade {
 	fn on_runtime_upgrade() -> frame_support::weights::Weight {
 		assert_eq!(sp_io::storage::get(TEST_RUNTIME_UPGRADE_KEY), Some(vec![1, 2, 3, 4].into()));
-		Weight::from_ref_time(1)
+		Weight::from_parts(1, 0)
 	}
 }
 

--- a/test/service/src/lib.rs
+++ b/test/service/src/lib.rs
@@ -792,7 +792,7 @@ impl TestNode {
 		self.send_extrinsic(
 			runtime::SudoCall::sudo_unchecked_weight {
 				call: Box::new(call.into()),
-				weight: Weight::from_ref_time(1_000),
+				weight: Weight::from_parts(1_000, 0),
 			},
 			Sr25519Keyring::Alice,
 		)


### PR DESCRIPTION
Use `Weight::from_parts` instead of `from_ref_time` and `from_proof_size`. One stop migration script: [migrate-from-parts.py](https://github.com/ggwpez/substrate-scripts/blob/master/migrate-from-parts.py).

Companion for https://github.com/paritytech/substrate/pull/13475  
Analogous to https://github.com/paritytech/polkadot/pull/6794