### PR TITLE
[Fix] Allow force_xcm_version call for assets parachains

### DIFF
--- a/parachains/runtimes/assets/statemine/src/xcm_config.rs
+++ b/parachains/runtimes/assets/statemine/src/xcm_config.rs
@@ -171,6 +171,7 @@ impl Contains<RuntimeCall> for SafeCallFilter {
 		}
 
 		match call {
+			RuntimeCall::PolkadotXcm(pallet_xcm::Call::force_xcm_version { .. }) |
 			RuntimeCall::System(
 				frame_system::Call::set_heap_pages { .. } |
 				frame_system::Call::set_code { .. } |

--- a/parachains/runtimes/assets/statemint/src/xcm_config.rs
+++ b/parachains/runtimes/assets/statemint/src/xcm_config.rs
@@ -171,6 +171,7 @@ impl Contains<RuntimeCall> for SafeCallFilter {
 		}
 
 		match call {
+			RuntimeCall::PolkadotXcm(pallet_xcm::Call::force_xcm_version { .. }) |
 			RuntimeCall::System(
 				frame_system::Call::set_heap_pages { .. } |
 				frame_system::Call::set_code { .. } |

--- a/parachains/runtimes/assets/westmint/src/xcm_config.rs
+++ b/parachains/runtimes/assets/westmint/src/xcm_config.rs
@@ -166,6 +166,7 @@ impl Contains<RuntimeCall> for SafeCallFilter {
 		}
 
 		match call {
+			RuntimeCall::PolkadotXcm(pallet_xcm::Call::force_xcm_version { .. }) |
 			RuntimeCall::System(
 				frame_system::Call::set_heap_pages { .. } |
 				frame_system::Call::set_code { .. } |


### PR DESCRIPTION
Same as https://github.com/paritytech/cumulus/pull/2222 but for statemine/t.