### PR TITLE
[Backport] of [Revert] Use XCM V3 for initiate_teleport weight calc #2102 (#2394) to client

### DIFF
--- a/parachains/runtimes/assets/statemine/src/weights/xcm/mod.rs
+++ b/parachains/runtimes/assets/statemine/src/weights/xcm/mod.rs
@@ -17,7 +17,7 @@
 mod pallet_xcm_benchmarks_fungible;
 mod pallet_xcm_benchmarks_generic;
 
-use crate::{xcm_config::MaxAssetsIntoHolding, Runtime};
+use crate::Runtime;
 use frame_support::weights::Weight;
 use pallet_xcm_benchmarks_fungible::WeightInfo as XcmFungibleWeight;
 use pallet_xcm_benchmarks_generic::WeightInfo as XcmGeneric;
@@ -35,18 +35,7 @@ impl WeighMultiAssets for MultiAssetFilter {
 		match self {
 			Self::Definite(assets) =>
 				weight.saturating_mul(assets.inner().into_iter().count() as u64),
-			Self::Wild(asset) => match asset {
-				All => weight.saturating_mul(MAX_ASSETS),
-				AllOf { fun, .. } => match fun {
-					WildFungibility::Fungible => weight,
-					// Magic number 2 has to do with the fact that we could have up to 2 times
-					// MaxAssetsIntoHolding in the worst-case scenario.
-					WildFungibility::NonFungible =>
-						weight.saturating_mul((MaxAssetsIntoHolding::get() * 2) as u64),
-				},
-				AllCounted(count) => weight.saturating_mul(MAX_ASSETS.min(*count as u64)),
-				AllOfCounted { count, .. } => weight.saturating_mul(MAX_ASSETS.min(*count as u64)),
-			},
+			Self::Wild(_) => weight.saturating_mul(MAX_ASSETS as u64),
 		}
 	}
 }
@@ -149,7 +138,10 @@ impl<Call> XcmWeightInfo<Call> for StatemineXcmWeight<Call> {
 		_dest: &MultiLocation,
 		_xcm: &Xcm<()>,
 	) -> Weight {
-		assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::initiate_teleport())
+		// Hardcoded till the XCM pallet is fixed
+		let hardcoded_weight = Weight::from_parts(200_000_000 as u64, 0);
+		let weight = assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::initiate_teleport());
+		hardcoded_weight.min(weight)
 	}
 	fn report_holding(_response_info: &QueryResponseInfo, _assets: &MultiAssetFilter) -> Weight {
 		XcmGeneric::<Runtime>::report_holding()

--- a/parachains/runtimes/assets/statemine/tests/tests.rs
+++ b/parachains/runtimes/assets/statemine/tests/tests.rs
@@ -448,7 +448,7 @@ fn receive_teleported_asset_works() {
 						id: Concrete(MultiLocation { parents: 1, interior: Here }),
 						fun: Fungible(10000000000000),
 					},
-					weight_limit: Limited(Weight::from_parts(303531000, 65536)),
+					weight_limit: Limited(Weight::from_parts(1303531000, 65536)),
 				},
 				DepositAsset {
 					assets: Wild(AllCounted(1)),

--- a/parachains/runtimes/assets/statemint/src/weights/xcm/mod.rs
+++ b/parachains/runtimes/assets/statemint/src/weights/xcm/mod.rs
@@ -17,7 +17,7 @@
 mod pallet_xcm_benchmarks_fungible;
 mod pallet_xcm_benchmarks_generic;
 
-use crate::{xcm_config::MaxAssetsIntoHolding, Runtime};
+use crate::Runtime;
 use frame_support::weights::Weight;
 use pallet_xcm_benchmarks_fungible::WeightInfo as XcmFungibleWeight;
 use pallet_xcm_benchmarks_generic::WeightInfo as XcmGeneric;
@@ -35,18 +35,7 @@ impl WeighMultiAssets for MultiAssetFilter {
 		match self {
 			Self::Definite(assets) =>
 				weight.saturating_mul(assets.inner().into_iter().count() as u64),
-			Self::Wild(asset) => match asset {
-				All => weight.saturating_mul(MAX_ASSETS),
-				AllOf { fun, .. } => match fun {
-					WildFungibility::Fungible => weight,
-					// Magic number 2 has to do with the fact that we could have up to 2 times
-					// MaxAssetsIntoHolding in the worst-case scenario.
-					WildFungibility::NonFungible =>
-						weight.saturating_mul((MaxAssetsIntoHolding::get() * 2) as u64),
-				},
-				AllCounted(count) => weight.saturating_mul(MAX_ASSETS.min(*count as u64)),
-				AllOfCounted { count, .. } => weight.saturating_mul(MAX_ASSETS.min(*count as u64)),
-			},
+			Self::Wild(_) => weight.saturating_mul(MAX_ASSETS as u64),
 		}
 	}
 }
