### PR TITLE
Increase xcm fees when busy

### DIFF
--- a/pallets/xcmp-queue/src/lib.rs
+++ b/pallets/xcmp-queue/src/lib.rs
@@ -53,7 +53,7 @@ use rand_chacha::{
 	ChaChaRng,
 };
 use scale_info::TypeInfo;
-use sp_runtime::RuntimeDebug;
+use sp_runtime::{FixedPointNumber, FixedU128, RuntimeDebug, Saturating};
 use sp_std::{convert::TryFrom, prelude::*};
 use xcm::{latest::prelude::*, VersionedXcm, WrapVersion, MAX_XCM_DECODE_DEPTH};
 use xcm_executor::traits::ConvertOrigin;
@@ -71,6 +71,8 @@ const DEFAULT_POV_SIZE: u64 = 64 * 1024; // 64 KB
 const MAX_MESSAGES_PER_BLOCK: u8 = 10;
 // Maximum amount of messages that can exist in the overweight queue at any given time.
 const MAX_OVERWEIGHT_MESSAGES: u32 = 1000;
+
+pub const MULTIPLICATIVE_FEE_FACTOR_XCMP: FixedU128 = FixedU128::from_rational(101, 100); // 1.01
 
 #[frame_support::pallet]
 pub mod pallet {
@@ -374,6 +376,16 @@ pub mod pallet {
 	/// Whether or not the XCMP queue is suspended from executing incoming XCMs or not.
 	#[pallet::storage]
 	pub(super) type QueueSuspended<T: Config> = StorageValue<_, bool, ValueQuery>;
+
+	frame_support::parameter_types! {
+		pub InitialFactor: FixedU128 = FixedU128::from_u32(1);
+	}
+
+	/// The number to multiply the base delivery fee by.
+	#[pallet::storage]
+	#[pallet::getter(fn delivery_fee_factor_xcmp)]
+	pub(crate) type DeliveryFeeFactorXCMP<T: Config> =
+		StorageValue<_, FixedU128, ValueQuery, InitialFactor>;
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode, RuntimeDebug, TypeInfo)]
@@ -516,7 +528,7 @@ impl<T: Config> Pallet<T> {
 		let max_message_size =
 			T::ChannelInfo::get_channel_max(recipient).ok_or(MessageSendError::NoChannel)?;
 		if data.len() > max_message_size {
-			return Err(MessageSendError::TooBig)
+			Self::increment_xcmp_fee_factor();
 		}
 
 		let mut s = <OutboundXcmpStatus<T>>::get();
@@ -943,6 +955,28 @@ impl<T: Config> Pallet<T> {
 			}
 		});
 	}
+
+	/// Raise the delivery fee factor by a multiplicative factor and stores the resulting value.
+	///
+	/// Returns the new delivery fee factor after the increment.
+	pub(crate) fn increment_xcmp_fee_factor() -> FixedU128 {
+		<DeliveryFeeFactorXCMP<T>>::mutate(|f| {
+			*f = f.saturating_mul(MULTIPLICATIVE_FEE_FACTOR_XCMP);
+			*f
+		})
+	}
+
+	/// Reduce the delivery fee factor by a multiplicative factor and stores the resulting value.
+	///
+	/// Does not reduce the fee factor below the initial value, which is currently set as 1.
+	///
+	/// Returns the new delivery fee factor after the decrement.
+	pub(crate) fn decrement_xcmp_fee_factor() -> FixedU128 {
+		<DeliveryFeeFactorXCMP<T>>::mutate(|f| {
+			*f = InitialFactor::get().max(*f / MULTIPLICATIVE_FEE_FACTOR_XCMP);
+			*f
+		})
+	}
 }
 
 impl<T: Config> XcmpMessageHandler for Pallet<T> {
@@ -1129,6 +1163,9 @@ impl<T: Config> XcmpMessageSource for Pallet<T> {
 
 		<OutboundXcmpStatus<T>>::put(statuses);
 
+		if !result.is_empty() {
+			Self::decrement_xcmp_fee_factor();
+		}
 		result
 	}
 }
@@ -1188,5 +1225,23 @@ impl<T: Config> SendXcm for Pallet<T> {
 			},
 			Err(e) => Err(SendError::Transport(<&'static str>::from(e))),
 		}
+	}
+}
+
+/// Implementation of `PriceForSiblingDelivery` which returns an exponentially increasing price.
+/// The `A` type parameter is used to denote the asset ID that will be used for paying the delivery
+/// fee.
+///
+/// The formula for the fee is based on the sum of a base fee plus a message length fee, multiplied
+/// by a specified factor. In mathematical form, it is `F * (B + msg_len * M)`.
+pub struct SiblingExponentialPrice<A, B, M, F>(sp_std::marker::PhantomData<(A, B, M, F)>);
+impl<A: Get<AssetId>, B: Get<u128>, M: Get<u128>, F: Get<FixedU128>> PriceForSiblingDelivery
+	for SiblingExponentialPrice<A, B, M, F>
+{
+	fn price_for_sibling_delivery(_para_id: ParaId, msg: &Xcm<()>) -> MultiAssets {
+		let msg_fee = (msg.encoded_size() as u128).saturating_mul(M::get());
+		let fee_sum = B::get().saturating_add(msg_fee);
+		let amount = F::get().saturating_mul_int(fee_sum);
+		(A::get(), amount).into()
 	}
 }

