### PR TITLE
Relay-parent digest logs for parachains

### DIFF
--- a/pallets/parachain-system/src/lib.rs
+++ b/pallets/parachain-system/src/lib.rs
@@ -391,6 +391,7 @@ pub mod pallet {
 			frame_system::Pallet::<T>::deposit_log(
 				cumulus_primitives_core::rpsr_digest::relay_parent_storage_root_item(
 					vfp.relay_parent_storage_root,
+					vfp.relay_parent_number,
 				),
 			);
 

--- a/pallets/parachain-system/src/lib.rs
+++ b/pallets/parachain-system/src/lib.rs
@@ -385,6 +385,15 @@ pub mod pallet {
 			)
 			.expect("Invalid relay chain state proof");
 
+			// Deposit a log indicating the relay-parent storage root.
+			// TODO: remove this in favor of the relay-parent's hash after
+			// https://github.com/paritytech/cumulus/issues/303
+			frame_system::Pallet::<T>::deposit_log(
+				cumulus_primitives_core::rpsr_digest::relay_parent_storage_root_item(
+					vfp.relay_parent_storage_root,
+				),
+			);
+
 			// initialization logic: we know that this runs exactly once every block,
 			// which means we can put the initialization logic here to remove the
 			// sequencing problem.

--- a/pallets/parachain-system/src/tests.rs
+++ b/pallets/parachain-system/src/tests.rs
@@ -1006,3 +1006,18 @@ fn upgrade_version_checks_should_work() {
 		});
 	}
 }
+
+#[test]
+fn deposits_relay_parent_storage_root() {
+	BlockTests::new().add_with_post_test(
+		123,
+		|| {},
+		|| {
+			let digest = System::digest();
+			assert!(cumulus_primitives_core::rpsr_digest::extract_relay_parent_storage_root(
+				&digest
+			)
+			.is_some());
+		},
+	);
+}

--- a/primitives/core/src/lib.rs
+++ b/primitives/core/src/lib.rs
@@ -214,7 +214,7 @@ pub const CUMULUS_CONSENSUS_ID: ConsensusEngineId = *b"CMLS";
 /// Consensus header digests for Cumulus parachains.
 #[derive(Clone, RuntimeDebug, Decode, Encode, PartialEq)]
 pub enum CumulusDigestItem {
-	/// A digest item indicating that the parachain block has the provided relay-parent.
+	/// A digest item indicating the relay-parent a parachain block was built against.
 	#[codec(index = 0)]
 	RelayParent(relay_chain::Hash),
 }

