### PR TITLE
[Revert] Use XCM V3 for initiate_teleport weight calc #2102

### DIFF
--- a/parachains/runtimes/assets/statemine/src/weights/xcm/mod.rs
+++ b/parachains/runtimes/assets/statemine/src/weights/xcm/mod.rs
@@ -17,7 +17,7 @@
 mod pallet_xcm_benchmarks_fungible;
 mod pallet_xcm_benchmarks_generic;
 
-use crate::{xcm_config::MaxAssetsIntoHolding, Runtime};
+use crate::Runtime;
 use frame_support::weights::Weight;
 use pallet_xcm_benchmarks_fungible::WeightInfo as XcmFungibleWeight;
 use pallet_xcm_benchmarks_generic::WeightInfo as XcmGeneric;
@@ -35,18 +35,7 @@ impl WeighMultiAssets for MultiAssetFilter {
 		match self {
 			Self::Definite(assets) =>
 				weight.saturating_mul(assets.inner().into_iter().count() as u64),
-			Self::Wild(asset) => match asset {
-				All => weight.saturating_mul(MAX_ASSETS),
-				AllOf { fun, .. } => match fun {
-					WildFungibility::Fungible => weight,
-					// Magic number 2 has to do with the fact that we could have up to 2 times
-					// MaxAssetsIntoHolding in the worst-case scenario.
-					WildFungibility::NonFungible =>
-						weight.saturating_mul((MaxAssetsIntoHolding::get() * 2) as u64),
-				},
-				AllCounted(count) => weight.saturating_mul(MAX_ASSETS.min(*count as u64)),
-				AllOfCounted { count, .. } => weight.saturating_mul(MAX_ASSETS.min(*count as u64)),
-			},
+			Self::Wild(_) => weight.saturating_mul(MAX_ASSETS as u64),
 		}
 	}
 }
@@ -149,7 +138,10 @@ impl<Call> XcmWeightInfo<Call> for StatemineXcmWeight<Call> {
 		_dest: &MultiLocation,
 		_xcm: &Xcm<()>,
 	) -> Weight {
-		assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::initiate_teleport())
+		// Hardcoded till the XCM pallet is fixed
+		let hardcoded_weight = Weight::from_ref_time(200_000_000 as u64);
+		let weight = assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::initiate_teleport());
+		hardcoded_weight.min(weight)
 	}
 	fn report_holding(_response_info: &QueryResponseInfo, _assets: &MultiAssetFilter) -> Weight {
 		XcmGeneric::<Runtime>::report_holding()

--- a/parachains/runtimes/assets/statemine/src/weights/xcm/mod.rs
+++ b/parachains/runtimes/assets/statemine/src/weights/xcm/mod.rs
@@ -139,7 +139,7 @@ impl<Call> XcmWeightInfo<Call> for StatemineXcmWeight<Call> {
 		_xcm: &Xcm<()>,
 	) -> Weight {
 		// Hardcoded till the XCM pallet is fixed
-		let hardcoded_weight = Weight::from_ref_time(200_000_000 as u64);
+		let hardcoded_weight = Weight::from_parts(200_000_000 as u64, 0);
 		let weight = assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::initiate_teleport());
 		hardcoded_weight.min(weight)
 	}

--- a/parachains/runtimes/assets/statemine/tests/tests.rs
+++ b/parachains/runtimes/assets/statemine/tests/tests.rs
@@ -448,7 +448,7 @@ fn receive_teleported_asset_works() {
 						id: Concrete(MultiLocation { parents: 1, interior: Here }),
 						fun: Fungible(10000000000000),
 					},
-					weight_limit: Limited(Weight::from_parts(303531000, 65536)),
+					weight_limit: Limited(Weight::from_parts(1303531000, 65536)),
 				},
 				DepositAsset {
 					assets: Wild(AllCounted(1)),

--- a/parachains/runtimes/assets/statemint/src/weights/xcm/mod.rs
+++ b/parachains/runtimes/assets/statemint/src/weights/xcm/mod.rs
@@ -139,7 +139,7 @@ impl<Call> XcmWeightInfo<Call> for StatemintXcmWeight<Call> {
 		_xcm: &Xcm<()>,
 	) -> Weight {
 		// Hardcoded till the XCM pallet is fixed
-		let hardcoded_weight = Weight::from_ref_time(200_000_000 as u64);
+		let hardcoded_weight = Weight::from_parts(200_000_000 as u64, 0);
 		let weight = assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::initiate_teleport());
 		hardcoded_weight.min(weight)
 	}