--- a/parachains/runtimes/assets/statemine/src/lib.rs
+++ b/parachains/runtimes/assets/statemine/src/lib.rs
@@ -28,7 +28,9 @@ pub mod constants;
 mod weights;
 pub mod xcm_config;
 
+use crate::xcm_config::{BaseDeliveryFee, FeeAssetId, XcmpFeeFactor};
 use cumulus_pallet_parachain_system::RelayNumberStrictlyIncreases;
+use cumulus_pallet_xcmp_queue::SiblingExponentialPrice;
 use sp_api::impl_runtime_apis;
 use sp_core::{crypto::KeyTypeId, OpaqueMetadata};
 use sp_runtime::{
@@ -475,7 +477,8 @@ impl cumulus_pallet_xcmp_queue::Config for Runtime {
 	>;
 	type ControllerOriginConverter = xcm_config::XcmOriginToTransactDispatchOrigin;
 	type WeightInfo = weights::cumulus_pallet_xcmp_queue::WeightInfo<Runtime>;
-	type PriceForSiblingDelivery = ();
+	type PriceForSiblingDelivery =
+		SiblingExponentialPrice<FeeAssetId, BaseDeliveryFee, TransactionByteFee, XcmpFeeFactor>;
 }
 
 impl cumulus_pallet_dmp_queue::Config for Runtime {

--- a/parachains/runtimes/assets/statemine/src/xcm_config.rs
+++ b/parachains/runtimes/assets/statemine/src/xcm_config.rs
@@ -18,6 +18,7 @@ use super::{
 	ParachainSystem, PolkadotXcm, Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin,
 	TrustBackedAssetsInstance, WeightToFee, XcmpQueue,
 };
+use crate::{TransactionByteFee, CENTS};
 use frame_support::{
 	match_types, parameter_types,
 	traits::{ConstU32, Contains, Everything, Nothing, PalletInfoAccess},
@@ -27,10 +28,11 @@ use parachains_common::{
 	impls::ToStakingPot,
 	xcm_config::{
 		AssetFeeAsExistentialDepositMultiplier, DenyReserveTransferToRelayChain, DenyThenTry,
+		ExponentialPrice,
 	},
 };
 use polkadot_parachain::primitives::Sibling;
-use sp_runtime::traits::ConvertInto;
+use sp_runtime::{traits::ConvertInto, FixedU128};
 use xcm::latest::prelude::*;
 use xcm_builder::{
 	AccountId32Aliases, AllowExplicitUnpaidExecutionFrom, AllowKnownQueryResponses,
@@ -129,6 +131,19 @@ pub type XcmOriginToTransactDispatchOrigin = (
 
 parameter_types! {
 	pub const MaxInstructions: u32 = 100;
+
+	/// The asset ID for the asset that we use to pay for message delivery fees.
+	pub FeeAssetId: AssetId = Concrete(Here.into());
+
+	/// The base fee for the message delivery fees.
+	pub const BaseDeliveryFee: u128 = CENTS.saturating_mul(3);
+
+	/// The factor to multiply by for the message delivery fees.
+	pub UmpFeeFactor: FixedU128 = ParachainSystem::delivery_fee_factor_ump();
+
+	/// The factor to multiply by for the message delivery fees.
+	pub XcmpFeeFactor: FixedU128 = XcmpQueue::delivery_fee_factor_xcmp();
+
 	pub const MaxAssetsIntoHolding: u32 = 64;
 	pub XcmAssetFeesReceiver: Option<AccountId> = Authorship::author();
 }
@@ -326,7 +341,11 @@ pub type LocalOriginToLocation = SignedToAccountId32<RuntimeOrigin, AccountId, R
 /// queues.
 pub type XcmRouter = (
 	// Two routers - use UMP to communicate with the relay chain:
-	cumulus_primitives_utility::ParentAsUmp<ParachainSystem, PolkadotXcm, ()>,
+	cumulus_primitives_utility::ParentAsUmp<
+		ParachainSystem,
+		PolkadotXcm,
+		ExponentialPrice<FeeAssetId, BaseDeliveryFee, TransactionByteFee, UmpFeeFactor>,
+	>,
 	// ..and XCMP to communicate with the sibling chains.
 	XcmpQueue,
 );

--- a/primitives/utility/src/lib.rs
+++ b/primitives/utility/src/lib.rs
@@ -54,10 +54,6 @@ impl<T: Get<MultiAssets>> PriceForParentDelivery for ConstantPrice<T> {
 /// Xcm router which recognises the `Parent` destination and handles it by sending the message into
 /// the given UMP `UpwardMessageSender` implementation. Thus this essentially adapts an
 /// `UpwardMessageSender` trait impl into a `SendXcm` trait impl.
-///
-/// NOTE: This is a pretty dumb "just send it" router; we will probably want to introduce queuing
-/// to UMP eventually and when we do, the pallet which implements the queuing will be responsible
-/// for the `SendXcm` implementation.
 pub struct ParentAsUmp<T, W, P>(PhantomData<(T, W, P)>);
 impl<T, W, P> SendXcm for ParentAsUmp<T, W, P>
 where


### PR DESCRIPTION
This is the corollary to https://github.com/paritytech/polkadot/pull/6843 . Xcmp fees upwards and horizontally get exponentially more expensive as the queues increase.