### PR TITLE
Fixed npm install call

### DIFF
--- a/scripts/bridges_rococo_wococo.sh
+++ b/scripts/bridges_rococo_wococo.sh
@@ -51,7 +51,6 @@ function ensure_polkadot_js_api() {
         pushd ./scripts/generate_hex_encoded_call
         npm install
         popd
-        exit 1
     fi
 }
 
@@ -65,11 +64,14 @@ function generate_hex_encoded_call_data() {
     echo "Input params: $@"
 
     node ./scripts/generate_hex_encoded_call "$type" "$endpoint" "$output" "$@"
+    local retVal=$?
 
     if [ $type != "check" ]; then
         local hex_encoded_data=$(cat $output)
         echo "Generated hex-encoded bytes to file '$output': $hex_encoded_data"
     fi
+
+    return $retVal
 }
 
 STATEMINE_ACCOUNT_SEED_FOR_LOCAL="//Alice"


### PR DESCRIPTION
Related to https://github.com/paritytech/parity-bridges-common/issues/1840

Couple of issues:
- `node`' exit code is overwritten and `generate_hex_encoded_call_data` always returns zero;
- after fixing it ^^^, we're doing `npm install` and then `exit 1`.

Example docker that uses updated script:
```dockerfile
FROM docker.io/paritytech/polkadotjs-cli:latest

RUN mkdir -p /data/scripts/generate_hex_encoded_call
RUN wget -O /data/scripts/generate_hex_encoded_call/index.js https://raw.githubusercontent.com/paritytech/cumulus/f0657dab3439f2b315493b8a044e957618645cc0/scripts/generate_hex_encoded_call/index.js
RUN wget -O /data/scripts/generate_hex_encoded_call/package.json https://raw.githubusercontent.com/paritytech/cumulus/f0657dab3439f2b315493b8a044e957618645cc0/scripts/generate_hex_encoded_call/package.json
RUN wget -O /data/scripts/generate_hex_encoded_call/package-lock.json https://raw.githubusercontent.com/paritytech/cumulus/f0657dab3439f2b315493b8a044e957618645cc0/scripts/generate_hex_encoded_call/package-lock.json
RUN wget -O /data/bridges_rococo_wococo.sh https://raw.githubusercontent.com/paritytech/cumulus/a72a27194eef2caa020f3f04114ab60518ddbb0e/scripts/bridges_rococo_wococo.sh
RUN chmod +x /data/bridges_rococo_wococo.sh

WORKDIR /data

ENTRYPOINT ["/data/bridges_rococo_wococo.sh", "send-remark-rococo"]
```