--- a/parachains/runtimes/assets/statemint/src/weights/xcm/mod.rs
+++ b/parachains/runtimes/assets/statemint/src/weights/xcm/mod.rs
@@ -17,7 +17,7 @@
 mod pallet_xcm_benchmarks_fungible;
 mod pallet_xcm_benchmarks_generic;
 
-use crate::{xcm_config::MaxAssetsIntoHolding, Runtime};
+use crate::Runtime;
 use frame_support::weights::Weight;
 use pallet_xcm_benchmarks_fungible::WeightInfo as XcmFungibleWeight;
 use pallet_xcm_benchmarks_generic::WeightInfo as XcmGeneric;
@@ -35,18 +35,7 @@ impl WeighMultiAssets for MultiAssetFilter {
 		match self {
 			Self::Definite(assets) =>
 				weight.saturating_mul(assets.inner().into_iter().count() as u64),
-			Self::Wild(asset) => match asset {
-				All => weight.saturating_mul(MAX_ASSETS),
-				AllOf { fun, .. } => match fun {
-					WildFungibility::Fungible => weight,
-					// Magic number 2 has to do with the fact that we could have up to 2 times
-					// MaxAssetsIntoHolding in the worst-case scenario.
-					WildFungibility::NonFungible =>
-						weight.saturating_mul((MaxAssetsIntoHolding::get() * 2) as u64),
-				},
-				AllCounted(count) => weight.saturating_mul(MAX_ASSETS.min(*count as u64)),
-				AllOfCounted { count, .. } => weight.saturating_mul(MAX_ASSETS.min(*count as u64)),
-			},
+			Self::Wild(_) => weight.saturating_mul(MAX_ASSETS as u64),
 		}
 	}
 }
@@ -149,7 +138,10 @@ impl<Call> XcmWeightInfo<Call> for StatemintXcmWeight<Call> {
 		_dest: &MultiLocation,
 		_xcm: &Xcm<()>,
 	) -> Weight {
-		assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::initiate_teleport())
+		// Hardcoded till the XCM pallet is fixed
+		let hardcoded_weight = Weight::from_ref_time(200_000_000 as u64);
+		let weight = assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::initiate_teleport());
+		hardcoded_weight.min(weight)
 	}
 	fn report_holding(_response_info: &QueryResponseInfo, _assets: &MultiAssetFilter) -> Weight {
 		XcmGeneric::<Runtime>::report_holding()

--- a/parachains/runtimes/assets/statemint/tests/tests.rs
+++ b/parachains/runtimes/assets/statemint/tests/tests.rs
@@ -460,7 +460,7 @@ fn receive_teleported_asset_works() {
 						id: Concrete(MultiLocation { parents: 1, interior: Here }),
 						fun: Fungible(10000000000000),
 					},
-					weight_limit: Limited(Weight::from_parts(303531000, 65536)),
+					weight_limit: Limited(Weight::from_parts(1303531000, 65536)),
 				},
 				DepositAsset {
 					assets: Wild(AllCounted(1)),

--- a/parachains/runtimes/assets/westmint/src/weights/xcm/mod.rs
+++ b/parachains/runtimes/assets/westmint/src/weights/xcm/mod.rs
@@ -139,7 +139,7 @@ impl<Call> XcmWeightInfo<Call> for WestmintXcmWeight<Call> {
 		_xcm: &Xcm<()>,
 	) -> Weight {
 		// Hardcoded till the XCM pallet is fixed
-		let hardcoded_weight = Weight::from_ref_time(200_000_000 as u64);
+		let hardcoded_weight = Weight::from_parts(200_000_000 as u64, 0);
 		let weight = assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::initiate_teleport());
 		hardcoded_weight.min(weight)
 	}

--- a/parachains/runtimes/assets/westmint/src/weights/xcm/mod.rs
+++ b/parachains/runtimes/assets/westmint/src/weights/xcm/mod.rs
@@ -17,7 +17,7 @@
 mod pallet_xcm_benchmarks_fungible;
 mod pallet_xcm_benchmarks_generic;
 
-use crate::{xcm_config::MaxAssetsIntoHolding, Runtime};
+use crate::Runtime;
 use frame_support::weights::Weight;
 use pallet_xcm_benchmarks_fungible::WeightInfo as XcmFungibleWeight;
 use pallet_xcm_benchmarks_generic::WeightInfo as XcmGeneric;
