### PR TITLE
Improve build times by disabling wasm-builder in `no_std`

### DIFF
--- a/parachain-template/runtime/Cargo.toml
+++ b/parachain-template/runtime/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [build-dependencies]
-substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "master" }
+substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "master", optional = true }
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
@@ -121,6 +121,7 @@ std = [
 	"xcm-builder/std",
 	"xcm-executor/std",
 	"xcm/std",
+	"substrate-wasm-builder",
 ]
 
 runtime-benchmarks = [

--- a/parachain-template/runtime/build.rs
+++ b/parachain-template/runtime/build.rs
@@ -1,9 +1,13 @@
-use substrate_wasm_builder::WasmBuilder;
-
+#[cfg(feature = "std")]
 fn main() {
-	WasmBuilder::new()
+	substrate_wasm_builder::WasmBuilder::new()
 		.with_current_project()
 		.export_heap_base()
 		.import_memory()
 		.build()
 }
+
+/// The wasm builder is deactivated when compiling
+/// this crate for wasm to speed up the compilation.
+#[cfg(not(feature = "std"))]
+fn main() {}

--- a/parachains/runtimes/assets/statemine/Cargo.toml
+++ b/parachains/runtimes/assets/statemine/Cargo.toml
@@ -76,7 +76,7 @@ assets-common = { path = "../common", default-features = false }
 asset-test-utils = { path = "../test-utils"}
 
 [build-dependencies]
-substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "master" }
+substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "master", optional = true }
 
 [features]
 default = [ "std" ]
@@ -188,4 +188,5 @@ std = [
 	"parachain-info/std",
 	"parachains-common/std",
 	"assets-common/std",
+	"substrate-wasm-builder",
 ]

--- a/parachains/runtimes/assets/statemine/build.rs
+++ b/parachains/runtimes/assets/statemine/build.rs
@@ -1,9 +1,26 @@
-use substrate_wasm_builder::WasmBuilder;
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(feature = "std")]
 fn main() {
-	WasmBuilder::new()
+	substrate_wasm_builder::WasmBuilder::new()
 		.with_current_project()
 		.export_heap_base()
 		.import_memory()
 		.build()
 }
+
+#[cfg(not(feature = "std"))]
+fn main() {}

--- a/parachains/runtimes/assets/statemint/Cargo.toml
+++ b/parachains/runtimes/assets/statemint/Cargo.toml
@@ -76,7 +76,7 @@ hex-literal = "0.3.4"
 asset-test-utils = { path = "../test-utils"}
 
 [build-dependencies]
-substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "master" }
+substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "master", optional = true }
 
 [features]
 default = [ "std" ]
@@ -178,4 +178,5 @@ std = [
 	"parachain-info/std",
 	"parachains-common/std",
 	"assets-common/std",
+	"substrate-wasm-builder",
 ]

--- a/parachains/runtimes/assets/statemint/build.rs
+++ b/parachains/runtimes/assets/statemint/build.rs
@@ -1,9 +1,26 @@
-use substrate_wasm_builder::WasmBuilder;
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(feature = "std")]
 fn main() {
-	WasmBuilder::new()
+	substrate_wasm_builder::WasmBuilder::new()
 		.with_current_project()
 		.export_heap_base()
 		.import_memory()
 		.build()
 }
+
+#[cfg(not(feature = "std"))]
+fn main() {}

--- a/parachains/runtimes/assets/westmint/Cargo.toml
+++ b/parachains/runtimes/assets/westmint/Cargo.toml
@@ -78,7 +78,7 @@ hex-literal = "0.3.4"
 asset-test-utils = { path = "../test-utils"}
 
 [build-dependencies]
-substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "master" }
+substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "master", optional = true }
 
 [features]
 default = [ "std" ]
@@ -184,4 +184,5 @@ std = [
 	"parachain-info/std",
 	"parachains-common/std",
 	"assets-common/std",
+	"substrate-wasm-builder",
 ]