@@ -149,7 +138,10 @@ impl<Call> XcmWeightInfo<Call> for StatemintXcmWeight<Call> {
 		_dest: &MultiLocation,
 		_xcm: &Xcm<()>,
 	) -> Weight {
-		assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::initiate_teleport())
+		// Hardcoded till the XCM pallet is fixed
+		let hardcoded_weight = Weight::from_parts(200_000_000 as u64, 0);
+		let weight = assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::initiate_teleport());
+		hardcoded_weight.min(weight)
 	}
 	fn report_holding(_response_info: &QueryResponseInfo, _assets: &MultiAssetFilter) -> Weight {
 		XcmGeneric::<Runtime>::report_holding()

--- a/parachains/runtimes/assets/statemint/tests/tests.rs
+++ b/parachains/runtimes/assets/statemint/tests/tests.rs
@@ -460,7 +460,7 @@ fn receive_teleported_asset_works() {
 						id: Concrete(MultiLocation { parents: 1, interior: Here }),
 						fun: Fungible(10000000000000),
 					},
-					weight_limit: Limited(Weight::from_parts(303531000, 65536)),
+					weight_limit: Limited(Weight::from_parts(1303531000, 65536)),
 				},
 				DepositAsset {
 					assets: Wild(AllCounted(1)),

--- a/parachains/runtimes/assets/westmint/src/weights/xcm/mod.rs
+++ b/parachains/runtimes/assets/westmint/src/weights/xcm/mod.rs
@@ -17,7 +17,7 @@
 mod pallet_xcm_benchmarks_fungible;
 mod pallet_xcm_benchmarks_generic;
 
-use crate::{xcm_config::MaxAssetsIntoHolding, Runtime};
+use crate::Runtime;
 use frame_support::weights::Weight;
 use pallet_xcm_benchmarks_fungible::WeightInfo as XcmFungibleWeight;
 use pallet_xcm_benchmarks_generic::WeightInfo as XcmGeneric;
@@ -35,18 +35,7 @@ impl WeighMultiAssets for MultiAssetFilter {
 		match self {
 			Self::Definite(assets) =>
 				weight.saturating_mul(assets.inner().into_iter().count() as u64),
-			Self::Wild(asset) => match asset {
-				All => weight.saturating_mul(MAX_ASSETS),
-				AllOf { fun, .. } => match fun {
-					WildFungibility::Fungible => weight,
-					// Magic number 2 has to do with the fact that we could have up to 2 times
-					// MaxAssetsIntoHolding in the worst-case scenario.
-					WildFungibility::NonFungible =>
-						weight.saturating_mul((MaxAssetsIntoHolding::get() * 2) as u64),
-				},
-				AllCounted(count) => weight.saturating_mul(MAX_ASSETS.min(*count as u64)),
-				AllOfCounted { count, .. } => weight.saturating_mul(MAX_ASSETS.min(*count as u64)),
-			},
+			Self::Wild(_) => weight.saturating_mul(MAX_ASSETS as u64),
 		}
 	}
 }
@@ -149,7 +138,10 @@ impl<Call> XcmWeightInfo<Call> for WestmintXcmWeight<Call> {
 		_dest: &MultiLocation,
 		_xcm: &Xcm<()>,
 	) -> Weight {
-		assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::initiate_teleport())
+		// Hardcoded till the XCM pallet is fixed
+		let hardcoded_weight = Weight::from_parts(200_000_000 as u64, 0);
+		let weight = assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::initiate_teleport());
+		hardcoded_weight.min(weight)
 	}
 	fn report_holding(_response_info: &QueryResponseInfo, _assets: &MultiAssetFilter) -> Weight {
 		XcmGeneric::<Runtime>::report_holding()

--- a/parachains/runtimes/bridge-hubs/bridge-hub-kusama/src/weights/xcm/mod.rs
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-kusama/src/weights/xcm/mod.rs
@@ -17,7 +17,7 @@
 mod pallet_xcm_benchmarks_fungible;
 mod pallet_xcm_benchmarks_generic;
 
-use crate::{xcm_config::MaxAssetsIntoHolding, Runtime};
+use crate::Runtime;
 use frame_support::weights::Weight;
 use pallet_xcm_benchmarks_fungible::WeightInfo as XcmFungibleWeight;
 use pallet_xcm_benchmarks_generic::WeightInfo as XcmGeneric;
@@ -35,18 +35,7 @@ impl WeighMultiAssets for MultiAssetFilter {
 		match self {
 			Self::Definite(assets) =>
 				weight.saturating_mul(assets.inner().into_iter().count() as u64),
-			Self::Wild(asset) => match asset {
-				All => weight.saturating_mul(MAX_ASSETS),
-				AllOf { fun, .. } => match fun {
-					WildFungibility::Fungible => weight,
-					// Magic number 2 has to do with the fact that we could have up to 2 times
-					// MaxAssetsIntoHolding in the worst-case scenario.
-					WildFungibility::NonFungible =>
-						weight.saturating_mul((MaxAssetsIntoHolding::get() * 2) as u64),
-				},
-				AllCounted(count) => weight.saturating_mul(MAX_ASSETS.min(*count as u64)),
-				AllOfCounted { count, .. } => weight.saturating_mul(MAX_ASSETS.min(*count as u64)),
-			},
+			Self::Wild(_) => weight.saturating_mul(MAX_ASSETS as u64),
 		}
 	}
 }
