### PR TITLE
[Backport] Bump transaction_version (#2520) to the source release branch

### DIFF
--- a/parachains/runtimes/collectives/collectives-polkadot/src/lib.rs
+++ b/parachains/runtimes/collectives/collectives-polkadot/src/lib.rs
@@ -111,7 +111,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_version: 9420,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
-	transaction_version: 4,
+	transaction_version: 5,
 	state_version: 0,
 };
 


### PR DESCRIPTION
 This PR backports `transaction_version` bump for `Collectives`  from the runtimes release branch