--- a/parachains/runtimes/assets/westmint/build.rs
+++ b/parachains/runtimes/assets/westmint/build.rs
@@ -1,9 +1,26 @@
-use substrate_wasm_builder::WasmBuilder;
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(feature = "std")]
 fn main() {
-	WasmBuilder::new()
+	substrate_wasm_builder::WasmBuilder::new()
 		.with_current_project()
 		.export_heap_base()
 		.import_memory()
 		.build()
 }
+
+#[cfg(not(feature = "std"))]
+fn main() {}

--- a/parachains/runtimes/bridge-hubs/bridge-hub-kusama/Cargo.toml
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-kusama/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 description = "Kusama's BridgeHub parachain runtime"
 
 [build-dependencies]
-substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "master" }
+substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "master", optional = true }
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
@@ -126,6 +126,7 @@ std = [
 	"xcm-builder/std",
 	"xcm-executor/std",
 	"xcm/std",
+	"substrate-wasm-builder",
 ]
 
 runtime-benchmarks = [

--- a/parachains/runtimes/bridge-hubs/bridge-hub-kusama/build.rs
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-kusama/build.rs
@@ -1,9 +1,26 @@
-use substrate_wasm_builder::WasmBuilder;
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(feature = "std")]
 fn main() {
-	WasmBuilder::new()
+	substrate_wasm_builder::WasmBuilder::new()
 		.with_current_project()
 		.export_heap_base()
 		.import_memory()
 		.build()
 }
+
+#[cfg(not(feature = "std"))]
+fn main() {}

--- a/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/Cargo.toml
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 description = "Polkadot's BridgeHub parachain runtime"
 
 [build-dependencies]
-substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "master" }
+substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "master", optional = true }
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
@@ -126,6 +126,7 @@ std = [
 	"xcm-builder/std",
 	"xcm-executor/std",
 	"xcm/std",
+	"substrate-wasm-builder",
 ]
 
 runtime-benchmarks = [

--- a/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/build.rs
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/build.rs
@@ -1,9 +1,26 @@
-use substrate_wasm_builder::WasmBuilder;
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(feature = "std")]
 fn main() {
-	WasmBuilder::new()
+	substrate_wasm_builder::WasmBuilder::new()
 		.with_current_project()
 		.export_heap_base()
 		.import_memory()
 		.build()
 }
+
+#[cfg(not(feature = "std"))]
+fn main() {}

--- a/parachains/runtimes/bridge-hubs/bridge-hub-rococo/Cargo.toml
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-rococo/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 description = "Rococo's BridgeHub  parachain runtime"
 
 [build-dependencies]
-substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "master" }
+substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "master", optional = true }
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
@@ -126,6 +126,7 @@ std = [
 	"xcm-builder/std",
 	"xcm-executor/std",
 	"xcm/std",
+	"substrate-wasm-builder",
 ]
 
 runtime-benchmarks = [

--- a/parachains/runtimes/bridge-hubs/bridge-hub-rococo/build.rs
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-rococo/build.rs
@@ -1,9 +1,26 @@
-use substrate_wasm_builder::WasmBuilder;
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(feature = "std")]
 fn main() {
-	WasmBuilder::new()
+	substrate_wasm_builder::WasmBuilder::new()
 		.with_current_project()
 		.export_heap_base()
 		.import_memory()
 		.build()
 }
+
+#[cfg(not(feature = "std"))]
+fn main() {}

--- a/parachains/runtimes/collectives/collectives-polkadot/Cargo.toml
+++ b/parachains/runtimes/collectives/collectives-polkadot/Cargo.toml
@@ -72,7 +72,7 @@ parachains-common = { path = "../../../common", default-features = false }
 hex-literal = "0.3.4"
 
 [build-dependencies]
-substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "master" }
+substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "master", optional = true }
 
 [features]
 default = [ "std" ]
@@ -170,4 +170,5 @@ std = [
 	"pallet-collator-selection/std",
 	"parachain-info/std",
 	"parachains-common/std",
+	"substrate-wasm-builder",
 ]