@@ -35,18 +35,7 @@ impl WeighMultiAssets for MultiAssetFilter {
 		match self {
 			Self::Definite(assets) =>
 				weight.saturating_mul(assets.inner().into_iter().count() as u64),
-			Self::Wild(asset) => match asset {
-				All => weight.saturating_mul(MAX_ASSETS),
-				AllOf { fun, .. } => match fun {
-					WildFungibility::Fungible => weight,
-					// Magic number 2 has to do with the fact that we could have up to 2 times
-					// MaxAssetsIntoHolding in the worst-case scenario.
-					WildFungibility::NonFungible =>
-						weight.saturating_mul((MaxAssetsIntoHolding::get() * 2) as u64),
-				},
-				AllCounted(count) => weight.saturating_mul(MAX_ASSETS.min(*count as u64)),
-				AllOfCounted { count, .. } => weight.saturating_mul(MAX_ASSETS.min(*count as u64)),
-			},
+			Self::Wild(_) => weight.saturating_mul(MAX_ASSETS as u64),
 		}
 	}
 }
@@ -149,7 +138,10 @@ impl<Call> XcmWeightInfo<Call> for WestmintXcmWeight<Call> {
 		_dest: &MultiLocation,
 		_xcm: &Xcm<()>,
 	) -> Weight {
-		assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::initiate_teleport())
+		// Hardcoded till the XCM pallet is fixed
+		let hardcoded_weight = Weight::from_ref_time(200_000_000 as u64);
+		let weight = assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::initiate_teleport());
+		hardcoded_weight.min(weight)
 	}
 	fn report_holding(_response_info: &QueryResponseInfo, _assets: &MultiAssetFilter) -> Weight {
 		XcmGeneric::<Runtime>::report_holding()

--- a/parachains/runtimes/assets/westmint/tests/tests.rs
+++ b/parachains/runtimes/assets/westmint/tests/tests.rs
@@ -448,7 +448,7 @@ fn receive_teleported_asset_works() {
 						id: Concrete(MultiLocation { parents: 1, interior: Here }),
 						fun: Fungible(10000000000000),
 					},
-					weight_limit: Limited(Weight::from_parts(303531000, 65536)),
+					weight_limit: Limited(Weight::from_parts(1303531000, 65536)),
 				},
 				DepositAsset {
 					assets: Wild(AllCounted(1)),

--- a/parachains/runtimes/assets/westmint/tests/tests.rs
+++ b/parachains/runtimes/assets/westmint/tests/tests.rs
@@ -473,31 +473,3 @@ fn receive_teleported_asset_works() {
 			assert_eq!(outcome.ensure_complete(), Ok(()));
 		})
 }
-
-#[test]
-fn plain_receive_teleported_asset_works() {
-	ExtBuilder::<Runtime>::default()
-		.with_collators(vec![AccountId::from(ALICE)])
-		.with_session_keys(vec![(
-			AccountId::from(ALICE),
-			AccountId::from(ALICE),
-			SessionKeys { aura: AuraId::from(sp_core::sr25519::Public::from_raw(ALICE)) },
-		)])
-		.build()
-		.execute_with(|| {
-			let data = hex_literal::hex!("02100204000100000b00a0724e18090a13000100000b00a0724e180901e20f5e480d010004000101001299557001f55815d3fcb53c74463acb0cf6d14d4639b340982c60877f384609").to_vec();
-			let message_id = sp_io::hashing::blake2_256(&data);
-
-			let maybe_msg = VersionedXcm::<RuntimeCall>::decode_all_with_depth_limit(
-				MAX_XCM_DECODE_DEPTH,
-				&mut data.as_ref(),
-			)
-				.map(xcm::v3::Xcm::<RuntimeCall>::try_from).expect("failed").expect("failed");
-
-			let weight_limit = ReservedDmpWeight::get();
-
-			let outcome =
-				XcmExecutor::<XcmConfig>::execute_xcm(Parent, maybe_msg, message_id, weight_limit);
-			assert_eq!(outcome.ensure_complete(), Ok(()));
-		})
-}

--- a/parachains/runtimes/assets/westmint/tests/tests.rs
+++ b/parachains/runtimes/assets/westmint/tests/tests.rs
@@ -1,21 +1,20 @@
 use asset_test_utils::{ExtBuilder, RuntimeHelper};
