### PR TITLE
Add Version Checks on Para Upgrade

### DIFF
--- a/pallets/parachain-system/src/lib.rs
+++ b/pallets/parachain-system/src/lib.rs
@@ -54,7 +54,6 @@ use sp_runtime::{
 	},
 };
 use sp_std::{cmp, collections::btree_map::BTreeMap, prelude::*};
-use sp_version::RuntimeVersion;
 use xcm::latest::XcmHash;
 
 mod migration;
@@ -543,13 +542,6 @@ pub mod pallet {
 		NothingAuthorized,
 		/// The given code upgrade has not been authorized.
 		Unauthorized,
-		/// Failed to extract (or decode) the runtime version from the new runtime.
-		FailedToExtractRuntimeVersion,
-		/// The name of specification for the new runtime does not match the current runtime's.
-		InvalidSpecName,
-		/// The specification version of the new runtime is not allowed to decrease from or remain
-		/// equal to the current runtime's.
-		SpecVersionNeedsToIncrease,
 	}
 
 	/// In case of a scheduled upgrade, this storage field contains the validation code to be applied.

--- a/pallets/parachain-system/src/tests.rs
+++ b/pallets/parachain-system/src/tests.rs
@@ -979,11 +979,11 @@ fn test() {
 #[test]
 fn upgrade_version_checks_should_work() {
 	let test_data = vec![
-		("test", 0, 1, Err(Error::<Test>::SpecVersionNeedsToIncrease)),
-		("test", 1, 0, Err(Error::<Test>::SpecVersionNeedsToIncrease)),
-		("test", 1, 1, Err(Error::<Test>::SpecVersionNeedsToIncrease)),
-		("test", 1, 2, Err(Error::<Test>::SpecVersionNeedsToIncrease)),
-		("test2", 1, 1, Err(Error::<Test>::InvalidSpecName)),
+		("test", 0, 1, Err(frame_system::Error::<Test>::SpecVersionNeedsToIncrease)),
+		("test", 1, 0, Err(frame_system::Error::<Test>::SpecVersionNeedsToIncrease)),
+		("test", 1, 1, Err(frame_system::Error::<Test>::SpecVersionNeedsToIncrease)),
+		("test", 1, 2, Err(frame_system::Error::<Test>::SpecVersionNeedsToIncrease)),
+		("test2", 1, 1, Err(frame_system::Error::<Test>::InvalidSpecName)),
 	];
 
 	for (spec_name, spec_version, impl_version, expected) in test_data.into_iter() {

--- a/pallets/parachain-system/src/tests.rs
+++ b/pallets/parachain-system/src/tests.rs
@@ -32,10 +32,11 @@ use frame_support::{
 use frame_system::RawOrigin;
 use hex_literal::hex;
 use relay_chain::HrmpChannelId;
-use sp_core::H256;
+use sp_core::{blake2_256, H256};
 use sp_runtime::{
 	testing::Header,
 	traits::{BlakeTwo256, IdentityLookup},
+	DispatchErrorWithPostInfo,
 };
 use sp_version::RuntimeVersion;
 use std::cell::RefCell;
@@ -973,4 +974,38 @@ fn test() {
 		})
 		.add(1, || {})
 		.add(2, || {});
+}
+
+#[test]
+fn upgrade_version_checks_should_work() {
+	let test_data = vec![
+		("test", 0, 1, Err(Error::<Test>::SpecVersionNeedsToIncrease)),
+		("test", 1, 0, Err(Error::<Test>::SpecVersionNeedsToIncrease)),
+		("test", 1, 1, Err(Error::<Test>::SpecVersionNeedsToIncrease)),
+		("test", 1, 2, Err(Error::<Test>::SpecVersionNeedsToIncrease)),
+		("test2", 1, 1, Err(Error::<Test>::InvalidSpecName)),
+	];
+
+	for (spec_name, spec_version, impl_version, expected) in test_data.into_iter() {
+		let version = RuntimeVersion {
+			spec_name: spec_name.into(),
+			spec_version,
+			impl_version,
+			..Default::default()
+		};
+		let read_runtime_version = ReadRuntimeVersion(version.encode());
+
+		let mut ext = new_test_ext();
+		ext.register_extension(sp_core::traits::ReadRuntimeVersionExt::new(read_runtime_version));
+		ext.execute_with(|| {
+			let new_code = vec![1, 2, 3, 4];
+			let new_code_hash = sp_core::H256(blake2_256(&new_code));
+
+			let _authorize =
+				ParachainSystem::authorize_upgrade(RawOrigin::Root.into(), new_code_hash, true);
+			let res = ParachainSystem::enact_authorized_upgrade(RawOrigin::None.into(), new_code);
+
+			assert_eq!(expected.map_err(DispatchErrorWithPostInfo::from), res);
+		});
+	}
 }


### PR DESCRIPTION
Adds checks to ensure that the spec version is increasing and that the spec name is the same. This will prevent accidentally upgrading a parachain to a different runtime.

### Migration

Although this changes storage, I did not increase the storage version or provide a migration. The reason is that the upgrade itself will `kill` the affected storage item, and the next time an upgrade is authorized, the new type will be written. But this will break any front ends that show authorized upgrades, so let me know if I should bump the storage version for this.

### Transaction Version

Unfortunately breaks it, although it's a Root call. Could also add a new function `authorize_upgrade_without_checks` as an alternative.