@@ -149,7 +138,10 @@ impl<Call> XcmWeightInfo<Call> for BridgeHubKusamaXcmWeight<Call> {
 		_dest: &MultiLocation,
 		_xcm: &Xcm<()>,
 	) -> Weight {
-		assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::initiate_teleport())
+		// Hardcoded till the XCM pallet is fixed
+		let hardcoded_weight = Weight::from_parts(200_000_000 as u64, 0);
+		let weight = assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::initiate_teleport());
+		hardcoded_weight.min(weight)
 	}
 	fn report_holding(_response_info: &QueryResponseInfo, _assets: &MultiAssetFilter) -> Weight {
 		XcmGeneric::<Runtime>::report_holding()

--- a/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/src/weights/xcm/mod.rs
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/src/weights/xcm/mod.rs
@@ -17,7 +17,7 @@
 mod pallet_xcm_benchmarks_fungible;
 mod pallet_xcm_benchmarks_generic;
 
-use crate::{xcm_config::MaxAssetsIntoHolding, Runtime};
+use crate::Runtime;
 use frame_support::weights::Weight;
 use pallet_xcm_benchmarks_fungible::WeightInfo as XcmFungibleWeight;
 use pallet_xcm_benchmarks_generic::WeightInfo as XcmGeneric;
@@ -35,18 +35,7 @@ impl WeighMultiAssets for MultiAssetFilter {
 		match self {
 			Self::Definite(assets) =>
 				weight.saturating_mul(assets.inner().into_iter().count() as u64),
-			Self::Wild(asset) => match asset {
-				All => weight.saturating_mul(MAX_ASSETS),
-				AllOf { fun, .. } => match fun {
-					WildFungibility::Fungible => weight,
-					// Magic number 2 has to do with the fact that we could have up to 2 times
-					// MaxAssetsIntoHolding in the worst-case scenario.
-					WildFungibility::NonFungible =>
-						weight.saturating_mul((MaxAssetsIntoHolding::get() * 2) as u64),
-				},
-				AllCounted(count) => weight.saturating_mul(MAX_ASSETS.min(*count as u64)),
-				AllOfCounted { count, .. } => weight.saturating_mul(MAX_ASSETS.min(*count as u64)),
-			},
+			Self::Wild(_) => weight.saturating_mul(MAX_ASSETS as u64),
 		}
 	}
 }

--- a/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/weights/xcm/mod.rs
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-rococo/src/weights/xcm/mod.rs
@@ -17,7 +17,7 @@
 mod pallet_xcm_benchmarks_fungible;
 mod pallet_xcm_benchmarks_generic;
 
-use crate::{xcm_config::MaxAssetsIntoHolding, Runtime};
+use crate::Runtime;
 use frame_support::weights::Weight;
 use pallet_xcm_benchmarks_fungible::WeightInfo as XcmFungibleWeight;
 use pallet_xcm_benchmarks_generic::WeightInfo as XcmGeneric;
@@ -35,18 +35,7 @@ impl WeighMultiAssets for MultiAssetFilter {
 		match self {
 			Self::Definite(assets) =>
 				weight.saturating_mul(assets.inner().into_iter().count() as u64),
-			Self::Wild(asset) => match asset {
-				All => weight.saturating_mul(MAX_ASSETS),
-				AllOf { fun, .. } => match fun {
-					WildFungibility::Fungible => weight,
-					// Magic number 2 has to do with the fact that we could have up to 2 times
-					// MaxAssetsIntoHolding in the worst-case scenario.
-					WildFungibility::NonFungible =>
-						weight.saturating_mul((MaxAssetsIntoHolding::get() * 2) as u64),
-				},
-				AllCounted(count) => weight.saturating_mul(MAX_ASSETS.min(*count as u64)),
-				AllOfCounted { count, .. } => weight.saturating_mul(MAX_ASSETS.min(*count as u64)),
-			},
+			Self::Wild(_) => weight.saturating_mul(MAX_ASSETS as u64),
 		}
 	}
 }
@@ -149,7 +138,10 @@ impl<Call> XcmWeightInfo<Call> for BridgeHubRococoXcmWeight<Call> {
 		_dest: &MultiLocation,
 		_xcm: &Xcm<()>,
 	) -> Weight {
-		assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::initiate_teleport())
+		// Hardcoded till the XCM pallet is fixed
+		let hardcoded_weight = Weight::from_parts(200_000_000 as u64, 0);
+		let weight = assets.weigh_multi_assets(XcmFungibleWeight::<Runtime>::initiate_teleport());
+		hardcoded_weight.min(weight)
 	}
 	fn report_holding(_response_info: &QueryResponseInfo, _assets: &MultiAssetFilter) -> Weight {
 		XcmGeneric::<Runtime>::report_holding()


### PR DESCRIPTION
This PR backports #2394 from the runtimes release branch to the client release branch