--- a/primitives/core/src/lib.rs
+++ b/primitives/core/src/lib.rs
@@ -244,8 +244,8 @@ pub fn extract_relay_parent(digest: &Digest) -> Option<relay_chain::Hash> {
 /// Utilities for handling the relay-parent storage root as a digest item.
 ///
 /// This is not intended to be part of the public API, as it is a workaround for
-/// https://github.com/paritytech/cumulus/issues/303 via
-/// https://github.com/paritytech/polkadot/issues/7191.
+/// <https://github.com/paritytech/cumulus/issues/303> via
+/// <https://github.com/paritytech/polkadot/issues/7191>.
 ///
 /// Runtimes using the parachain-system pallet are expected produce this digest item,
 /// but will stop as soon as they are able to provide the relay-parent hash directly.

--- a/primitives/core/src/lib.rs
+++ b/primitives/core/src/lib.rs
@@ -247,7 +247,10 @@ pub fn extract_relay_parent(digest: &Digest) -> Option<relay_chain::Hash> {
 ///
 /// This is not intended to be part of the public API, as it is a workaround for
 /// https://github.com/paritytech/cumulus/issues/303 via
-/// https://github.com/paritytech/polkadot/issues/7191
+/// https://github.com/paritytech/polkadot/issues/7191.
+///
+/// Runtimes using the parachain-system pallet are expected produce this digest item,
+/// but will stop as soon as they are able to provide the relay-parent hash directly.
 #[doc(hidden)]
 pub mod rpsr_digest {
 	use super::{relay_chain, ConsensusEngineId, Decode, Digest, DigestItem, Encode};

--- a/primitives/core/src/lib.rs
+++ b/primitives/core/src/lib.rs
@@ -247,7 +247,7 @@ pub fn extract_relay_parent(digest: &Digest) -> Option<relay_chain::Hash> {
 /// <https://github.com/paritytech/cumulus/issues/303> via
 /// <https://github.com/paritytech/polkadot/issues/7191>.
 ///
-/// Runtimes using the parachain-system pallet are expected produce this digest item,
+/// Runtimes using the parachain-system pallet are expected to produce this digest item,
 /// but will stop as soon as they are able to provide the relay-parent hash directly.
 ///
 /// The relay-chain storage root is, in practice, a unique identifier of a block

--- a/primitives/core/src/lib.rs
+++ b/primitives/core/src/lib.rs
@@ -26,10 +26,8 @@ use crate::substrate::{
 use codec::{Decode, Encode};
 use polkadot_parachain::primitives::HeadData;
 use scale_info::TypeInfo;
-use sp_runtime::{traits::Block as BlockT, RuntimeDebug};
+use sp_runtime::RuntimeDebug;
 use sp_std::prelude::*;
-
-use crate::substrate::{generic::{Digest, DigestItem}, traits::Block as BlockT, ConsensusEngineId};
 
 pub use polkadot_core_primitives::InboundDownwardMessage;
 pub use polkadot_parachain::primitives::{

--- a/primitives/core/src/lib.rs
+++ b/primitives/core/src/lib.rs
@@ -276,10 +276,7 @@ pub mod rpsr_digest {
 	pub fn extract_relay_parent_storage_root(digest: &Digest) -> Option<relay_chain::Hash> {
 		digest.convert_first(|d| match d {
 			DigestItem::Consensus(id, val) if id == &RPSR_CONSENSUS_ID =>
-				match relay_chain::Hash::decode(&mut &val[..]) {
-					Ok(hash) => Some(hash),
-					_ => None,
-				},
+				relay_chain::Hash::decode(&mut &val[..]).ok(),
 			_ => None,
 		})
 	}

--- a/primitives/core/src/lib.rs
+++ b/primitives/core/src/lib.rs
@@ -251,6 +251,14 @@ pub fn extract_relay_parent(digest: &Digest) -> Option<relay_chain::Hash> {
 ///
 /// Runtimes using the parachain-system pallet are expected produce this digest item,
 /// but will stop as soon as they are able to provide the relay-parent hash directly.
+///
+/// The relay-chain storage root is, in practice, a unique identifier of a block
+/// in the absence of equivocations (which are slashable). This assumes that the relay chain
+/// uses BABE or SASSAFRAS, because the slot and the author's VRF randomness are both included
+/// in the relay-chain storage root in both cases.
+///
+/// Therefore, the relay-parent storage root is a suitable identifier of unique relay chain
+/// blocks in low-value scenarios such as performance optimizations.
 #[doc(hidden)]
 pub mod rpsr_digest {
 	use super::{relay_chain, ConsensusEngineId, Decode, Digest, DigestItem, Encode};


### PR DESCRIPTION
**After runtimes update to incorporate this PR, parachains using `pallet-parachain-system` will include a new digest in every header indicating their relay-parent's state root and number. Later on, this digest is intended to change to the relay-parent hash.**

Partially addresses #303 in the absence of https://github.com/paritytech/polkadot/issues/7191 .

This introduces a (currently unused) `CumulusDigestItem` which will have the relay-parent hash once that's available. In the meantime, there is a `#[doc(hidden)]` digest item representing the relay-parent storage root. This serves as a good enough unique identifier to implement https://github.com/paritytech/cumulus/issues/2476 .

For consideration - adding this private digest is not ideal, but it does let us implement some much better logic around asynchronous backing for parachains without needing to go through an execution API upgrade.