--- a/parachains/runtimes/collectives/collectives-polkadot/build.rs
+++ b/parachains/runtimes/collectives/collectives-polkadot/build.rs
@@ -1,9 +1,26 @@
-use substrate_wasm_builder::WasmBuilder;
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(feature = "std")]
 fn main() {
-	WasmBuilder::new()
+	substrate_wasm_builder::WasmBuilder::new()
 		.with_current_project()
 		.export_heap_base()
 		.import_memory()
 		.build()
 }
+
+#[cfg(not(feature = "std"))]
+fn main() {}

--- a/parachains/runtimes/contracts/contracts-rococo/Cargo.toml
+++ b/parachains/runtimes/contracts/contracts-rococo/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [build-dependencies]
-substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "master" }
+substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "master", optional = true }
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
@@ -129,6 +129,7 @@ std = [
 	"cumulus-primitives-core/std",
 	"cumulus-primitives-timestamp/std",
 	"cumulus-primitives-utility/std",
+	"substrate-wasm-builder",
 ]
 
 runtime-benchmarks = [

--- a/parachains/runtimes/contracts/contracts-rococo/build.rs
+++ b/parachains/runtimes/contracts/contracts-rococo/build.rs
@@ -1,9 +1,26 @@
-use substrate_wasm_builder::WasmBuilder;
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(feature = "std")]
 fn main() {
-	WasmBuilder::new()
+	substrate_wasm_builder::WasmBuilder::new()
 		.with_current_project()
 		.export_heap_base()
 		.import_memory()
 		.build()
 }
+
+#[cfg(not(feature = "std"))]
+fn main() {}

--- a/parachains/runtimes/starters/seedling/Cargo.toml
+++ b/parachains/runtimes/starters/seedling/Cargo.toml
@@ -33,7 +33,7 @@ parachains-common = { path = "../../../common", default-features = false }
 cumulus-primitives-core = { path = "../../../../primitives/core", default-features = false }
 
 [build-dependencies]
-substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "master" }
+substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "master", optional = true }
 
 [features]
 default = [ "std" ]
@@ -60,4 +60,5 @@ std = [
 	"cumulus-primitives-core/std",
 	"parachain-info/std",
 	"parachains-common/std",
+	"substrate-wasm-builder",
 ]

--- a/parachains/runtimes/starters/seedling/build.rs
+++ b/parachains/runtimes/starters/seedling/build.rs
@@ -1,25 +1,26 @@
-// Copyright 2019-2021 Parity Technologies (UK) Ltd.
-// This file is part of Cumulus.
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
 
-// Substrate is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-// Substrate is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-
-// You should have received a copy of the GNU General Public License
-// along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
-
-use substrate_wasm_builder::WasmBuilder;
-
+#[cfg(feature = "std")]
 fn main() {
-	WasmBuilder::new()
+	substrate_wasm_builder::WasmBuilder::new()
 		.with_current_project()
 		.export_heap_base()
 		.import_memory()
 		.build()
 }
+
+#[cfg(not(feature = "std"))]
+fn main() {}

--- a/parachains/runtimes/starters/shell/Cargo.toml
+++ b/parachains/runtimes/starters/shell/Cargo.toml
@@ -37,7 +37,7 @@ parachain-info = { path = "../../../pallets/parachain-info", default-features = 
 parachains-common = { path = "../../../common", default-features = false }
 
 [build-dependencies]
-substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "master" }
+substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "master", optional = true }
 
 [features]
 default = [ "std" ]
