### PR TITLE
FeeManager that puts fees in a central account

### DIFF
--- a/parachains/common/src/lib.rs
+++ b/parachains/common/src/lib.rs
@@ -68,7 +68,10 @@ mod types {
 /// Common constants of parachains.
 mod constants {
 	use super::types::BlockNumber;
-	use frame_support::weights::{constants::WEIGHT_REF_TIME_PER_SECOND, Weight};
+	use frame_support::{
+		weights::{constants::WEIGHT_REF_TIME_PER_SECOND, Weight},
+		PalletId,
+	};
 	use sp_runtime::Perbill;
 	/// This determines the average expected block time that we are targeting. Blocks will be
 	/// produced at a minimum duration defined by `SLOT_DURATION`. `SLOT_DURATION` is picked up by
@@ -96,6 +99,9 @@ mod constants {
 		WEIGHT_REF_TIME_PER_SECOND.saturating_div(2),
 		polkadot_primitives::MAX_POV_SIZE as u64,
 	);
+
+	/// Relay Chain treasury pallet id, used to convert into AccountId
+	pub const RELAY_TREASURY_PALLET_ID: PalletId = PalletId(*b"py/trsry");
 }
 
 /// Opaque types. These are used by the CLI to instantiate machinery that don't need to know

--- a/parachains/runtimes/assets/statemine/src/xcm_config.rs
+++ b/parachains/runtimes/assets/statemine/src/xcm_config.rs
@@ -18,6 +18,7 @@ use super::{
 	ParachainSystem, PolkadotXcm, Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin,
 	TrustBackedAssetsInstance, WeightToFee, XcmpQueue,
 };
+use cumulus_primitives_utility::XcmFeeManagerToAccount;
 use frame_support::{
 	match_types, parameter_types,
 	traits::{ConstU32, Contains, Everything, Nothing, PalletInfoAccess},
@@ -28,9 +29,10 @@ use parachains_common::{
 	xcm_config::{
 		AssetFeeAsExistentialDepositMultiplier, DenyReserveTransferToRelayChain, DenyThenTry,
 	},
+	RELAY_TREASURY_PALLET_ID,
 };
 use polkadot_parachain::primitives::Sibling;
-use sp_runtime::traits::ConvertInto;
+use sp_runtime::traits::{AccountIdConversion, ConvertInto};
 use xcm::latest::prelude::*;
 use xcm_builder::{
 	AccountId32Aliases, AllowExplicitUnpaidExecutionFrom, AllowKnownQueryResponses,
@@ -133,6 +135,7 @@ parameter_types! {
 	pub const MaxInstructions: u32 = 100;
 	pub const MaxAssetsIntoHolding: u32 = 64;
 	pub XcmAssetFeesReceiver: Option<AccountId> = Authorship::author();
+	pub XcmAssetFeesReceiverToTreasury: Option<AccountId> = Some(RELAY_TREASURY_PALLET_ID.into_account_truncating());
 }
 
 match_types! {
@@ -351,7 +354,8 @@ impl xcm_executor::Config for XcmConfig {
 	type MaxAssetsIntoHolding = MaxAssetsIntoHolding;
 	type AssetLocker = ();
 	type AssetExchanger = ();
-	type FeeManager = ();
+	type FeeManager =
+		XcmFeeManagerToAccount<AssetTransactors, AccountId, XcmAssetFeesReceiverToTreasury>;
 	type MessageExporter = ();
 	type UniversalAliases = Nothing;
 	type CallDispatcher = WithOriginFilter<SafeCallFilter>;

--- a/parachains/runtimes/assets/statemint/src/xcm_config.rs
+++ b/parachains/runtimes/assets/statemint/src/xcm_config.rs
@@ -18,6 +18,7 @@ use super::{
 	ParachainSystem, PolkadotXcm, Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin,
 	TrustBackedAssetsInstance, WeightToFee, XcmpQueue,
 };
+use cumulus_primitives_utility::XcmFeeManagerToAccount;
 use frame_support::{
 	match_types, parameter_types,
 	traits::{ConstU32, Contains, Everything, Nothing, PalletInfoAccess},
@@ -28,9 +29,10 @@ use parachains_common::{
 	xcm_config::{
 		AssetFeeAsExistentialDepositMultiplier, DenyReserveTransferToRelayChain, DenyThenTry,
 	},
+	RELAY_TREASURY_PALLET_ID,
 };
 use polkadot_parachain::primitives::Sibling;
-use sp_runtime::traits::ConvertInto;
+use sp_runtime::traits::{AccountIdConversion, ConvertInto};
 use xcm::latest::prelude::*;
 use xcm_builder::{
 	AccountId32Aliases, AllowExplicitUnpaidExecutionFrom, AllowKnownQueryResponses,
@@ -133,6 +135,7 @@ parameter_types! {
 	pub const MaxInstructions: u32 = 100;
 	pub const MaxAssetsIntoHolding: u32 = 64;
 	pub XcmAssetFeesReceiver: Option<AccountId> = Authorship::author();
+	pub XcmAssetFeesReceiverToTreasury: Option<AccountId> = Some(RELAY_TREASURY_PALLET_ID.into_account_truncating());
 }
 
 match_types! {
@@ -317,7 +320,8 @@ impl xcm_executor::Config for XcmConfig {
 	type MaxAssetsIntoHolding = MaxAssetsIntoHolding;
 	type AssetLocker = ();
 	type AssetExchanger = ();
-	type FeeManager = ();
+	type FeeManager =
+		XcmFeeManagerToAccount<AssetTransactors, AccountId, XcmAssetFeesReceiverToTreasury>;
 	type MessageExporter = ();
 	type UniversalAliases = Nothing;
 	type CallDispatcher = WithOriginFilter<SafeCallFilter>;

--- a/parachains/runtimes/assets/westmint/src/xcm_config.rs
+++ b/parachains/runtimes/assets/westmint/src/xcm_config.rs
@@ -18,6 +18,7 @@ use super::{
 	ParachainSystem, PolkadotXcm, Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin,
 	TrustBackedAssetsInstance, WeightToFee, XcmpQueue,
 };
+use cumulus_primitives_utility::XcmFeeManagerToAccount;
 use frame_support::{
 	match_types, parameter_types,
 	traits::{ConstU32, Contains, Everything, Nothing, PalletInfoAccess},
@@ -28,9 +29,10 @@ use parachains_common::{
 	xcm_config::{
 		AssetFeeAsExistentialDepositMultiplier, DenyReserveTransferToRelayChain, DenyThenTry,
 	},
+	RELAY_TREASURY_PALLET_ID,
 };
 use polkadot_parachain::primitives::Sibling;
-use sp_runtime::traits::ConvertInto;
+use sp_runtime::traits::{AccountIdConversion, ConvertInto};
 use xcm::latest::prelude::*;
 use xcm_builder::{
 	AccountId32Aliases, AllowExplicitUnpaidExecutionFrom, AllowKnownQueryResponses,
@@ -131,6 +133,7 @@ parameter_types! {
 	pub const MaxInstructions: u32 = 100;
 	pub const MaxAssetsIntoHolding: u32 = 64;
 	pub XcmAssetFeesReceiver: Option<AccountId> = Authorship::author();
+	pub XcmAssetFeesReceiverToTreasury: Option<AccountId> = Some(RELAY_TREASURY_PALLET_ID.into_account_truncating());
 }
 
 match_types! {
@@ -344,7 +347,8 @@ impl xcm_executor::Config for XcmConfig {
 	type MaxAssetsIntoHolding = MaxAssetsIntoHolding;
 	type AssetLocker = ();
 	type AssetExchanger = ();
-	type FeeManager = ();
+	type FeeManager =
+		XcmFeeManagerToAccount<AssetTransactors, AccountId, XcmAssetFeesReceiverToTreasury>;
 	type MessageExporter = ();
 	type UniversalAliases = Nothing;
 	type CallDispatcher = WithOriginFilter<SafeCallFilter>;

--- a/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/src/xcm_config.rs
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/src/xcm_config.rs
@@ -18,16 +18,19 @@ use super::{
 	AccountId, AllPalletsWithSystem, Balances, ParachainInfo, ParachainSystem, PolkadotXcm,
 	Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin, WeightToFee, XcmpQueue,
 };
+use cumulus_primitives_utility::XcmFeeManagerToAccount;
 use frame_support::{
 	match_types, parameter_types,
 	traits::{ConstU32, Contains, Everything, Nothing},
 };
 use pallet_xcm::XcmPassthrough;
-use parachains_common::xcm_config::{
-	ConcreteNativeAssetFrom, DenyReserveTransferToRelayChain, DenyThenTry,
+use parachains_common::{
+	xcm_config::{ConcreteNativeAssetFrom, DenyReserveTransferToRelayChain, DenyThenTry},
+	RELAY_TREASURY_PALLET_ID,
 };
 use polkadot_parachain::primitives::Sibling;
 use polkadot_runtime_common::impls::ToAuthor;
+use sp_runtime::traits::AccountIdConversion;
 use xcm::latest::prelude::*;
 use xcm_builder::{
 	AccountId32Aliases, AllowExplicitUnpaidExecutionFrom, AllowKnownQueryResponses,
@@ -47,6 +50,7 @@ parameter_types! {
 		X2(GlobalConsensus(RelayNetwork::get().unwrap()), Parachain(ParachainInfo::parachain_id().into()));
 	pub const MaxInstructions: u32 = 100;
 	pub const MaxAssetsIntoHolding: u32 = 64;
+	pub XcmAssetFeesReceiverToTreasury: Option<AccountId> = Some(RELAY_TREASURY_PALLET_ID.into_account_truncating());
 	pub FellowshipLocation: MultiLocation = MultiLocation::new(1, Parachain(1001));
 	pub const GovernanceLocation: MultiLocation = MultiLocation::parent();
 }
@@ -205,7 +209,8 @@ impl xcm_executor::Config for XcmConfig {
 	type MaxAssetsIntoHolding = MaxAssetsIntoHolding;
 	type AssetLocker = ();
 	type AssetExchanger = ();
-	type FeeManager = ();
+	type FeeManager =
+		XcmFeeManagerToAccount<CurrencyTransactor, AccountId, XcmAssetFeesReceiverToTreasury>;
 	type MessageExporter = ();
 	type UniversalAliases = Nothing;
 	type CallDispatcher = WithOriginFilter<SafeCallFilter>;

--- a/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/xcm_config.rs
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/xcm_config.rs
@@ -18,16 +18,19 @@ use super::{
 	AccountId, AllPalletsWithSystem, Balances, ParachainInfo, ParachainSystem, PolkadotXcm,
 	Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin, WeightToFee, XcmpQueue,
 };
+use cumulus_primitives_utility::XcmFeeManagerToAccount;
 use frame_support::{
 	match_types, parameter_types,
 	traits::{ConstU32, Contains, Everything, Nothing},
 };
 use pallet_xcm::XcmPassthrough;
-use parachains_common::xcm_config::{
-	ConcreteNativeAssetFrom, DenyReserveTransferToRelayChain, DenyThenTry,
+use parachains_common::{
+	xcm_config::{ConcreteNativeAssetFrom, DenyReserveTransferToRelayChain, DenyThenTry},
+	RELAY_TREASURY_PALLET_ID,
 };
 use polkadot_parachain::primitives::Sibling;
 use polkadot_runtime_common::impls::ToAuthor;
+use sp_runtime::traits::AccountIdConversion;
 use xcm::latest::prelude::*;
 use xcm_builder::{
 	AccountId32Aliases, AllowExplicitUnpaidExecutionFrom, AllowKnownQueryResponses,
@@ -47,6 +50,7 @@ parameter_types! {
 		X2(GlobalConsensus(RelayNetwork::get().unwrap()), Parachain(ParachainInfo::parachain_id().into()));
 	pub const MaxInstructions: u32 = 100;
 	pub const MaxAssetsIntoHolding: u32 = 64;
+	pub XcmAssetFeesReceiverToTreasury: Option<AccountId> = Some(RELAY_TREASURY_PALLET_ID.into_account_truncating());
 }
 
 /// Type for specifying how a `MultiLocation` can be converted into an `AccountId`. This is used
@@ -203,7 +207,8 @@ impl xcm_executor::Config for XcmConfig {
 	type MaxAssetsIntoHolding = MaxAssetsIntoHolding;
 	type AssetLocker = ();
 	type AssetExchanger = ();
-	type FeeManager = ();
+	type FeeManager =
+		XcmFeeManagerToAccount<CurrencyTransactor, AccountId, XcmAssetFeesReceiverToTreasury>;
 	type MessageExporter = ();
 	type UniversalAliases = Nothing;
 	type CallDispatcher = WithOriginFilter<SafeCallFilter>;

--- a/parachains/runtimes/collectives/collectives-polkadot/src/xcm_config.rs
+++ b/parachains/runtimes/collectives/collectives-polkadot/src/xcm_config.rs
@@ -17,6 +17,7 @@ use super::{
 	AccountId, AllPalletsWithSystem, Balances, Fellows, ParachainInfo, ParachainSystem,
 	PolkadotXcm, Runtime, RuntimeCall, RuntimeEvent, RuntimeOrigin, WeightToFee, XcmpQueue,
 };
+use cumulus_primitives_utility::XcmFeeManagerToAccount;
 use frame_support::{
 	match_types, parameter_types,
 	traits::{ConstU32, Contains, Everything, Nothing},
@@ -26,8 +27,10 @@ use pallet_xcm::XcmPassthrough;
 use parachains_common::{
 	impls::ToStakingPot,
 	xcm_config::{ConcreteNativeAssetFrom, DenyReserveTransferToRelayChain, DenyThenTry},
+	RELAY_TREASURY_PALLET_ID,
 };
 use polkadot_parachain::primitives::Sibling;
+use sp_runtime::traits::AccountIdConversion;
 use xcm::latest::prelude::*;
 use xcm_builder::{
 	AccountId32Aliases, AllowExplicitUnpaidExecutionFrom, AllowKnownQueryResponses,
@@ -105,6 +108,7 @@ parameter_types! {
 	pub UnitWeightCost: Weight = Weight::from_parts(1_000_000_000, 64 * 1024);
 	pub const MaxInstructions: u32 = 100;
 	pub const MaxAssetsIntoHolding: u32 = 64;
+	pub XcmAssetFeesReceiverToTreasury: Option<AccountId> = Some(RELAY_TREASURY_PALLET_ID.into_account_truncating());
 	// Fellows pluralistic body.
 	pub const FellowsBodyId: BodyId = BodyId::Technical;
 }
@@ -241,7 +245,8 @@ impl xcm_executor::Config for XcmConfig {
 	type MaxAssetsIntoHolding = MaxAssetsIntoHolding;
 	type AssetLocker = ();
 	type AssetExchanger = ();
-	type FeeManager = ();
+	type FeeManager =
+		XcmFeeManagerToAccount<CurrencyTransactor, AccountId, XcmAssetFeesReceiverToTreasury>;
 	type MessageExporter = ();
 	type UniversalAliases = Nothing;
 	type CallDispatcher = WithOriginFilter<SafeCallFilter>;


### PR DESCRIPTION
Similar to XcmFeesTo32ByteAccount, an implementation of FeeManager that routes XCM fees to a central account.

Associated issue: https://github.com/paritytech/cumulus/issues/2320