-use codec::{DecodeLimit, Encode};
+use codec::Encode;
 use cumulus_primitives_utility::ChargeWeightInFungibles;
 use frame_support::{
 	assert_noop, assert_ok, sp_io,
 	weights::{Weight, WeightToFee as WeightToFeeT},
 };
 use parachains_common::{AccountId, AuraId, Balance};
+use westmint_runtime::xcm_config::{
+	AssetFeeAsExistentialDepositMultiplierFeeCharger, WestendLocation,
+};
 pub use westmint_runtime::{
 	constants::fee::WeightToFee,
 	xcm_config::{TrustBackedAssetsPalletLocation, XcmConfig},
 	Assets, Balances, ExistentialDeposit, ReservedDmpWeight, Runtime, SessionKeys, System,
 };
-use westmint_runtime::{
-	xcm_config::{AssetFeeAsExistentialDepositMultiplierFeeCharger, WestendLocation},
-	RuntimeCall,
-};
-use xcm::{latest::prelude::*, VersionedXcm, MAX_XCM_DECODE_DEPTH};
+use xcm::latest::prelude::*;
 use xcm_executor::{
 	traits::{Convert, WeightTrader},
 	XcmExecutor,

--- a/parachains/runtimes/bridge-hubs/bridge-hub-kusama/src/weights/xcm/mod.rs
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-kusama/src/weights/xcm/mod.rs
@@ -17,7 +17,7 @@
 mod pallet_xcm_benchmarks_fungible;
 mod pallet_xcm_benchmarks_generic;
 
-use crate::{xcm_config::MaxAssetsIntoHolding, Runtime};
+use crate::Runtime;
 use frame_support::weights::Weight;
 use pallet_xcm_benchmarks_fungible::WeightInfo as XcmFungibleWeight;
 use pallet_xcm_benchmarks_generic::WeightInfo as XcmGeneric;
@@ -35,18 +35,7 @@ impl WeighMultiAssets for MultiAssetFilter {
 		match self {
 			Self::Definite(assets) =>
 				weight.saturating_mul(assets.inner().into_iter().count() as u64),
-			Self::Wild(asset) => match asset {
-				All => weight.saturating_mul(MAX_ASSETS),
-				AllOf { fun, .. } => match fun {
-					WildFungibility::Fungible => weight,
-					// Magic number 2 has to do with the fact that we could have up to 2 times
-					// MaxAssetsIntoHolding in the worst-case scenario.
-					WildFungibility::NonFungible =>
-						weight.saturating_mul((MaxAssetsIntoHolding::get() * 2) as u64),
-				},
-				AllCounted(count) => weight.saturating_mul(MAX_ASSETS.min(*count as u64)),
-				AllOfCounted { count, .. } => weight.saturating_mul(MAX_ASSETS.min(*count as u64)),
-			},
+			Self::Wild(_) => weight.saturating_mul(MAX_ASSETS as u64),
 		}
 	}
 }
@@ -149,7 +138,10 @@ impl<Call> XcmWeightInfo<Call> for BridgeHubKusamaXcmWeight<Call> {
 		_dest: &MultiLocation,
 		_xcm: &Xcm<()>,
 	) -> Weight {
-		assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::initiate_teleport())
+		// Hardcoded till the XCM pallet is fixed
+		let hardcoded_weight = Weight::from_ref_time(200_000_000 as u64);
+		let weight = assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::initiate_teleport());
+		hardcoded_weight.min(weight)
 	}
 	fn report_holding(_response_info: &QueryResponseInfo, _assets: &MultiAssetFilter) -> Weight {
 		XcmGeneric::<Runtime>::report_holding()

--- a/parachains/runtimes/bridge-hubs/bridge-hub-kusama/src/weights/xcm/mod.rs
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-kusama/src/weights/xcm/mod.rs
@@ -139,7 +139,7 @@ impl<Call> XcmWeightInfo<Call> for BridgeHubKusamaXcmWeight<Call> {
 		_xcm: &Xcm<()>,
 	) -> Weight {
 		// Hardcoded till the XCM pallet is fixed
-		let hardcoded_weight = Weight::from_ref_time(200_000_000 as u64);
+		let hardcoded_weight = Weight::from_parts(200_000_000 as u64, 0);
 		let weight = assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::initiate_teleport());
 		hardcoded_weight.min(weight)
 	}

--- a/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/src/weights/xcm/mod.rs
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/src/weights/xcm/mod.rs
@@ -17,7 +17,7 @@
 mod pallet_xcm_benchmarks_fungible;
 mod pallet_xcm_benchmarks_generic;
 
