### PR TITLE
Make zombienet tests required

### DIFF
--- a/scripts/ci/gitlab/pipeline/zombienet.yml
+++ b/scripts/ci/gitlab/pipeline/zombienet.yml
@@ -35,7 +35,7 @@
     expire_in: 2 days
     paths:
       - ./zombienet-logs
-  allow_failure: true
+  allow_failure: false
   retry: 2
   tags:
     - zombienet-polkadot-integration-test


### PR DESCRIPTION
Zombienet tests are still allowed to fail. Since the other tests have been removed for a while, let's make them mandatory.