### PR TITLE
XCM: Use matcher API in DenyReserveAssetTransferToRelay

### DIFF
--- a/parachain-template/runtime/src/xcm_config.rs
+++ b/parachain-template/runtime/src/xcm_config.rs
@@ -11,7 +11,7 @@ use frame_support::{
 use pallet_xcm::XcmPassthrough;
 use polkadot_parachain::primitives::Sibling;
 use polkadot_runtime_common::impls::ToAuthor;
-use xcm::latest::prelude::*;
+use xcm::{latest::prelude::*, CreateMatcher, MatchXcm};
 use xcm_builder::{
 	AccountId32Aliases, AllowExplicitUnpaidExecutionFrom, AllowTopLevelPaidExecutionFrom,
 	CurrencyAdapter, EnsureXcmOrigin, FixedWeightBounds, IsConcrete, NativeAsset, ParentIsPreset,
@@ -122,32 +122,29 @@ impl ShouldExecute for DenyReserveTransferToRelayChain {
 		_max_weight: Weight,
 		_weight_credit: &mut Weight,
 	) -> Result<(), ()> {
-		if message.iter().any(|inst| {
-			matches!(
-				inst,
-				InitiateReserveWithdraw {
-					reserve: MultiLocation { parents: 1, interior: Here },
-					..
-				} | DepositReserveAsset { dest: MultiLocation { parents: 1, interior: Here }, .. } |
-					TransferReserveAsset {
-						dest: MultiLocation { parents: 1, interior: Here },
-						..
-					}
-			)
-		}) {
-			return Err(()) // Deny
-		}
+		message.matcher().match_next_inst_while(true, |inst| match inst {
+			InitiateReserveWithdraw {
+				reserve: MultiLocation { parents: 1, interior: Here },
+				..
+			} |
+			DepositReserveAsset { dest: MultiLocation { parents: 1, interior: Here }, .. } |
+			TransferReserveAsset { dest: MultiLocation { parents: 1, interior: Here }, .. } => {
+				Err(()) // Deny
+			},
+			// An unexpected reserve transfer has arrived from the Relay Chain. Generally,
+			// `IsReserve` should not allow this, but we just log it here.
+			ReserveAssetDeposited { .. }
+				if matches!(origin, MultiLocation { parents: 1, interior: Here }) =>
+			{
+				log::warn!(
+					target: "xcm::barrier",
+					"Unexpected ReserveAssetDeposited from the Relay Chain",
+				);
+				Ok(ControlFlow::Continue)
+			},
+			_ => Ok(ControlFlow::Continue),
+		})?;
 
-		// An unexpected reserve transfer has arrived from the Relay Chain. Generally, `IsReserve`
-		// should not allow this, but we just log it here.
-		if matches!(origin, MultiLocation { parents: 1, interior: Here }) &&
-			message.iter().any(|inst| matches!(inst, ReserveAssetDeposited { .. }))
-		{
-			log::warn!(
-				target: "xcm::barriers",
-				"Unexpected ReserveAssetDeposited from the Relay Chain",
-			);
-		}
 		// Permit everything else
 		Ok(())
 	}

--- a/parachain-template/runtime/src/xcm_config.rs
+++ b/parachain-template/runtime/src/xcm_config.rs
@@ -122,7 +122,7 @@ impl ShouldExecute for DenyReserveTransferToRelayChain {
 		_max_weight: Weight,
 		_weight_credit: &mut Weight,
 	) -> Result<(), ()> {
-		message.matcher().match_next_inst_while(true, |inst| match inst {
+		message.matcher().match_next_inst_while(|_| true, |inst| match inst {
 			InitiateReserveWithdraw {
 				reserve: MultiLocation { parents: 1, interior: Here },
 				..

--- a/parachain-template/runtime/src/xcm_config.rs
+++ b/parachain-template/runtime/src/xcm_config.rs
@@ -140,9 +140,9 @@ impl ShouldExecute for DenyReserveTransferToRelayChain {
 					target: "xcm::barrier",
 					"Unexpected ReserveAssetDeposited from the Relay Chain",
 				);
-				Ok(ControlFlow::Continue)
+				Ok(ControlFlow::Continue(()))
 			},
-			_ => Ok(ControlFlow::Continue),
+			_ => Ok(ControlFlow::Continue(())),
 		})?;
 
 		// Permit everything else

--- a/parachain-template/runtime/src/xcm_config.rs
+++ b/parachain-template/runtime/src/xcm_config.rs
@@ -2,7 +2,7 @@ use super::{
 	AccountId, AllPalletsWithSystem, Balances, ParachainInfo, ParachainSystem, PolkadotXcm,
 	Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin, WeightToFee, XcmpQueue,
 };
-use core::marker::PhantomData;
+use core::{marker::PhantomData, ops::ControlFlow};
 use frame_support::{
 	log, match_types, parameter_types,
 	traits::{ConstU32, Everything, Nothing},

--- a/parachain-template/runtime/src/xcm_config.rs
+++ b/parachain-template/runtime/src/xcm_config.rs
@@ -122,28 +122,35 @@ impl ShouldExecute for DenyReserveTransferToRelayChain {
 		_max_weight: Weight,
 		_weight_credit: &mut Weight,
 	) -> Result<(), ()> {
-		message.matcher().match_next_inst_while(|_| true, |inst| match inst {
-			InitiateReserveWithdraw {
-				reserve: MultiLocation { parents: 1, interior: Here },
-				..
-			} |
-			DepositReserveAsset { dest: MultiLocation { parents: 1, interior: Here }, .. } |
-			TransferReserveAsset { dest: MultiLocation { parents: 1, interior: Here }, .. } => {
-				Err(()) // Deny
+		message.matcher().match_next_inst_while(
+			|_| true,
+			|inst| match inst {
+				InitiateReserveWithdraw {
+					reserve: MultiLocation { parents: 1, interior: Here },
+					..
+				} |
+				DepositReserveAsset {
+					dest: MultiLocation { parents: 1, interior: Here }, ..
+				} |
+				TransferReserveAsset {
+					dest: MultiLocation { parents: 1, interior: Here }, ..
+				} => {
+					Err(()) // Deny
+				},
+				// An unexpected reserve transfer has arrived from the Relay Chain. Generally,
+				// `IsReserve` should not allow this, but we just log it here.
+				ReserveAssetDeposited { .. }
+					if matches!(origin, MultiLocation { parents: 1, interior: Here }) =>
+				{
+					log::warn!(
+						target: "xcm::barrier",
+						"Unexpected ReserveAssetDeposited from the Relay Chain",
+					);
+					Ok(ControlFlow::Continue(()))
+				},
+				_ => Ok(ControlFlow::Continue(())),
 			},
-			// An unexpected reserve transfer has arrived from the Relay Chain. Generally,
-			// `IsReserve` should not allow this, but we just log it here.
-			ReserveAssetDeposited { .. }
-				if matches!(origin, MultiLocation { parents: 1, interior: Here }) =>
-			{
-				log::warn!(
-					target: "xcm::barrier",
-					"Unexpected ReserveAssetDeposited from the Relay Chain",
-				);
-				Ok(ControlFlow::Continue(()))
-			},
-			_ => Ok(ControlFlow::Continue(())),
-		})?;
+		)?;
 
 		// Permit everything else
 		Ok(())

--- a/parachains/common/src/xcm_config.rs
+++ b/parachains/common/src/xcm_config.rs
@@ -1,5 +1,5 @@
 use crate::impls::AccountIdOf;
-use core::marker::PhantomData;
+use core::{marker::PhantomData, ops::ControlFlow};
 use frame_support::{
 	log,
 	traits::{fungibles::Inspect, tokens::BalanceConversion, ContainsPair},

--- a/parachains/common/src/xcm_config.rs
+++ b/parachains/common/src/xcm_config.rs
@@ -42,7 +42,7 @@ impl ShouldExecute for DenyReserveTransferToRelayChain {
 		_max_weight: Weight,
 		_weight_credit: &mut Weight,
 	) -> Result<(), ()> {
-		message.matcher().match_next_inst_while(true, |inst| match inst {
+		message.matcher().match_next_inst_while(|_| true, |inst| match inst {
 			InitiateReserveWithdraw {
 				reserve: MultiLocation { parents: 1, interior: Here },
 				..

--- a/parachains/common/src/xcm_config.rs
+++ b/parachains/common/src/xcm_config.rs
@@ -61,10 +61,10 @@ impl ShouldExecute for DenyReserveTransferToRelayChain {
 					target: "xcm::barrier",
 					"Unexpected ReserveAssetDeposited from the Relay Chain",
 				);
-				Ok(ControlFlow::Continue)
+				Ok(ControlFlow::Continue(()))
 			},
 
-			_ => Ok(ControlFlow::Continue),
+			_ => Ok(ControlFlow::Continue(())),
 		})?;
 
 		// Permit everything else

--- a/parachains/common/src/xcm_config.rs
+++ b/parachains/common/src/xcm_config.rs
@@ -6,7 +6,7 @@ use frame_support::{
 	weights::{Weight, WeightToFee, WeightToFeePolynomial},
 };
 use sp_runtime::traits::Get;
-use xcm::latest::prelude::*;
+use xcm::{latest::prelude::*, CreateMatcher, MatchXcm};
 use xcm_executor::traits::ShouldExecute;
 
 //TODO: move DenyThenTry to polkadot's xcm module.
@@ -42,32 +42,31 @@ impl ShouldExecute for DenyReserveTransferToRelayChain {
 		_max_weight: Weight,
 		_weight_credit: &mut Weight,
 	) -> Result<(), ()> {
-		if message.iter().any(|inst| {
-			matches!(
-				inst,
-				InitiateReserveWithdraw {
-					reserve: MultiLocation { parents: 1, interior: Here },
-					..
-				} | DepositReserveAsset { dest: MultiLocation { parents: 1, interior: Here }, .. } |
-					TransferReserveAsset {
-						dest: MultiLocation { parents: 1, interior: Here },
-						..
-					}
-			)
-		}) {
-			return Err(()) // Deny
-		}
+		message.matcher().match_next_inst_while(true, |inst| match inst {
+			InitiateReserveWithdraw {
+				reserve: MultiLocation { parents: 1, interior: Here },
+				..
+			} |
+			DepositReserveAsset { dest: MultiLocation { parents: 1, interior: Here }, .. } |
+			TransferReserveAsset { dest: MultiLocation { parents: 1, interior: Here }, .. } => {
+				Err(()) // Deny
+			},
 
-		// An unexpected reserve transfer has arrived from the Relay Chain. Generally, `IsReserve`
-		// should not allow this, but we just log it here.
-		if matches!(origin, MultiLocation { parents: 1, interior: Here }) &&
-			message.iter().any(|inst| matches!(inst, ReserveAssetDeposited { .. }))
-		{
-			log::warn!(
-				target: "xcm::barriers",
-				"Unexpected ReserveAssetDeposited from the Relay Chain",
-			);
-		}
+			// An unexpected reserve transfer has arrived from the Relay Chain. Generally,
+			// `IsReserve` should not allow this, but we just log it here.
+			ReserveAssetDeposited { .. }
+				if matches!(origin, MultiLocation { parents: 1, interior: Here }) =>
+			{
+				log::warn!(
+					target: "xcm::barrier",
+					"Unexpected ReserveAssetDeposited from the Relay Chain",
+				);
+				Ok(ControlFlow::Continue)
+			},
+
+			_ => Ok(ControlFlow::Continue),
+		})?;
+
 		// Permit everything else
 		Ok(())
 	}


### PR DESCRIPTION
This is a follow up to paritytech/polkadot#6756 to switch all barriers into using the matcher API for writing its conditionals.