### PR TITLE
Enabled `polkadot-parachain` build for `runtime-benchmarks`

### DIFF
--- a/polkadot-parachain/Cargo.toml
+++ b/polkadot-parachain/Cargo.toml
@@ -107,6 +107,14 @@ runtime-benchmarks = [
 	"statemint-runtime/runtime-benchmarks",
 	"statemine-runtime/runtime-benchmarks",
 	"westmint-runtime/runtime-benchmarks",
+	"bridge-hub-rococo-runtime/runtime-benchmarks",
+	"bridge-hub-kusama-runtime/runtime-benchmarks",
+	"bridge-hub-polkadot-runtime/runtime-benchmarks",
+	"collectives-polkadot-runtime/runtime-benchmarks",
+	"rococo-parachain-runtime/runtime-benchmarks",
+	"contracts-rococo-runtime/runtime-benchmarks",
+	"contracts-rococo-runtime/runtime-benchmarks",
+	"penpal-runtime/runtime-benchmarks",
 ]
 try-runtime = [
 	"statemint-runtime/try-runtime",


### PR DESCRIPTION
e.g. `cargo build --locked --profile=production -p polkadot-parachain-bin --features runtime-benchmarks` is not working without this
