### PR TITLE
introduce RelaychainStateProvider to parachain-system

### DIFF
--- a/pallets/parachain-system/src/lib.rs
+++ b/pallets/parachain-system/src/lib.rs
@@ -1153,6 +1153,7 @@ pub trait RelaychainStateProvider {
 #[deprecated]
 pub struct RelaychainBlockNumberProvider<T>(sp_std::marker::PhantomData<T>);
 
+#[allow(deprecated)]
 impl<T: Config> BlockNumberProvider for RelaychainBlockNumberProvider<T> {
 	type BlockNumber = relay_chain::BlockNumber;
 

--- a/pallets/parachain-system/src/lib.rs
+++ b/pallets/parachain-system/src/lib.rs
@@ -1150,7 +1150,7 @@ pub trait RelaychainStateProvider {
 /// When validation data is not available (e.g. within on_initialize), 0 will be returned.
 ///
 /// **NOTE**: This has been deprecated, please use [`RelaychainDataProvider`]
-#[deprecated]
+#[deprecated = "Use `RelaychainDataProvider` instead"]
 pub struct RelaychainBlockNumberProvider<T>(sp_std::marker::PhantomData<T>);
 
 #[allow(deprecated)]


### PR DESCRIPTION
This will allow parachains to read the relay chain state via storage proofs.