### PR TITLE
Bump transaction_version

### DIFF
--- a/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/src/lib.rs
+++ b/parachains/runtimes/bridge-hubs/bridge-hub-polkadot/src/lib.rs
@@ -131,7 +131,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_version: 9420,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
-	transaction_version:2,
+	transaction_version: 2,
 	state_version: 1,
 };
 


### PR DESCRIPTION
This PR bumps `transaction_version` based on the [Extrinsic ordering check](https://github.com/paritytech/cumulus/issues/2507#issuecomment-1534403237) in #2507 