### PR TITLE
[Test] Integration tests for Statemint via XCM-Emulator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,15 +351,15 @@ dependencies = [
  "parachain-info",
  "parachains-common",
  "parity-scale-codec",
- "polkadot-parachain",
+ "polkadot-parachain 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "sp-consensus-aura",
  "sp-core",
  "sp-io",
  "sp-runtime",
  "sp-std",
  "substrate-wasm-builder",
- "xcm",
- "xcm-executor",
+ "xcm 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "xcm-executor 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
 ]
 
 [[package]]
@@ -375,9 +375,9 @@ dependencies = [
  "sp-api",
  "sp-std",
  "substrate-wasm-builder",
- "xcm",
+ "xcm 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "xcm-builder",
- "xcm-executor",
+ "xcm-executor 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
 ]
 
 [[package]]
@@ -523,7 +523,7 @@ dependencies = [
 [[package]]
 name = "binary-merkle-tree"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "hash-db",
  "log",
@@ -735,8 +735,8 @@ dependencies = [
  "parachain-info",
  "parachains-common",
  "parity-scale-codec",
- "polkadot-core-primitives",
- "polkadot-parachain",
+ "polkadot-core-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "polkadot-parachain 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "polkadot-runtime-common",
  "scale-info",
  "serde",
@@ -754,9 +754,9 @@ dependencies = [
  "sp-transaction-pool",
  "sp-version",
  "substrate-wasm-builder",
- "xcm",
+ "xcm 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "xcm-builder",
- "xcm-executor",
+ "xcm-executor 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
 ]
 
 [[package]]
@@ -797,8 +797,8 @@ dependencies = [
  "parachain-info",
  "parachains-common",
  "parity-scale-codec",
- "polkadot-core-primitives",
- "polkadot-parachain",
+ "polkadot-core-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "polkadot-parachain 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "polkadot-runtime-common",
  "polkadot-runtime-constants",
  "scale-info",
@@ -817,9 +817,9 @@ dependencies = [
  "sp-transaction-pool",
  "sp-version",
  "substrate-wasm-builder",
- "xcm",
+ "xcm 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "xcm-builder",
- "xcm-executor",
+ "xcm-executor 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
 ]
 
 [[package]]
@@ -860,8 +860,8 @@ dependencies = [
  "parachain-info",
  "parachains-common",
  "parity-scale-codec",
- "polkadot-core-primitives",
- "polkadot-parachain",
+ "polkadot-core-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "polkadot-parachain 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "polkadot-runtime-common",
  "rococo-runtime-constants",
  "scale-info",
@@ -880,9 +880,9 @@ dependencies = [
  "sp-transaction-pool",
  "sp-version",
  "substrate-wasm-builder",
- "xcm",
+ "xcm 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "xcm-builder",
- "xcm-executor",
+ "xcm-executor 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
 ]
 
 [[package]]
@@ -1306,8 +1306,8 @@ dependencies = [
  "parachain-info",
  "parachains-common",
  "parity-scale-codec",
- "polkadot-core-primitives",
- "polkadot-parachain",
+ "polkadot-core-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "polkadot-parachain 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "polkadot-runtime-common",
  "polkadot-runtime-constants",
  "scale-info",
@@ -1325,9 +1325,9 @@ dependencies = [
  "sp-transaction-pool",
  "sp-version",
  "substrate-wasm-builder",
- "xcm",
+ "xcm 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "xcm-builder",
- "xcm-executor",
+ "xcm-executor 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
 ]
 
 [[package]]
@@ -1439,8 +1439,8 @@ dependencies = [
  "parachain-info",
  "parachains-common",
  "parity-scale-codec",
- "polkadot-core-primitives",
- "polkadot-parachain",
+ "polkadot-core-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "polkadot-parachain 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "polkadot-runtime-common",
  "scale-info",
  "smallvec",
@@ -1456,9 +1456,9 @@ dependencies = [
  "sp-transaction-pool",
  "sp-version",
  "substrate-wasm-builder",
- "xcm",
+ "xcm 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "xcm-builder",
- "xcm-executor",
+ "xcm-executor 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
 ]
 
 [[package]]
@@ -1859,7 +1859,7 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-test-helpers",
  "polkadot-overseer",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "sc-client-api",
  "sp-api",
  "sp-consensus",
@@ -1913,7 +1913,7 @@ dependencies = [
  "futures-timer",
  "log",
  "parity-scale-codec",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "sc-client-api",
  "sc-consensus",
  "schnellru",
@@ -1962,8 +1962,8 @@ dependencies = [
  "parking_lot 0.12.1",
  "polkadot-client",
  "polkadot-node-primitives",
- "polkadot-parachain",
- "polkadot-primitives",
+ "polkadot-parachain 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "polkadot-test-client",
  "portpicker",
  "sc-cli",
@@ -1995,7 +1995,7 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-overseer",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "portpicker",
  "rand 0.8.5",
  "sc-cli",
@@ -2023,7 +2023,7 @@ dependencies = [
  "cumulus-relay-chain-interface",
  "cumulus-relay-chain-minimal-node",
  "futures",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "sc-client-api",
  "sc-consensus",
  "sc-network",
@@ -2074,7 +2074,7 @@ dependencies = [
  "sp-runtime",
  "sp-std",
  "sp-version",
- "xcm",
+ "xcm 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
 ]
 
 [[package]]
@@ -2095,7 +2095,7 @@ dependencies = [
  "lazy_static",
  "log",
  "parity-scale-codec",
- "polkadot-parachain",
+ "polkadot-parachain 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "sc-client-api",
  "scale-info",
  "sp-core",
@@ -2109,7 +2109,7 @@ dependencies = [
  "sp-tracing",
  "sp-trie",
  "sp-version",
- "xcm",
+ "xcm 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
 ]
 
 [[package]]
@@ -2144,7 +2144,7 @@ dependencies = [
  "frame-system",
  "pallet-sudo",
  "parity-scale-codec",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "scale-info",
  "sp-runtime",
  "sp-std",
@@ -2162,7 +2162,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "xcm",
+ "xcm 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
 ]
 
 [[package]]
@@ -2184,9 +2184,9 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "xcm",
+ "xcm 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "xcm-builder",
- "xcm-executor",
+ "xcm-executor 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
 ]
 
 [[package]]
@@ -2201,7 +2201,7 @@ dependencies = [
  "scale-info",
  "sp-runtime",
  "sp-std",
- "xcm",
+ "xcm 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
 ]
 
 [[package]]
@@ -2209,14 +2209,14 @@ name = "cumulus-primitives-core"
 version = "0.1.0"
 dependencies = [
  "parity-scale-codec",
- "polkadot-core-primitives",
- "polkadot-parachain",
- "polkadot-primitives",
+ "polkadot-core-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "polkadot-parachain 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "sp-api",
  "sp-runtime",
  "sp-std",
  "sp-trie",
- "xcm",
+ "xcm 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
 ]
 
 [[package]]
@@ -2270,9 +2270,9 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "xcm",
+ "xcm 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "xcm-builder",
- "xcm-executor",
+ "xcm-executor 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
 ]
 
 [[package]]
@@ -2287,7 +2287,7 @@ dependencies = [
  "futures-timer",
  "polkadot-cli",
  "polkadot-client",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "polkadot-service",
  "polkadot-test-client",
  "prioritized-metered-channel",
@@ -2334,14 +2334,14 @@ dependencies = [
  "lru 0.9.0",
  "polkadot-availability-recovery",
  "polkadot-collator-protocol",
- "polkadot-core-primitives",
+ "polkadot-core-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "polkadot-network-bridge",
  "polkadot-node-collation-generation",
  "polkadot-node-core-runtime-api",
  "polkadot-node-network-protocol",
  "polkadot-node-subsystem-util",
  "polkadot-overseer",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "sc-authority-discovery",
  "sc-client-api",
  "sc-network",
@@ -2400,8 +2400,8 @@ dependencies = [
  "pallet-balances",
  "pallet-transaction-payment",
  "parity-scale-codec",
- "polkadot-parachain",
- "polkadot-primitives",
+ "polkadot-parachain 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "sc-block-builder",
  "sc-consensus",
  "sc-executor",
@@ -2424,7 +2424,7 @@ version = "0.1.0"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "sp-runtime",
  "sp-state-machine",
  "sp-std",
@@ -2498,7 +2498,7 @@ dependencies = [
  "polkadot-cli",
  "polkadot-node-subsystem",
  "polkadot-overseer",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "polkadot-service",
  "polkadot-test-service",
  "portpicker",
@@ -3367,7 +3367,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -3390,7 +3390,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 [[package]]
 name = "frame-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -3415,7 +3415,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "Inflector",
  "array-bytes 4.2.0",
@@ -3462,7 +3462,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -3473,7 +3473,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -3490,7 +3490,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3519,7 +3519,7 @@ dependencies = [
 [[package]]
 name = "frame-remote-externalities"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "futures",
  "log",
@@ -3535,7 +3535,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "bitflags",
  "environmental",
@@ -3568,7 +3568,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -3584,7 +3584,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -3596,7 +3596,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3606,7 +3606,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "frame-support",
  "log",
@@ -3624,7 +3624,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3639,7 +3639,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -3648,7 +3648,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4617,7 +4617,7 @@ checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 [[package]]
 name = "kusama-runtime"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -4679,9 +4679,9 @@ dependencies = [
  "pallet-xcm",
  "pallet-xcm-benchmarks",
  "parity-scale-codec",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "polkadot-runtime-common",
- "polkadot-runtime-parachains",
+ "polkadot-runtime-parachains 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "rustc-hex",
  "scale-info",
  "serde",
@@ -4707,18 +4707,18 @@ dependencies = [
  "sp-version",
  "static_assertions",
  "substrate-wasm-builder",
- "xcm",
+ "xcm 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "xcm-builder",
- "xcm-executor",
+ "xcm-executor 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
 ]
 
 [[package]]
 name = "kusama-runtime-constants"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "frame-support",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "polkadot-runtime-common",
  "smallvec",
  "sp-core",
@@ -5569,7 +5569,7 @@ dependencies = [
 [[package]]
 name = "mmr-gadget"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "futures",
  "log",
@@ -5588,7 +5588,7 @@ dependencies = [
 [[package]]
 name = "mmr-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "anyhow",
  "jsonrpsee",
@@ -6157,7 +6157,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6173,7 +6173,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6187,7 +6187,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6211,7 +6211,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6231,7 +6231,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6246,7 +6246,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6265,7 +6265,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "array-bytes 4.2.0",
  "binary-merkle-tree",
@@ -6289,7 +6289,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6307,7 +6307,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6351,7 +6351,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6421,7 +6421,7 @@ dependencies = [
 [[package]]
 name = "pallet-conviction-voting"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -6438,7 +6438,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6456,7 +6456,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6479,7 +6479,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6492,7 +6492,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "5.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6510,7 +6510,7 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6528,7 +6528,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6551,7 +6551,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -6567,7 +6567,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6587,7 +6587,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6618,7 +6618,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6635,7 +6635,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6652,7 +6652,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6697,7 +6697,7 @@ dependencies = [
 [[package]]
 name = "pallet-nis"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6713,7 +6713,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6730,7 +6730,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6750,7 +6750,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
 version = "1.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
@@ -6761,7 +6761,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6778,7 +6778,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6802,7 +6802,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6819,7 +6819,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6834,7 +6834,7 @@ dependencies = [
 [[package]]
 name = "pallet-ranked-collective"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6852,7 +6852,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6867,7 +6867,7 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -6886,7 +6886,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6903,7 +6903,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6924,7 +6924,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6940,7 +6940,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6954,7 +6954,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6977,7 +6977,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -6988,7 +6988,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -6997,7 +6997,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7006,7 +7006,7 @@ dependencies = [
 [[package]]
 name = "pallet-state-trie-migration"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7023,7 +7023,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7052,7 +7052,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7070,7 +7070,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7089,7 +7089,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7105,7 +7105,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -7121,7 +7121,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -7133,7 +7133,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7165,7 +7165,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7181,7 +7181,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7196,7 +7196,7 @@ dependencies = [
 [[package]]
 name = "pallet-whitelist"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7211,7 +7211,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "bounded-collections",
  "frame-benchmarking",
@@ -7225,14 +7225,14 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "xcm",
- "xcm-executor",
+ "xcm 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "xcm-executor 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
 ]
 
 [[package]]
 name = "pallet-xcm-benchmarks"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7243,9 +7243,9 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
- "xcm",
+ "xcm 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "xcm-builder",
- "xcm-executor",
+ "xcm-executor 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
 ]
 
 [[package]]
@@ -7280,7 +7280,7 @@ dependencies = [
  "parachain-template-runtime",
  "parity-scale-codec",
  "polkadot-cli",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "sc-basic-authorship",
  "sc-chain-spec",
  "sc-cli",
@@ -7310,7 +7310,7 @@ dependencies = [
  "substrate-frame-rpc-system",
  "substrate-prometheus-endpoint",
  "try-runtime-cli",
- "xcm",
+ "xcm 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
 ]
 
 [[package]]
@@ -7348,7 +7348,7 @@ dependencies = [
  "pallet-xcm",
  "parachain-info",
  "parity-scale-codec",
- "polkadot-parachain",
+ "polkadot-parachain 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "polkadot-runtime-common",
  "scale-info",
  "smallvec",
@@ -7364,9 +7364,9 @@ dependencies = [
  "sp-transaction-pool",
  "sp-version",
  "substrate-wasm-builder",
- "xcm",
+ "xcm 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "xcm-builder",
- "xcm-executor",
+ "xcm-executor 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
 ]
 
 [[package]]
@@ -7382,7 +7382,7 @@ dependencies = [
  "pallet-balances",
  "pallet-collator-selection",
  "parity-scale-codec",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "scale-info",
  "sp-consensus-aura",
  "sp-core",
@@ -7390,9 +7390,9 @@ dependencies = [
  "sp-runtime",
  "sp-std",
  "substrate-wasm-builder",
- "xcm",
+ "xcm 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "xcm-builder",
- "xcm-executor",
+ "xcm-executor 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
 ]
 
 [[package]]
@@ -7510,9 +7510,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.6"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0744126afe1a6dd7f394cb50a716dbe086cb06e255e53d8d0185d82828358fb5"
+checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
 
 [[package]]
 name = "pbkdf2"
@@ -7593,8 +7593,8 @@ dependencies = [
  "parachain-info",
  "parachains-common",
  "parity-scale-codec",
- "polkadot-parachain",
- "polkadot-primitives",
+ "polkadot-parachain 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "polkadot-runtime-common",
  "scale-info",
  "smallvec",
@@ -7610,9 +7610,9 @@ dependencies = [
  "sp-transaction-pool",
  "sp-version",
  "substrate-wasm-builder",
- "xcm",
+ "xcm 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "xcm-builder",
- "xcm-executor",
+ "xcm-executor 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
 ]
 
 [[package]]
@@ -7781,7 +7781,7 @@ dependencies = [
 [[package]]
 name = "polkadot-approval-distribution"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "futures",
  "polkadot-node-jaeger",
@@ -7789,7 +7789,7 @@ dependencies = [
  "polkadot-node-network-protocol",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "rand 0.8.5",
  "tracing-gum",
 ]
@@ -7797,13 +7797,13 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "futures",
  "polkadot-node-network-protocol",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "rand 0.8.5",
  "tracing-gum",
 ]
@@ -7811,7 +7811,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-distribution"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "derive_more",
  "fatality",
@@ -7823,7 +7823,7 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "rand 0.8.5",
  "sp-core",
  "sp-keystore",
@@ -7834,7 +7834,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-recovery"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "fatality",
  "futures",
@@ -7845,7 +7845,7 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "rand 0.8.5",
  "sc-network",
  "thiserror",
@@ -7855,7 +7855,7 @@ dependencies = [
 [[package]]
 name = "polkadot-cli"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "clap 4.1.14",
  "frame-benchmarking-cli",
@@ -7883,7 +7883,7 @@ dependencies = [
 [[package]]
 name = "polkadot-client"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -7893,9 +7893,9 @@ dependencies = [
  "futures",
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
- "polkadot-core-primitives",
+ "polkadot-core-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "polkadot-node-core-parachains-inherent",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "polkadot-runtime",
  "polkadot-runtime-common",
  "rococo-runtime",
@@ -7926,7 +7926,7 @@ dependencies = [
 [[package]]
 name = "polkadot-collator-protocol"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "always-assert",
  "bitvec",
@@ -7937,7 +7937,7 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "sp-core",
  "sp-keystore",
  "sp-runtime",
@@ -7948,7 +7948,19 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "polkadot-core-primitives"
+version = "0.9.39"
+source = "git+https://github.com/paritytech/polkadot?branch=ru/feature/xcm-emulator#1ed7fa798986dcc5d785d7e567568a70481d26c6"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -7960,7 +7972,7 @@ dependencies = [
 [[package]]
 name = "polkadot-dispute-distribution"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "derive_more",
  "fatality",
@@ -7974,7 +7986,7 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "sc-network",
  "sp-application-crypto",
  "sp-keystore",
@@ -7985,11 +7997,11 @@ dependencies = [
 [[package]]
 name = "polkadot-erasure-coding"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "reed-solomon-novelpoly",
  "sp-core",
  "sp-trie",
@@ -7999,14 +8011,14 @@ dependencies = [
 [[package]]
 name = "polkadot-gossip-support"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "futures",
  "futures-timer",
  "polkadot-node-network-protocol",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "sc-network",
@@ -8019,7 +8031,7 @@ dependencies = [
 [[package]]
 name = "polkadot-network-bridge"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "always-assert",
  "async-trait",
@@ -8032,7 +8044,7 @@ dependencies = [
  "polkadot-node-network-protocol",
  "polkadot-node-subsystem",
  "polkadot-overseer",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "sc-network",
  "sp-consensus",
  "thiserror",
@@ -8042,7 +8054,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-collation-generation"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -8050,7 +8062,7 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "sp-core",
  "sp-maybe-compressed-blob",
  "thiserror",
@@ -8060,7 +8072,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "bitvec",
  "derive_more",
@@ -8075,7 +8087,7 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-overseer",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "sc-keystore",
  "schnorrkel",
  "sp-application-crypto",
@@ -8089,7 +8101,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-av-store"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "bitvec",
  "futures",
@@ -8101,7 +8113,7 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-overseer",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "sp-consensus",
  "thiserror",
  "tracing-gum",
@@ -8110,7 +8122,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-backing"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "bitvec",
  "fatality",
@@ -8119,7 +8131,7 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "polkadot-statement-table",
  "sp-keystore",
  "thiserror",
@@ -8129,12 +8141,12 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "sp-keystore",
  "thiserror",
  "tracing-gum",
@@ -8144,7 +8156,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-candidate-validation"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "async-trait",
  "futures",
@@ -8155,8 +8167,8 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-parachain",
- "polkadot-primitives",
+ "polkadot-parachain 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "sp-maybe-compressed-blob",
  "tracing-gum",
 ]
@@ -8164,12 +8176,12 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-api"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
  "polkadot-node-subsystem",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "sc-client-api",
  "sc-consensus-babe",
  "sp-blockchain",
@@ -8179,7 +8191,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-selection"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "futures",
  "futures-timer",
@@ -8188,7 +8200,7 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "thiserror",
  "tracing-gum",
 ]
@@ -8196,7 +8208,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "fatality",
  "futures",
@@ -8206,7 +8218,7 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "sc-keystore",
  "thiserror",
  "tracing-gum",
@@ -8215,14 +8227,14 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "async-trait",
  "futures",
  "futures-timer",
  "polkadot-node-subsystem",
  "polkadot-overseer",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "sp-blockchain",
  "sp-inherents",
  "thiserror",
@@ -8232,7 +8244,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-provisioner"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "bitvec",
  "fatality",
@@ -8241,7 +8253,7 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "rand 0.8.5",
  "thiserror",
  "tracing-gum",
@@ -8250,7 +8262,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "always-assert",
  "assert_matches",
@@ -8260,11 +8272,11 @@ dependencies = [
  "libc",
  "parity-scale-codec",
  "pin-project",
- "polkadot-core-primitives",
+ "polkadot-core-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "polkadot-node-metrics",
  "polkadot-node-primitives",
- "polkadot-parachain",
- "polkadot-primitives",
+ "polkadot-parachain 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "rand 0.8.5",
  "rayon",
  "sc-executor",
@@ -8287,14 +8299,14 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-checker"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "futures",
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-overseer",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "sp-keystore",
  "thiserror",
  "tracing-gum",
@@ -8303,14 +8315,14 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-runtime-api"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "futures",
  "lru 0.9.0",
  "polkadot-node-metrics",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-types",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "sp-consensus-babe",
  "tracing-gum",
 ]
@@ -8318,7 +8330,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-jaeger"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "lazy_static",
  "log",
@@ -8326,7 +8338,7 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "polkadot-node-primitives",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "sc-network",
  "sp-core",
  "thiserror",
@@ -8336,14 +8348,14 @@ dependencies = [
 [[package]]
 name = "polkadot-node-metrics"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "bs58",
  "futures",
  "futures-timer",
  "log",
  "parity-scale-codec",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "prioritized-metered-channel",
  "sc-cli",
  "sc-service",
@@ -8355,7 +8367,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -8365,7 +8377,7 @@ dependencies = [
  "parity-scale-codec",
  "polkadot-node-jaeger",
  "polkadot-node-primitives",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "rand 0.8.5",
  "sc-authority-discovery",
  "sc-network",
@@ -8377,13 +8389,13 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "bounded-vec",
  "futures",
  "parity-scale-codec",
- "polkadot-parachain",
- "polkadot-primitives",
+ "polkadot-parachain 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "schnorrkel",
  "serde",
  "sp-application-crypto",
@@ -8400,7 +8412,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "polkadot-node-jaeger",
  "polkadot-node-subsystem-types",
@@ -8410,14 +8422,14 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-test-helpers"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "async-trait",
  "futures",
  "parking_lot 0.12.1",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "sc-keystore",
  "sp-application-crypto",
  "sp-core",
@@ -8428,7 +8440,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-types"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -8437,7 +8449,7 @@ dependencies = [
  "polkadot-node-jaeger",
  "polkadot-node-network-protocol",
  "polkadot-node-primitives",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "polkadot-statement-table",
  "sc-network",
  "smallvec",
@@ -8451,7 +8463,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-util"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -8471,7 +8483,7 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-overseer",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "prioritized-metered-channel",
  "rand 0.8.5",
  "sp-application-crypto",
@@ -8484,7 +8496,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "async-trait",
  "futures",
@@ -8496,7 +8508,7 @@ dependencies = [
  "polkadot-node-network-protocol",
  "polkadot-node-primitives",
  "polkadot-node-subsystem-types",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "sc-client-api",
  "sp-api",
  "sp-core",
@@ -8507,13 +8519,30 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "bounded-collections",
  "derive_more",
  "frame-support",
  "parity-scale-codec",
- "polkadot-core-primitives",
+ "polkadot-core-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "scale-info",
+ "serde",
+ "sp-core",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "polkadot-parachain"
+version = "0.9.39"
+source = "git+https://github.com/paritytech/polkadot?branch=ru/feature/xcm-emulator#1ed7fa798986dcc5d785d7e567568a70481d26c6"
+dependencies = [
+ "bounded-collections",
+ "derive_more",
+ "frame-support",
+ "parity-scale-codec",
+ "polkadot-core-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=ru/feature/xcm-emulator)",
  "scale-info",
  "serde",
  "sp-core",
@@ -8554,7 +8583,7 @@ dependencies = [
  "parity-scale-codec",
  "penpal-runtime",
  "polkadot-cli",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "polkadot-service",
  "rococo-parachain-runtime",
  "sc-basic-authorship",
@@ -8599,13 +8628,13 @@ dependencies = [
  "try-runtime-cli",
  "wait-timeout",
  "westmint-runtime",
- "xcm",
+ "xcm 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
 ]
 
 [[package]]
 name = "polkadot-performance-test"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "env_logger 0.9.0",
  "kusama-runtime",
@@ -8613,7 +8642,7 @@ dependencies = [
  "polkadot-erasure-coding",
  "polkadot-node-core-pvf",
  "polkadot-node-primitives",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "quote",
  "thiserror",
 ]
@@ -8621,13 +8650,39 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "bitvec",
  "hex-literal 0.3.4",
  "parity-scale-codec",
- "polkadot-core-primitives",
- "polkadot-parachain",
+ "polkadot-core-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "polkadot-parachain 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "scale-info",
+ "serde",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-arithmetic",
+ "sp-authority-discovery",
+ "sp-consensus-slots",
+ "sp-core",
+ "sp-inherents",
+ "sp-io",
+ "sp-keystore",
+ "sp-runtime",
+ "sp-staking",
+ "sp-std",
+]
+
+[[package]]
+name = "polkadot-primitives"
+version = "0.9.39"
+source = "git+https://github.com/paritytech/polkadot?branch=ru/feature/xcm-emulator#1ed7fa798986dcc5d785d7e567568a70481d26c6"
+dependencies = [
+ "bitvec",
+ "hex-literal 0.3.4",
+ "parity-scale-codec",
+ "polkadot-core-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=ru/feature/xcm-emulator)",
+ "polkadot-parachain 0.9.39 (git+https://github.com/paritytech/polkadot?branch=ru/feature/xcm-emulator)",
  "scale-info",
  "serde",
  "sp-api",
@@ -8647,12 +8702,12 @@ dependencies = [
 [[package]]
 name = "polkadot-rpc"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "jsonrpsee",
  "mmr-rpc",
  "pallet-transaction-payment-rpc",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "sc-chain-spec",
  "sc-client-api",
  "sc-consensus-babe",
@@ -8679,7 +8734,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -8736,10 +8791,10 @@ dependencies = [
  "pallet-whitelist",
  "pallet-xcm",
  "parity-scale-codec",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "polkadot-runtime-common",
  "polkadot-runtime-constants",
- "polkadot-runtime-parachains",
+ "polkadot-runtime-parachains 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "rustc-hex",
  "scale-info",
  "serde",
@@ -8765,15 +8820,15 @@ dependencies = [
  "sp-version",
  "static_assertions",
  "substrate-wasm-builder",
- "xcm",
+ "xcm 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "xcm-builder",
- "xcm-executor",
+ "xcm-executor 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
 ]
 
 [[package]]
 name = "polkadot-runtime-common"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -8796,8 +8851,8 @@ dependencies = [
  "pallet-treasury",
  "pallet-vesting",
  "parity-scale-codec",
- "polkadot-primitives",
- "polkadot-runtime-parachains",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "polkadot-runtime-parachains 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "rustc-hex",
  "scale-info",
  "serde",
@@ -8813,16 +8868,16 @@ dependencies = [
  "sp-staking",
  "sp-std",
  "static_assertions",
- "xcm",
+ "xcm 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
 ]
 
 [[package]]
 name = "polkadot-runtime-constants"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "frame-support",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "polkadot-runtime-common",
  "smallvec",
  "sp-core",
@@ -8833,11 +8888,23 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "bs58",
  "parity-scale-codec",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "sp-std",
+ "sp-tracing",
+]
+
+[[package]]
+name = "polkadot-runtime-metrics"
+version = "0.9.39"
+source = "git+https://github.com/paritytech/polkadot?branch=ru/feature/xcm-emulator#1ed7fa798986dcc5d785d7e567568a70481d26c6"
+dependencies = [
+ "bs58",
+ "parity-scale-codec",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=ru/feature/xcm-emulator)",
  "sp-std",
  "sp-tracing",
 ]
@@ -8845,7 +8912,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "bitflags",
  "bitvec",
@@ -8863,9 +8930,9 @@ dependencies = [
  "pallet-timestamp",
  "pallet-vesting",
  "parity-scale-codec",
- "polkadot-parachain",
- "polkadot-primitives",
- "polkadot-runtime-metrics",
+ "polkadot-parachain 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "polkadot-runtime-metrics 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rustc-hex",
@@ -8882,14 +8949,55 @@ dependencies = [
  "sp-staking",
  "sp-std",
  "static_assertions",
- "xcm",
- "xcm-executor",
+ "xcm 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "xcm-executor 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+]
+
+[[package]]
+name = "polkadot-runtime-parachains"
+version = "0.9.39"
+source = "git+https://github.com/paritytech/polkadot?branch=ru/feature/xcm-emulator#1ed7fa798986dcc5d785d7e567568a70481d26c6"
+dependencies = [
+ "bitflags",
+ "bitvec",
+ "derive_more",
+ "frame-support",
+ "frame-system",
+ "log",
+ "pallet-authority-discovery",
+ "pallet-authorship",
+ "pallet-babe",
+ "pallet-balances",
+ "pallet-session",
+ "pallet-staking",
+ "pallet-timestamp",
+ "pallet-vesting",
+ "parity-scale-codec",
+ "polkadot-parachain 0.9.39 (git+https://github.com/paritytech/polkadot?branch=ru/feature/xcm-emulator)",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=ru/feature/xcm-emulator)",
+ "polkadot-runtime-metrics 0.9.39 (git+https://github.com/paritytech/polkadot?branch=ru/feature/xcm-emulator)",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rustc-hex",
+ "scale-info",
+ "serde",
+ "sp-api",
+ "sp-core",
+ "sp-inherents",
+ "sp-io",
+ "sp-keystore",
+ "sp-runtime",
+ "sp-session",
+ "sp-staking",
+ "sp-std",
+ "xcm 0.9.39 (git+https://github.com/paritytech/polkadot?branch=ru/feature/xcm-emulator)",
+ "xcm-executor 0.9.39 (git+https://github.com/paritytech/polkadot?branch=ru/feature/xcm-emulator)",
 ]
 
 [[package]]
 name = "polkadot-service"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "async-trait",
  "frame-benchmarking-cli",
@@ -8936,12 +9044,12 @@ dependencies = [
  "polkadot-node-subsystem-types",
  "polkadot-node-subsystem-util",
  "polkadot-overseer",
- "polkadot-parachain",
- "polkadot-primitives",
+ "polkadot-parachain 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "polkadot-rpc",
  "polkadot-runtime",
  "polkadot-runtime-constants",
- "polkadot-runtime-parachains",
+ "polkadot-runtime-parachains 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "polkadot-statement-distribution",
  "rococo-runtime",
  "rococo-runtime-constants",
@@ -8999,7 +9107,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-distribution"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "arrayvec 0.5.2",
  "fatality",
@@ -9010,7 +9118,7 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "sp-keystore",
  "sp-staking",
  "thiserror",
@@ -9020,21 +9128,21 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "parity-scale-codec",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "sp-core",
 ]
 
 [[package]]
 name = "polkadot-test-client"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-subsystem",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "polkadot-test-runtime",
  "polkadot-test-service",
  "sc-block-builder",
@@ -9055,7 +9163,7 @@ dependencies = [
 [[package]]
 name = "polkadot-test-runtime"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "bitvec",
  "frame-election-provider-support",
@@ -9081,10 +9189,10 @@ dependencies = [
  "pallet-vesting",
  "pallet-xcm",
  "parity-scale-codec",
- "polkadot-parachain",
- "polkadot-primitives",
+ "polkadot-parachain 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "polkadot-runtime-common",
- "polkadot-runtime-parachains",
+ "polkadot-runtime-parachains 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "rustc-hex",
  "scale-info",
  "serde",
@@ -9108,15 +9216,15 @@ dependencies = [
  "sp-version",
  "substrate-wasm-builder",
  "test-runtime-constants",
- "xcm",
+ "xcm 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "xcm-builder",
- "xcm-executor",
+ "xcm-executor 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
 ]
 
 [[package]]
 name = "polkadot-test-service"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "frame-benchmarking",
  "frame-system",
@@ -9128,11 +9236,11 @@ dependencies = [
  "polkadot-node-primitives",
  "polkadot-node-subsystem",
  "polkadot-overseer",
- "polkadot-parachain",
- "polkadot-primitives",
+ "polkadot-parachain 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "polkadot-rpc",
  "polkadot-runtime-common",
- "polkadot-runtime-parachains",
+ "polkadot-runtime-parachains 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "polkadot-service",
  "polkadot-test-runtime",
  "rand 0.8.5",
@@ -9850,7 +9958,7 @@ dependencies = [
  "parachain-info",
  "parachains-common",
  "parity-scale-codec",
- "polkadot-parachain",
+ "polkadot-parachain 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "scale-info",
  "sp-api",
  "sp-block-builder",
@@ -9864,15 +9972,15 @@ dependencies = [
  "sp-transaction-pool",
  "sp-version",
  "substrate-wasm-builder",
- "xcm",
+ "xcm 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "xcm-builder",
- "xcm-executor",
+ "xcm-executor 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
 ]
 
 [[package]]
 name = "rococo-runtime"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "binary-merkle-tree",
  "frame-benchmarking",
@@ -9923,10 +10031,10 @@ dependencies = [
  "pallet-xcm",
  "pallet-xcm-benchmarks",
  "parity-scale-codec",
- "polkadot-parachain",
- "polkadot-primitives",
+ "polkadot-parachain 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "polkadot-runtime-common",
- "polkadot-runtime-parachains",
+ "polkadot-runtime-parachains 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "rococo-runtime-constants",
  "scale-info",
  "serde",
@@ -9950,18 +10058,18 @@ dependencies = [
  "sp-version",
  "static_assertions",
  "substrate-wasm-builder",
- "xcm",
+ "xcm 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "xcm-builder",
- "xcm-executor",
+ "xcm-executor 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
 ]
 
 [[package]]
 name = "rococo-runtime-constants"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "frame-support",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "polkadot-runtime-common",
  "smallvec",
  "sp-core",
@@ -10205,7 +10313,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "4.1.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "log",
  "sp-core",
@@ -10216,7 +10324,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "async-trait",
  "futures",
@@ -10244,7 +10352,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "futures",
  "futures-timer",
@@ -10267,7 +10375,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -10282,7 +10390,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "memmap2",
  "sc-chain-spec-derive",
@@ -10301,7 +10409,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -10312,7 +10420,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "array-bytes 4.2.0",
  "chrono",
@@ -10352,7 +10460,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "fnv",
  "futures",
@@ -10378,7 +10486,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -10404,7 +10512,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "async-trait",
  "futures",
@@ -10458,7 +10566,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -10497,7 +10605,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -10519,7 +10627,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "array-bytes 4.2.0",
  "async-trait",
@@ -10554,7 +10662,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -10573,7 +10681,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -10586,7 +10694,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "ahash 0.8.2",
  "array-bytes 4.2.0",
@@ -10626,7 +10734,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "finality-grandpa",
  "futures",
@@ -10646,7 +10754,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "async-trait",
  "futures",
@@ -10669,7 +10777,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "lru 0.8.1",
  "parity-scale-codec",
@@ -10693,7 +10801,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "sc-allocator",
  "sp-maybe-compressed-blob",
@@ -10706,7 +10814,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "log",
  "sc-allocator",
@@ -10719,7 +10827,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -10737,7 +10845,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "ansi_term",
  "futures",
@@ -10753,7 +10861,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "array-bytes 4.2.0",
  "async-trait",
@@ -10768,7 +10876,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "array-bytes 4.2.0",
  "async-channel",
@@ -10813,7 +10921,7 @@ dependencies = [
 [[package]]
 name = "sc-network-bitswap"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "cid",
  "futures",
@@ -10833,7 +10941,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "array-bytes 4.2.0",
  "async-trait",
@@ -10861,7 +10969,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "ahash 0.8.2",
  "futures",
@@ -10880,7 +10988,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "array-bytes 4.2.0",
  "futures",
@@ -10902,7 +11010,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "array-bytes 4.2.0",
  "async-trait",
@@ -10936,7 +11044,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "array-bytes 4.2.0",
  "futures",
@@ -10956,7 +11064,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "array-bytes 4.2.0",
  "bytes",
@@ -10987,7 +11095,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "futures",
  "libp2p",
@@ -11000,7 +11108,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -11009,7 +11117,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -11039,7 +11147,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -11058,7 +11166,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "http",
  "jsonrpsee",
@@ -11073,7 +11181,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "array-bytes 4.2.0",
  "futures",
@@ -11099,7 +11207,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "async-trait",
  "directories",
@@ -11165,7 +11273,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -11176,7 +11284,7 @@ dependencies = [
 [[package]]
 name = "sc-storage-monitor"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "clap 4.1.14",
  "fs4",
@@ -11192,7 +11300,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -11211,7 +11319,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "6.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "futures",
  "libc",
@@ -11230,7 +11338,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "chrono",
  "futures",
@@ -11249,7 +11357,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "ansi_term",
  "atty",
@@ -11280,7 +11388,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -11291,7 +11399,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "async-trait",
  "futures",
@@ -11318,7 +11426,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "async-trait",
  "futures",
@@ -11332,7 +11440,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "async-channel",
  "futures",
@@ -11739,9 +11847,9 @@ dependencies = [
  "sp-transaction-pool",
  "sp-version",
  "substrate-wasm-builder",
- "xcm",
+ "xcm 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "xcm-builder",
- "xcm-executor",
+ "xcm-executor 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
 ]
 
 [[package]]
@@ -11813,7 +11921,7 @@ checksum = "03b634d87b960ab1a38c4fe143b508576f075e7c978bfad18217645ebfdfa2ec"
 [[package]]
 name = "slot-range-helper"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -11890,7 +11998,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "hash-db",
  "log",
@@ -11908,7 +12016,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "Inflector",
  "blake2",
@@ -11922,7 +12030,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11935,7 +12043,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -11949,7 +12057,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -11962,7 +12070,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -11974,7 +12082,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "futures",
  "log",
@@ -11992,7 +12100,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "async-trait",
  "futures",
@@ -12007,7 +12115,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -12025,7 +12133,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "async-trait",
  "merlin",
@@ -12048,7 +12156,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-beefy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "lazy_static",
  "parity-scale-codec",
@@ -12067,7 +12175,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -12085,7 +12193,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12097,7 +12205,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-vrf"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12110,7 +12218,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "array-bytes 4.2.0",
  "bitflags",
@@ -12153,7 +12261,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -12167,7 +12275,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12178,7 +12286,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.1",
@@ -12187,7 +12295,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12197,7 +12305,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.13.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -12208,7 +12316,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -12223,7 +12331,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "bytes",
  "ed25519",
@@ -12249,7 +12357,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -12260,7 +12368,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.13.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "futures",
  "merlin",
@@ -12276,7 +12384,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "4.1.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "thiserror",
  "zstd",
@@ -12285,7 +12393,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "ckb-merkle-mountain-range",
  "log",
@@ -12303,7 +12411,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12317,7 +12425,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -12327,7 +12435,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -12337,7 +12445,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -12347,7 +12455,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -12369,7 +12477,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -12387,7 +12495,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -12408,7 +12516,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12422,7 +12530,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12434,7 +12542,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.13.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "hash-db",
  "log",
@@ -12454,12 +12562,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 
 [[package]]
 name = "sp-storage"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -12472,7 +12580,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "async-trait",
  "futures-timer",
@@ -12487,7 +12595,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "parity-scale-codec",
  "sp-std",
@@ -12499,7 +12607,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -12508,7 +12616,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "async-trait",
  "log",
@@ -12524,7 +12632,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "ahash 0.8.2",
  "hash-db",
@@ -12547,7 +12655,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -12564,7 +12672,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -12575,7 +12683,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -12589,7 +12697,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12701,8 +12809,8 @@ dependencies = [
  "parachain-info",
  "parachains-common",
  "parity-scale-codec",
- "polkadot-core-primitives",
- "polkadot-parachain",
+ "polkadot-core-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "polkadot-parachain 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "polkadot-runtime-common",
  "scale-info",
  "smallvec",
@@ -12719,9 +12827,9 @@ dependencies = [
  "sp-version",
  "sp-weights",
  "substrate-wasm-builder",
- "xcm",
+ "xcm 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "xcm-builder",
- "xcm-executor",
+ "xcm-executor 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
 ]
 
 [[package]]
@@ -12767,8 +12875,8 @@ dependencies = [
  "parachain-info",
  "parachains-common",
  "parity-scale-codec",
- "polkadot-core-primitives",
- "polkadot-parachain",
+ "polkadot-core-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "polkadot-parachain 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "polkadot-runtime-common",
  "polkadot-runtime-constants",
  "scale-info",
@@ -12786,9 +12894,34 @@ dependencies = [
  "sp-version",
  "sp-weights",
  "substrate-wasm-builder",
- "xcm",
+ "xcm 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "xcm-builder",
- "xcm-executor",
+ "xcm-executor 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+]
+
+[[package]]
+name = "statemint-runtime-integration-tests"
+version = "1.0.0"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "pallet-assets",
+ "pallet-balances",
+ "pallet-xcm",
+ "parachains-common",
+ "parity-scale-codec",
+ "penpal-runtime",
+ "polkadot-core-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "polkadot-parachain 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "polkadot-runtime",
+ "polkadot-runtime-parachains 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "sp-core",
+ "sp-runtime",
+ "sp-weights",
+ "statemint-runtime",
+ "xcm 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "xcm-emulator",
+ "xcm-executor 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
 ]
 
 [[package]]
@@ -12913,7 +13046,7 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "platforms 2.0.0",
 ]
@@ -12921,7 +13054,7 @@ dependencies = [
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures",
@@ -12940,7 +13073,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#72dd574acf805fda1dc1e64b7bbd510e12a81312"
 dependencies = [
  "hyper",
  "log",
@@ -12952,7 +13085,7 @@ dependencies = [
 [[package]]
 name = "substrate-rpc-client"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "async-trait",
  "jsonrpsee",
@@ -12965,7 +13098,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-trie-migration-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "jsonrpsee",
  "log",
@@ -12984,7 +13117,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "array-bytes 4.2.0",
  "async-trait",
@@ -13031,7 +13164,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "5.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "ansi_term",
  "build-helper",
@@ -13158,10 +13291,10 @@ checksum = "13a4ec180a2de59b57434704ccfad967f789b12737738798fa08798cd5824c16"
 [[package]]
 name = "test-runtime-constants"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "frame-support",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "polkadot-runtime-common",
  "smallvec",
  "sp-core",
@@ -13548,10 +13681,10 @@ dependencies = [
 [[package]]
 name = "tracing-gum"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "polkadot-node-jaeger",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "tracing",
  "tracing-gum-proc-macro",
 ]
@@ -13559,7 +13692,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "expander 0.0.6",
  "proc-macro-crate",
@@ -13689,7 +13822,7 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 [[package]]
 name = "try-runtime-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#7bbfe737a180e548ace7e819099dcb62cf48fa11"
+source = "git+https://github.com/paritytech/substrate?branch=master#d443f148ce0aa6a51798b86c6b3ae54113786f94"
 dependencies = [
  "async-trait",
  "clap 4.1.14",
@@ -14617,7 +14750,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -14673,10 +14806,10 @@ dependencies = [
  "pallet-xcm",
  "pallet-xcm-benchmarks",
  "parity-scale-codec",
- "polkadot-parachain",
- "polkadot-primitives",
+ "polkadot-parachain 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "polkadot-runtime-common",
- "polkadot-runtime-parachains",
+ "polkadot-runtime-parachains 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "rustc-hex",
  "scale-info",
  "serde",
@@ -14701,18 +14834,18 @@ dependencies = [
  "sp-version",
  "substrate-wasm-builder",
  "westend-runtime-constants",
- "xcm",
+ "xcm 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "xcm-builder",
- "xcm-executor",
+ "xcm-executor 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
 ]
 
 [[package]]
 name = "westend-runtime-constants"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "frame-support",
- "polkadot-primitives",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "polkadot-runtime-common",
  "smallvec",
  "sp-core",
@@ -14765,8 +14898,8 @@ dependencies = [
  "parachain-info",
  "parachains-common",
  "parity-scale-codec",
- "polkadot-core-primitives",
- "polkadot-parachain",
+ "polkadot-core-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "polkadot-parachain 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "polkadot-runtime-common",
  "scale-info",
  "smallvec",
@@ -14783,9 +14916,9 @@ dependencies = [
  "sp-version",
  "substrate-wasm-builder",
  "westend-runtime-constants",
- "xcm",
+ "xcm 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "xcm-builder",
- "xcm-executor",
+ "xcm-executor 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
 ]
 
 [[package]]
@@ -15145,7 +15278,7 @@ dependencies = [
 [[package]]
 name = "xcm"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "bounded-collections",
  "derivative",
@@ -15155,13 +15288,29 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-weights",
- "xcm-procedural",
+ "xcm-procedural 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+]
+
+[[package]]
+name = "xcm"
+version = "0.9.39"
+source = "git+https://github.com/paritytech/polkadot?branch=ru/feature/xcm-emulator#1ed7fa798986dcc5d785d7e567568a70481d26c6"
+dependencies = [
+ "bounded-collections",
+ "derivative",
+ "impl-trait-for-tuples",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-weights",
+ "xcm-procedural 0.9.39 (git+https://github.com/paritytech/polkadot?branch=ru/feature/xcm-emulator)",
 ]
 
 [[package]]
 name = "xcm-builder"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -15169,20 +15318,46 @@ dependencies = [
  "log",
  "pallet-transaction-payment",
  "parity-scale-codec",
- "polkadot-parachain",
+ "polkadot-parachain 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
  "scale-info",
  "sp-arithmetic",
  "sp-io",
  "sp-runtime",
  "sp-std",
- "xcm",
- "xcm-executor",
+ "xcm 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+ "xcm-executor 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+]
+
+[[package]]
+name = "xcm-emulator"
+version = "0.9.39"
+source = "git+https://github.com/paritytech/polkadot?branch=ru/feature/xcm-emulator#1ed7fa798986dcc5d785d7e567568a70481d26c6"
+dependencies = [
+ "cumulus-pallet-dmp-queue",
+ "cumulus-pallet-parachain-system",
+ "cumulus-pallet-xcmp-queue",
+ "cumulus-primitives-core",
+ "cumulus-primitives-parachain-inherent",
+ "cumulus-test-relay-sproof-builder",
+ "frame-support",
+ "frame-system",
+ "parachain-info",
+ "parity-scale-codec",
+ "paste",
+ "polkadot-primitives 0.9.39 (git+https://github.com/paritytech/polkadot?branch=ru/feature/xcm-emulator)",
+ "polkadot-runtime-parachains 0.9.39 (git+https://github.com/paritytech/polkadot?branch=ru/feature/xcm-emulator)",
+ "quote",
+ "sp-arithmetic",
+ "sp-io",
+ "sp-std",
+ "xcm 0.9.39 (git+https://github.com/paritytech/polkadot?branch=ru/feature/xcm-emulator)",
+ "xcm-executor 0.9.39 (git+https://github.com/paritytech/polkadot?branch=ru/feature/xcm-emulator)",
 ]
 
 [[package]]
 name = "xcm-executor"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -15196,13 +15371,43 @@ dependencies = [
  "sp-runtime",
  "sp-std",
  "sp-weights",
- "xcm",
+ "xcm 0.9.39 (git+https://github.com/paritytech/polkadot?branch=master)",
+]
+
+[[package]]
+name = "xcm-executor"
+version = "0.9.39"
+source = "git+https://github.com/paritytech/polkadot?branch=ru/feature/xcm-emulator#1ed7fa798986dcc5d785d7e567568a70481d26c6"
+dependencies = [
+ "environmental",
+ "frame-support",
+ "impl-trait-for-tuples",
+ "log",
+ "parity-scale-codec",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+ "sp-weights",
+ "xcm 0.9.39 (git+https://github.com/paritytech/polkadot?branch=ru/feature/xcm-emulator)",
 ]
 
 [[package]]
 name = "xcm-procedural"
 version = "0.9.39"
-source = "git+https://github.com/paritytech/polkadot?branch=master#dc230b323b5baeb9b4297430ed539b208d30bf6a"
+source = "git+https://github.com/paritytech/polkadot?branch=master#173a5a325177dd63ae32b55e11a35df5fb29163e"
+dependencies = [
+ "Inflector",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "xcm-procedural"
+version = "0.9.39"
+source = "git+https://github.com/paritytech/polkadot?branch=ru/feature/xcm-emulator#1ed7fa798986dcc5d785d7e567568a70481d26c6"
 dependencies = [
  "Inflector",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ members = [
 	"parachains/runtimes/starters/seedling",
 	"parachains/runtimes/assets/common",
 	"parachains/runtimes/assets/statemint",
+	"parachains/runtimes/assets/integration-tests",
 	"parachains/runtimes/assets/statemine",
 	"parachains/runtimes/assets/westmint",
 	"parachains/runtimes/bridge-hubs/bridge-hub-rococo",
@@ -61,3 +62,12 @@ inherits = "release"
 lto = true
 codegen-units = 1
 
+# make sure xcm-emulator works as otherwise it depends on cumulus master
+[patch.'https://github.com/paritytech/cumulus']
+cumulus-primitives-core = { path = "primitives/core" }
+cumulus-pallet-xcmp-queue = { path = "pallets/xcmp-queue" }
+cumulus-pallet-dmp-queue = { path = "pallets/dmp-queue" }
+cumulus-pallet-parachain-system = { path = "pallets/parachain-system"}
+parachain-info = { path = "parachains/pallets/parachain-info"}
+cumulus-primitives-parachain-inherent = { path = "primitives/parachain-inherent"}
+cumulus-test-relay-sproof-builder = { path = "test/relay-sproof-builder" }

--- a/parachains/runtimes/assets/integration-tests/Cargo.toml
+++ b/parachains/runtimes/assets/integration-tests/Cargo.toml
@@ -6,23 +6,26 @@ edition = "2021"
 description = "Statemint parachain runtime integration tests"
 
 [dev-dependencies]
+codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false }
+
 xcm-emulator = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "ru/feature/xcm-emulator" }
-polkadot-runtime = { git = "https://github.com/paritytech/polkadot", branch = "master" }
+pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
+pallet-assets = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
+polkadot-core-primitives = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "master" }
+polkadot-parachain = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "master" }
 polkadot-runtime-parachains = { git = "https://github.com/paritytech/polkadot", branch = "master" }
+parachains-common = { path = "../../../common", default-features = false }
+
+polkadot-runtime = { git = "https://github.com/paritytech/polkadot", branch = "master" }
 penpal-runtime = { path = "../../testing/penpal"}
 statemint-runtime = { path = "../statemint"}
 
 xcm = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "master" }
 xcm-executor = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "master" }
 pallet-xcm = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "master" }
+
 sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
 frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
 frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
 sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
 sp-weights = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
-pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
-pallet-assets = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
-polkadot-core-primitives = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "master" }
-polkadot-parachain = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "master" }
-parachains-common = { path = "../../../common", default-features = false }
-codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false }

--- a/parachains/runtimes/assets/integration-tests/Cargo.toml
+++ b/parachains/runtimes/assets/integration-tests/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "statemint-runtime-integration-tests"
+version = "1.0.0"
+authors = ["Parity Technologies <admin@parity.io>"]
+edition = "2021"
+description = "Statemint parachain runtime integration tests"
+
+[dev-dependencies]
+xcm-emulator = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "ru/feature/xcm-emulator" }
+polkadot-runtime = { git = "https://github.com/paritytech/polkadot", branch = "master" }
+polkadot-runtime-parachains = { git = "https://github.com/paritytech/polkadot", branch = "master" }
+penpal-runtime = { path = "../../testing/penpal"}
+statemint-runtime = { path = "../statemint"}
+
+xcm = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "master" }
+xcm-executor = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "master" }
+pallet-xcm = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "master" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
+frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
+frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
+sp-core = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
+sp-weights = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
+pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
+pallet-assets = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
+polkadot-core-primitives = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "master" }
+polkadot-parachain = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "master" }
+parachains-common = { path = "../../../common", default-features = false }
+codec = { package = "parity-scale-codec", version = "3.4.0", default-features = false }

--- a/parachains/runtimes/assets/integration-tests/src/lib.rs
+++ b/parachains/runtimes/assets/integration-tests/src/lib.rs
@@ -1,0 +1,2 @@
+#[cfg(test)]
+mod tests {}

--- a/parachains/runtimes/assets/integration-tests/tests/statemint.rs
+++ b/parachains/runtimes/assets/integration-tests/tests/statemint.rs
@@ -1,0 +1,372 @@
+use frame_support::{
+	assert_ok,
+	instances::Instance1,
+	pallet_prelude::Hooks,
+	sp_io, sp_tracing,
+	traits::{fungibles::Inspect, GenesisBuild},
+};
+
+use codec::Encode;
+use polkadot_runtime_parachains::configuration::HostConfiguration;
+use sp_core::parameter_types;
+use statemint_runtime::constants::currency::DOLLARS;
+use xcm::prelude::*;
+use xcm_emulator::{decl_test_network, decl_test_parachain, decl_test_relay_chain, TestExt};
+
+use xcm_executor::traits::Convert;
+
+use parachains_common::Balance;
+use polkadot_core_primitives::InboundDownwardMessage;
+use polkadot_parachain::primitives::DmpMessageHandler;
+use sp_weights::Weight;
+use xcm::{
+	latest::{Ancestor, MultiLocation},
+	prelude::{AccountId32, Here, Parachain},
+	v3::Outcome,
+	VersionedMultiAssets,
+};
+
+pub const ALICE: sp_runtime::AccountId32 = sp_runtime::AccountId32::new([0u8; 32]);
+pub const BOB: sp_runtime::AccountId32 = sp_runtime::AccountId32::new([1u8; 32]);
+pub const INITIAL_BALANCE: u128 = 1000 * DOLLARS;
+
+decl_test_parachain! {
+	pub struct Statemint {
+		Runtime = statemint_runtime::Runtime,
+		RuntimeOrigin = statemint_runtime::RuntimeOrigin,
+		XcmpMessageHandler = statemint_runtime::XcmpQueue,
+		DmpMessageHandler = statemint_runtime::DmpQueue,
+		new_ext = statemint_ext(),
+	}
+}
+
+decl_test_parachain! {
+	pub struct Penpal {
+		Runtime = penpal_runtime::Runtime,
+		RuntimeOrigin = penpal_runtime::RuntimeOrigin,
+		XcmpMessageHandler = penpal_runtime::XcmpQueue,
+		DmpMessageHandler = penpal_runtime::DmpQueue,
+		new_ext = penpal_ext(),
+	}
+}
+
+decl_test_relay_chain! {
+	pub struct Relay {
+		Runtime = polkadot_runtime::Runtime,
+		XcmConfig = polkadot_runtime::xcm_config::XcmConfig,
+		new_ext = relay_ext(),
+	}
+}
+
+decl_test_network! {
+	pub struct MockNet {
+		relay_chain = Relay,
+		parachains = vec![
+			(1000, Statemint),
+			(2000, Penpal),
+		],
+	}
+}
+
+// Define Statemint TestExternalities.
+pub fn statemint_ext() -> sp_io::TestExternalities {
+	use statemint_runtime::{Runtime, System};
+
+	let mut t = frame_system::GenesisConfig::default().build_storage::<Runtime>().unwrap();
+
+	pallet_balances::GenesisConfig::<Runtime> {
+		balances: vec![(ALICE, INITIAL_BALANCE), (parent_account_id(), INITIAL_BALANCE)],
+	}
+	.assimilate_storage(&mut t)
+	.unwrap();
+
+	let mut ext = sp_io::TestExternalities::new(t);
+	ext.execute_with(|| {
+		sp_tracing::try_init_simple();
+		System::set_block_number(1);
+	});
+	ext
+}
+
+// Define Penpal TestExternalities.
+pub fn penpal_ext() -> sp_io::TestExternalities {
+	use penpal_runtime::{Runtime, System};
+
+	let mut t = frame_system::GenesisConfig::default().build_storage::<Runtime>().unwrap();
+
+	pallet_balances::GenesisConfig::<Runtime> {
+		balances: vec![(ALICE, INITIAL_BALANCE), (parent_account_id(), INITIAL_BALANCE)],
+	}
+	.assimilate_storage(&mut t)
+	.unwrap();
+
+	let mut ext = sp_io::TestExternalities::new(t);
+	ext.execute_with(|| {
+		sp_tracing::try_init_simple();
+		System::set_block_number(1);
+	});
+	ext
+}
+
+// Define Polkadot TestExternalities.
+pub fn relay_ext() -> sp_io::TestExternalities {
+	use polkadot_runtime::{Runtime, RuntimeOrigin, System};
+
+	// <XcmConfig::XcmSender as xcm_executor::Config>::XcmSender = RelayChainXcmRouter;
+	// <Runtime as pallet_xcm::Config>::XcmRouter = RelayChainXcmRouter;
+
+	let mut t = frame_system::GenesisConfig::default().build_storage::<Runtime>().unwrap();
+
+	polkadot_runtime_parachains::configuration::GenesisConfig::<Runtime> {
+		config: HostConfiguration {
+			max_upward_queue_count: 10,
+			max_upward_queue_size: 51200,
+			max_upward_message_size: 51200,
+			max_upward_message_num_per_candidate: 10,
+			max_downward_message_size: 51200,
+			..Default::default()
+		},
+	}
+	.assimilate_storage(&mut t)
+	.unwrap();
+
+	pallet_balances::GenesisConfig::<Runtime> {
+		balances: vec![
+			(ALICE, INITIAL_BALANCE),
+			(child_account_id(1000), INITIAL_BALANCE),
+			(child_account_id(2000), INITIAL_BALANCE),
+		],
+	}
+	.assimilate_storage(&mut t)
+	.unwrap();
+
+	let mut ext = sp_io::TestExternalities::new(t);
+	ext.execute_with(|| {
+		System::set_block_number(1);
+	});
+	ext
+}
+
+pub fn parent_account_id() -> parachains_common::AccountId {
+	let location = (Parent,);
+	statemint_runtime::xcm_config::LocationToAccountId::convert(location.into()).unwrap()
+}
+
+pub fn child_account_id(para: u32) -> polkadot_core_primitives::AccountId {
+	let location = (Parachain(para),);
+	polkadot_runtime::xcm_config::SovereignAccountOf::convert(location.into()).unwrap()
+}
+
+pub type RelayChainPalletXcm = pallet_xcm::Pallet<polkadot_runtime::Runtime>;
+pub type StatemintPalletXcm = pallet_xcm::Pallet<statemint_runtime::Runtime>;
+pub type PenpalPalletXcm = pallet_xcm::Pallet<penpal_runtime::Runtime>;
+
+parameter_types! {
+	pub StatemintLocation: MultiLocation = (Ancestor(0), Parachain(1000)).into();
+}
+
+#[test]
+// NOTE: This needs to be run before every other test to ensure that chains can communicate with one
+// another.
+fn force_xcm_version() {
+	let xcm_version = 3;
+	Relay::execute_with(|| {
+		use polkadot_runtime::{RuntimeEvent, System};
+
+		let statemint_location: MultiLocation = (Ancestor(0), Parachain(1000)).into();
+		let penpal_location: MultiLocation = (Ancestor(0), Parachain(2000)).into();
+
+		// Check that we can force xcm version for Statemint and Penpal from Polkadot.
+		for location in [statemint_location, penpal_location] {
+			assert_ok!(RelayChainPalletXcm::force_xcm_version(
+				polkadot_runtime::RuntimeOrigin::root(),
+				Box::new(location),
+				xcm_version,
+			));
+			assert!(System::events().iter().any(|r| matches!(
+				r.event,
+				RuntimeEvent::XcmPallet(pallet_xcm::Event::SupportedVersionChanged {
+					0: loc,
+					1: ver,
+				}) if loc == location && ver == xcm_version
+			)));
+		}
+	});
+
+	// Penpal forces Polkadot xcm version.
+	Penpal::execute_with(|| {
+		use penpal_runtime::{RuntimeEvent, System};
+
+		let location: MultiLocation = (Parent).into();
+
+		assert_ok!(PenpalPalletXcm::force_xcm_version(
+			penpal_runtime::RuntimeOrigin::root(),
+			Box::new(location),
+			xcm_version,
+		));
+
+		assert!(System::events().iter().any(|r| matches!(
+			r.event,
+			RuntimeEvent::PolkadotXcm(pallet_xcm::Event::SupportedVersionChanged {
+				0: loc,
+				1: ver,
+			}) if loc == location && ver == xcm_version
+		)));
+	});
+}
+
+// Direct message passing tests.
+mod dmp {
+	use super::*;
+	use xcm::latest::Error;
+	use xcm_emulator::cumulus_pallet_dmp_queue;
+
+	fn get_balances() -> (Balance, Balance) {
+		let mut relay_balance = Default::default();
+		Relay::execute_with(|| {
+			relay_balance =
+				polkadot_runtime::System::account::<sp_runtime::AccountId32>(ALICE.into())
+					.data
+					.free;
+		});
+		let mut assets_para_balance = Default::default();
+
+		Statemint::execute_with(|| {
+			assets_para_balance =
+				statemint_runtime::System::account::<sp_runtime::AccountId32>(ALICE.into())
+					.data
+					.free;
+		});
+
+		(relay_balance, assets_para_balance)
+	}
+
+	fn get_benf() -> Junction {
+		AccountId32 { network: None, id: ALICE.into() }
+	}
+
+	const AP_DEST: (Ancestor, Junction) = (Ancestor(0), Parachain(1000));
+
+	#[test]
+	fn teleport_native_assets_relay_to_assets_para() {
+		force_xcm_version();
+		let amount = 1000_000_000;
+		let assets: VersionedMultiAssets = (Here, amount).into();
+
+		let mut messages: Vec<InboundDownwardMessage> = Vec::new();
+
+		let (relay_balance, ap_balance) = get_balances();
+
+		Relay::execute_with(|| {
+			use polkadot_runtime::{RuntimeEvent, RuntimeOrigin, System};
+
+			assert_ok!(RelayChainPalletXcm::limited_teleport_assets(
+				RuntimeOrigin::signed(ALICE.into()),
+				Box::new(AP_DEST.into()),
+				Box::new(get_benf().into()),
+				Box::new(assets),
+				0,
+				WeightLimit::Unlimited,
+			));
+			assert!(System::events().iter().any(|r| matches!(
+				r.event,
+				RuntimeEvent::XcmPallet(pallet_xcm::Event::Attempted(Outcome::Complete { .. }))
+			)));
+		});
+
+		Statemint::execute_with(|| {
+			use statemint_runtime::{Runtime, RuntimeEvent, System};
+			assert!(System::events().iter().any(|r| matches!(
+				&r.event,
+				RuntimeEvent::Balances(pallet_balances::Event::Deposit { who, .. })
+				if *who == ALICE.into()
+			)));
+		});
+
+		let (relay_balance_after, ap_balance_after) = get_balances();
+		assert_eq!(relay_balance - amount, relay_balance_after);
+		assert!(ap_balance_after > ap_balance);
+	}
+
+	#[test]
+	fn transact_sudo_relay_to_assets_para_works() {
+		force_xcm_version();
+
+		Relay::execute_with(|| {
+			use polkadot_runtime::{RuntimeEvent, RuntimeOrigin, System};
+
+			let call = statemint_runtime::RuntimeCall::Assets(pallet_assets::Call::<
+				statemint_runtime::Runtime,
+				Instance1,
+			>::force_create {
+				id: 1.into(),
+				is_sufficient: true,
+				min_balance: 1000,
+				owner: ALICE.into(),
+			});
+			let xcm = Xcm(vec![
+				UnpaidExecution { weight_limit: WeightLimit::Unlimited, check_origin: None },
+				Transact {
+					require_weight_at_most: Weight::from_parts(1000000000, 200000),
+					origin_kind: OriginKind::Superuser,
+					call: call.encode().into(),
+				},
+			]);
+			assert_ok!(RelayChainPalletXcm::send(
+				RuntimeOrigin::root(),
+				Box::new(AP_DEST.into()),
+				Box::new(VersionedXcm::from(xcm)),
+			));
+			assert!(System::events().iter().any(|r| matches!(
+				r.event,
+				RuntimeEvent::XcmPallet(pallet_xcm::Event::Sent { .. })
+			)));
+		});
+
+		Statemint::execute_with(|| {
+			assert!(statemint_runtime::Assets::asset_exists(1));
+		});
+	}
+
+	#[test]
+	fn reserved_transfer_native_relay_to_assets_para_fails() {
+		force_xcm_version();
+		let (relay_balance, ap_balance) = get_balances();
+		let amount = 1000_000_000;
+		let assets: VersionedMultiAssets = (Here, amount).into();
+
+		Relay::execute_with(|| {
+			use polkadot_runtime::{RuntimeEvent, RuntimeOrigin, System};
+
+			assert_ok!(RelayChainPalletXcm::limited_reserve_transfer_assets(
+				RuntimeOrigin::signed(ALICE.into()),
+				Box::new(AP_DEST.into()),
+				Box::new(get_benf().into()),
+				Box::new(assets),
+				0,
+				WeightLimit::Unlimited,
+			));
+
+			assert!(System::events().iter().any(|r| matches!(
+				r.event,
+				RuntimeEvent::XcmPallet(pallet_xcm::Event::Attempted(Outcome::Complete { .. }))
+			)));
+		});
+
+		Statemint::execute_with(|| {
+			use statemint_runtime::{RuntimeEvent, System};
+
+			assert!(System::events().iter().any(|r| matches!(
+				r.event,
+				RuntimeEvent::DmpQueue(cumulus_pallet_dmp_queue::Event::ExecutedDownward {
+					outcome: Outcome::Incomplete(_, Error::UntrustedReserveLocation),
+					..
+				})
+			)));
+		});
+
+		let (relay_balance_after, ap_balance_after) = get_balances();
+		assert_eq!(relay_balance - amount, relay_balance_after);
+		assert_eq!(ap_balance_after, ap_balance);
+	}
+}

--- a/parachains/runtimes/assets/integration-tests/tests/tests.rs
+++ b/parachains/runtimes/assets/integration-tests/tests/tests.rs
@@ -1,0 +1,1 @@
+mod statemint;


### PR DESCRIPTION
**WORK IN PROGRESS**

Needs to be rebased once the below PR has been merged, then we can get rid of patch overrides as xcm-emulator is now cumulus-based.

Depends on: https://github.com/paritytech/cumulus/pull/2447.
Note, that this does not work without `path` overrides, until the above PR has been merged, due to the fact that we import Polkadot master across the board in cumulus, but xcm-emulator does not exist there yet.

This is an initial take on writing XCM integration tests for live runtimes via XCM-Emulator. In this case Statemint and Polkadot. 

**Current trade-offs**
`integration-tests` is a separate module as opposed to something that lives under specific runtime's directory, to avoid runtime recompilation when tests change. That saves a lot of dev time. 