-use crate::{xcm_config::MaxAssetsIntoHolding, Runtime};
+use crate::Runtime;
 use frame_support::weights::Weight;
 use pallet_xcm_benchmarks_fungible::WeightInfo as XcmFungibleWeight;
 use pallet_xcm_benchmarks_generic::WeightInfo as XcmGeneric;
@@ -35,18 +35,7 @@ impl WeighMultiAssets for MultiAssetFilter {
 		match self {
 			Self::Definite(assets) =>
 				weight.saturating_mul(assets.inner().into_iter().count() as u64),
-			Self::Wild(asset) => match asset {
-				All => weight.saturating_mul(MAX_ASSETS),
-				AllOf { fun, .. } => match fun {
-					WildFungibility::Fungible => weight,
-					// Magic number 2 has to do with the fact that we could have up to 2 times
-					// MaxAssetsIntoHolding in the worst-case scenario.
-					WildFungibility::NonFungible =>
-						weight.saturating_mul((MaxAssetsIntoHolding::get() * 2) as u64),
-				},
-				AllCounted(count) => weight.saturating_mul(MAX_ASSETS.min(*count as u64)),
-				AllOfCounted { count, .. } => weight.saturating_mul(MAX_ASSETS.min(*count as u64)),
-			},
+			Self::Wild(_) => weight.saturating_mul(MAX_ASSETS as u64),
 		}
 	}
 }

--- a/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/weights/xcm/mod.rs
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/weights/xcm/mod.rs
@@ -139,7 +139,7 @@ impl<Call> XcmWeightInfo<Call> for BridgeHubRococoXcmWeight<Call> {
 		_xcm: &Xcm<()>,
 	) -> Weight {
 		// Hardcoded till the XCM pallet is fixed
-		let hardcoded_weight = Weight::from_ref_time(200_000_000 as u64);
+		let hardcoded_weight = Weight::from_parts(200_000_000 as u64, 0);
 		let weight = assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::initiate_teleport());
 		hardcoded_weight.min(weight)
 	}

--- a/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/weights/xcm/mod.rs
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/weights/xcm/mod.rs
@@ -17,7 +17,7 @@
 mod pallet_xcm_benchmarks_fungible;
 mod pallet_xcm_benchmarks_generic;
 
-use crate::{xcm_config::MaxAssetsIntoHolding, Runtime};
+use crate::Runtime;
 use frame_support::weights::Weight;
 use pallet_xcm_benchmarks_fungible::WeightInfo as XcmFungibleWeight;
 use pallet_xcm_benchmarks_generic::WeightInfo as XcmGeneric;
@@ -35,18 +35,7 @@ impl WeighMultiAssets for MultiAssetFilter {
 		match self {
 			Self::Definite(assets) =>
 				weight.saturating_mul(assets.inner().into_iter().count() as u64),
-			Self::Wild(asset) => match asset {
-				All => weight.saturating_mul(MAX_ASSETS),
-				AllOf { fun, .. } => match fun {
-					WildFungibility::Fungible => weight,
-					// Magic number 2 has to do with the fact that we could have up to 2 times
-					// MaxAssetsIntoHolding in the worst-case scenario.
-					WildFungibility::NonFungible =>
-						weight.saturating_mul((MaxAssetsIntoHolding::get() * 2) as u64),
-				},
-				AllCounted(count) => weight.saturating_mul(MAX_ASSETS.min(*count as u64)),
-				AllOfCounted { count, .. } => weight.saturating_mul(MAX_ASSETS.min(*count as u64)),
-			},
+			Self::Wild(_) => weight.saturating_mul(MAX_ASSETS as u64),
 		}
 	}
 }
@@ -149,7 +138,10 @@ impl<Call> XcmWeightInfo<Call> for BridgeHubRococoXcmWeight<Call> {
 		_dest: &MultiLocation,
 		_xcm: &Xcm<()>,
 	) -> Weight {
-		assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::initiate_teleport())
+		// Hardcoded till the XCM pallet is fixed
+		let hardcoded_weight = Weight::from_ref_time(200_000_000 as u64);
+		let weight = assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::initiate_teleport());
+		hardcoded_weight.min(weight)
 	}
 	fn report_holding(_response_info: &QueryResponseInfo, _assets: &MultiAssetFilter) -> Weight {
 		XcmGeneric::<Runtime>::report_holding()


### PR DESCRIPTION
This PR reverts changes made in #2102 because of https://github.com/paritytech/cumulus/issues/2392