@@ -65,6 +65,7 @@ std = [
 	"cumulus-primitives-core/std",
 	"parachain-info/std",
 	"parachains-common/std",
+	"substrate-wasm-builder",
 ]
 try-runtime = [
 	"frame-executive/try-runtime",

--- a/parachains/runtimes/starters/shell/build.rs
+++ b/parachains/runtimes/starters/shell/build.rs
@@ -14,12 +14,14 @@
 // You should have received a copy of the GNU General Public License
 // along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
 
-use substrate_wasm_builder::WasmBuilder;
-
+#[cfg(feature = "std")]
 fn main() {
-	WasmBuilder::new()
+	substrate_wasm_builder::WasmBuilder::new()
 		.with_current_project()
 		.export_heap_base()
 		.import_memory()
 		.build()
 }
+
+#[cfg(not(feature = "std"))]
+fn main() {}

--- a/parachains/runtimes/testing/penpal/Cargo.toml
+++ b/parachains/runtimes/testing/penpal/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [build-dependencies]
-substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "master" }
+substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "master", optional = true }
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = ["derive"] }
@@ -124,6 +124,7 @@ std = [
 	"xcm-builder/std",
 	"xcm-executor/std",
 	"xcm/std",
+	"substrate-wasm-builder",
 ]
 
 runtime-benchmarks = [

--- a/parachains/runtimes/testing/penpal/build.rs
+++ b/parachains/runtimes/testing/penpal/build.rs
@@ -14,12 +14,14 @@
 // You should have received a copy of the GNU General Public License
 // along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
 
-use substrate_wasm_builder::WasmBuilder;
-
+#[cfg(feature = "std")]
 fn main() {
-	WasmBuilder::new()
+	substrate_wasm_builder::WasmBuilder::new()
 		.with_current_project()
 		.export_heap_base()
 		.import_memory()
 		.build()
 }
+
+#[cfg(not(feature = "std"))]
+fn main() {}

--- a/parachains/runtimes/testing/rococo-parachain/Cargo.toml
+++ b/parachains/runtimes/testing/rococo-parachain/Cargo.toml
@@ -55,7 +55,7 @@ parachains-common = { path = "../../../common", default-features = false }
 parachain-info = { path = "../../../pallets/parachain-info", default-features = false }
 
 [build-dependencies]
-substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "master" }
+substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "master", optional = true }
 
 [features]
 default = [ "std" ]
@@ -99,6 +99,7 @@ std = [
 	"cumulus-primitives-utility/std",
 	"parachain-info/std",
 	"parachains-common/std",
+	"substrate-wasm-builder",
 ]
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",

--- a/parachains/runtimes/testing/rococo-parachain/build.rs
+++ b/parachains/runtimes/testing/rococo-parachain/build.rs
@@ -1,25 +1,26 @@
-// Copyright 2019-2021 Parity Technologies (UK) Ltd.
-// This file is part of Cumulus.
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
 
-// Substrate is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-// Substrate is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-
-// You should have received a copy of the GNU General Public License
-// along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
-
-use substrate_wasm_builder::WasmBuilder;
-
+#[cfg(feature = "std")]
 fn main() {
-	WasmBuilder::new()
+	substrate_wasm_builder::WasmBuilder::new()
 		.with_current_project()
 		.export_heap_base()
 		.import_memory()
 		.build()
 }
+
+#[cfg(not(feature = "std"))]
+fn main() {}

--- a/test/runtime/Cargo.toml
+++ b/test/runtime/Cargo.toml
@@ -35,7 +35,7 @@ cumulus-primitives-core = { path = "../../primitives/core", default-features = f
 cumulus-primitives-timestamp = { path = "../../primitives/timestamp", default-features = false }
 
 [build-dependencies]
-substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "master" }
+substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "master" , optional = true }
 
 [features]
 default = [ "std" ]
@@ -64,5 +64,6 @@ std = [
 	"cumulus-pallet-parachain-system/std",
 	"cumulus-primitives-core/std",
 	"cumulus-primitives-timestamp/std",
+	"substrate-wasm-builder",
 ]
 increment-spec-version = []

--- a/test/runtime/build.rs
+++ b/test/runtime/build.rs
@@ -14,9 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
 
-use substrate_wasm_builder::WasmBuilder;
-
+#[cfg(feature = "std")]
 fn main() {
+	use substrate_wasm_builder::WasmBuilder;
+
 	WasmBuilder::new()
 		.with_current_project()
 		.export_heap_base()
@@ -30,3 +31,6 @@ fn main() {
 		.set_file_name("wasm_binary_spec_version_incremented.rs")
 		.build();
 }
+
+#[cfg(not(feature = "std"))]
+fn main() {}


### PR DESCRIPTION
There is no need to compile wasm-builder in `no_std` as we skip the compilation of the crate any way. So, we can also directly disable wasm-builder as dependency in `no_std` to improve build times.