### PR TITLE
Add benchmarks for for import/validation/production

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -579,7 +579,7 @@ dependencies = [
 [[package]]
 name = "binary-merkle-tree"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "hash-db",
  "log",
@@ -1535,6 +1535,15 @@ dependencies = [
  "bitflags",
  "clap_lex 0.4.1",
  "strsim",
+]
+
+[[package]]
+name = "clap_complete"
+version = "4.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1594fe2312ec4abf402076e407628f5c313e54c32ade058521df4ee34ecac8a8"
+dependencies = [
+ "clap 4.2.7",
 ]
 
 [[package]]
@@ -2819,6 +2828,7 @@ dependencies = [
  "frame-system",
  "frame-system-rpc-runtime-api",
  "pallet-balances",
+ "pallet-glutton",
  "pallet-sudo",
  "pallet-timestamp",
  "pallet-transaction-payment",
@@ -2850,17 +2860,25 @@ dependencies = [
  "cumulus-client-consensus-relay-chain",
  "cumulus-client-pov-recovery",
  "cumulus-client-service",
+ "cumulus-pallet-parachain-system",
  "cumulus-primitives-core",
  "cumulus-primitives-parachain-inherent",
  "cumulus-relay-chain-inprocess-interface",
  "cumulus-relay-chain-interface",
  "cumulus-relay-chain-minimal-node",
+ "cumulus-test-client",
+ "cumulus-test-relay-sproof-builder",
  "cumulus-test-relay-validation-worker-provider",
  "cumulus-test-runtime",
  "frame-system",
  "frame-system-rpc-runtime-api",
  "futures",
  "jsonrpsee",
+ "kitchensink-runtime",
+ "node-cli",
+ "node-primitives",
+ "pallet-im-online",
+ "pallet-timestamp",
  "pallet-transaction-payment",
  "parachains-common",
  "parity-scale-codec",
@@ -2872,12 +2890,16 @@ dependencies = [
  "polkadot-test-service",
  "portpicker",
  "rand 0.8.5",
+ "rococo-parachain-runtime",
  "sc-basic-authorship",
+ "sc-block-builder",
  "sc-chain-spec",
  "sc-cli",
  "sc-client-api",
  "sc-consensus",
  "sc-executor",
+ "sc-executor-common",
+ "sc-executor-wasmtime",
  "sc-network",
  "sc-service",
  "sc-telemetry",
@@ -2885,8 +2907,12 @@ dependencies = [
  "sc-transaction-pool",
  "sc-transaction-pool-api",
  "serde",
+ "sp-api",
  "sp-arithmetic",
+ "sp-authority-discovery",
  "sp-blockchain",
+ "sp-consensus",
+ "sp-consensus-grandpa",
  "sp-core",
  "sp-io",
  "sp-keyring",
@@ -2897,6 +2923,7 @@ dependencies = [
  "sp-trie",
  "substrate-test-client",
  "substrate-test-utils",
+ "tempfile",
  "tokio",
  "tracing",
  "url",
@@ -3781,7 +3808,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 [[package]]
 name = "fork-tree"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -3804,7 +3831,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 [[package]]
 name = "frame-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -3829,7 +3856,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "Inflector",
  "array-bytes 4.2.0",
@@ -3874,9 +3901,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "frame-benchmarking-pallet-pov"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "frame-election-provider-solution-type"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -3887,7 +3929,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -3904,7 +3946,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3933,7 +3975,7 @@ dependencies = [
 [[package]]
 name = "frame-remote-externalities"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "async-recursion",
  "futures",
@@ -3953,7 +3995,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "bitflags",
  "environmental",
@@ -3986,7 +4028,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -4002,7 +4044,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -4014,7 +4056,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4024,7 +4066,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "cfg-if",
  "frame-support",
@@ -4043,7 +4085,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4058,7 +4100,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -4067,7 +4109,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -5082,6 +5124,112 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 
 [[package]]
+name = "kitchensink-runtime"
+version = "3.0.0-dev"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
+dependencies = [
+ "frame-benchmarking",
+ "frame-benchmarking-pallet-pov",
+ "frame-election-provider-support",
+ "frame-executive",
+ "frame-support",
+ "frame-system",
+ "frame-system-benchmarking",
+ "frame-system-rpc-runtime-api",
+ "frame-try-runtime",
+ "log",
+ "node-primitives",
+ "pallet-alliance",
+ "pallet-asset-rate",
+ "pallet-asset-tx-payment",
+ "pallet-assets",
+ "pallet-authority-discovery",
+ "pallet-authorship",
+ "pallet-babe",
+ "pallet-bags-list",
+ "pallet-balances",
+ "pallet-bounties",
+ "pallet-child-bounties",
+ "pallet-collective",
+ "pallet-contracts",
+ "pallet-contracts-primitives",
+ "pallet-conviction-voting",
+ "pallet-core-fellowship",
+ "pallet-democracy",
+ "pallet-election-provider-multi-phase",
+ "pallet-election-provider-support-benchmarking",
+ "pallet-elections-phragmen",
+ "pallet-fast-unstake",
+ "pallet-glutton",
+ "pallet-grandpa",
+ "pallet-identity",
+ "pallet-im-online",
+ "pallet-indices",
+ "pallet-insecure-randomness-collective-flip",
+ "pallet-lottery",
+ "pallet-membership",
+ "pallet-message-queue",
+ "pallet-mmr",
+ "pallet-multisig",
+ "pallet-nfts",
+ "pallet-nfts-runtime-api",
+ "pallet-nis",
+ "pallet-nomination-pools",
+ "pallet-nomination-pools-benchmarking",
+ "pallet-nomination-pools-runtime-api",
+ "pallet-offences",
+ "pallet-offences-benchmarking",
+ "pallet-preimage",
+ "pallet-proxy",
+ "pallet-ranked-collective",
+ "pallet-recovery",
+ "pallet-referenda",
+ "pallet-remark",
+ "pallet-root-testing",
+ "pallet-salary",
+ "pallet-scheduler",
+ "pallet-session",
+ "pallet-session-benchmarking",
+ "pallet-society",
+ "pallet-staking",
+ "pallet-staking-reward-curve",
+ "pallet-staking-runtime-api",
+ "pallet-state-trie-migration",
+ "pallet-statement",
+ "pallet-sudo",
+ "pallet-timestamp",
+ "pallet-tips",
+ "pallet-transaction-payment",
+ "pallet-transaction-payment-rpc-runtime-api",
+ "pallet-transaction-storage",
+ "pallet-treasury",
+ "pallet-uniques",
+ "pallet-utility",
+ "pallet-vesting",
+ "pallet-whitelist",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-api",
+ "sp-authority-discovery",
+ "sp-block-builder",
+ "sp-consensus-babe",
+ "sp-consensus-grandpa",
+ "sp-core",
+ "sp-inherents",
+ "sp-io",
+ "sp-offchain",
+ "sp-runtime",
+ "sp-session",
+ "sp-staking",
+ "sp-statement-store",
+ "sp-std",
+ "sp-transaction-pool",
+ "sp-version",
+ "static_assertions",
+ "substrate-wasm-builder",
+]
+
+[[package]]
 name = "kusama-runtime"
 version = "0.9.41"
 source = "git+https://github.com/paritytech/polkadot?branch=master#57ec016a97b0e67127bcdf24965ff6bfc16d4cd7"
@@ -6064,7 +6212,7 @@ dependencies = [
 [[package]]
 name = "mmr-gadget"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "futures",
  "log",
@@ -6083,7 +6231,7 @@ dependencies = [
 [[package]]
 name = "mmr-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "anyhow",
  "jsonrpsee",
@@ -6352,6 +6500,157 @@ dependencies = [
 ]
 
 [[package]]
+name = "node-cli"
+version = "3.0.0-dev"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
+dependencies = [
+ "array-bytes 4.2.0",
+ "clap 4.2.7",
+ "clap_complete",
+ "frame-benchmarking-cli",
+ "frame-system",
+ "frame-system-rpc-runtime-api",
+ "futures",
+ "jsonrpsee",
+ "kitchensink-runtime",
+ "log",
+ "node-executor",
+ "node-inspect",
+ "node-primitives",
+ "node-rpc",
+ "pallet-asset-tx-payment",
+ "pallet-assets",
+ "pallet-balances",
+ "pallet-im-online",
+ "pallet-transaction-payment",
+ "parity-scale-codec",
+ "rand 0.8.5",
+ "sc-authority-discovery",
+ "sc-basic-authorship",
+ "sc-chain-spec",
+ "sc-cli",
+ "sc-client-api",
+ "sc-consensus",
+ "sc-consensus-babe",
+ "sc-consensus-grandpa",
+ "sc-consensus-slots",
+ "sc-executor",
+ "sc-network",
+ "sc-network-common",
+ "sc-network-statement",
+ "sc-network-sync",
+ "sc-rpc",
+ "sc-service",
+ "sc-statement-store",
+ "sc-storage-monitor",
+ "sc-sync-state-rpc",
+ "sc-sysinfo",
+ "sc-telemetry",
+ "sc-transaction-pool",
+ "sc-transaction-pool-api",
+ "serde",
+ "serde_json",
+ "sp-api",
+ "sp-authority-discovery",
+ "sp-consensus",
+ "sp-consensus-babe",
+ "sp-consensus-grandpa",
+ "sp-core",
+ "sp-inherents",
+ "sp-io",
+ "sp-keyring",
+ "sp-keystore",
+ "sp-runtime",
+ "sp-timestamp",
+ "sp-transaction-pool",
+ "sp-transaction-storage-proof",
+ "substrate-build-script-utils",
+ "substrate-frame-cli",
+ "try-runtime-cli",
+]
+
+[[package]]
+name = "node-executor"
+version = "3.0.0-dev"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
+dependencies = [
+ "frame-benchmarking",
+ "kitchensink-runtime",
+ "node-primitives",
+ "parity-scale-codec",
+ "sc-executor",
+ "scale-info",
+ "sp-core",
+ "sp-keystore",
+ "sp-state-machine",
+ "sp-statement-store",
+ "sp-tracing",
+ "sp-trie",
+]
+
+[[package]]
+name = "node-inspect"
+version = "0.9.0-dev"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
+dependencies = [
+ "clap 4.2.7",
+ "parity-scale-codec",
+ "sc-cli",
+ "sc-client-api",
+ "sc-executor",
+ "sc-service",
+ "sp-blockchain",
+ "sp-core",
+ "sp-runtime",
+ "thiserror",
+]
+
+[[package]]
+name = "node-primitives"
+version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
+dependencies = [
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-application-crypto",
+ "sp-core",
+ "sp-runtime",
+]
+
+[[package]]
+name = "node-rpc"
+version = "3.0.0-dev"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
+dependencies = [
+ "jsonrpsee",
+ "mmr-rpc",
+ "node-primitives",
+ "pallet-transaction-payment-rpc",
+ "sc-chain-spec",
+ "sc-client-api",
+ "sc-consensus-babe",
+ "sc-consensus-babe-rpc",
+ "sc-consensus-grandpa",
+ "sc-consensus-grandpa-rpc",
+ "sc-rpc",
+ "sc-rpc-api",
+ "sc-rpc-spec-v2",
+ "sc-sync-state-rpc",
+ "sc-transaction-pool-api",
+ "sp-api",
+ "sp-block-builder",
+ "sp-blockchain",
+ "sp-consensus",
+ "sp-consensus-babe",
+ "sp-keystore",
+ "sp-runtime",
+ "sp-statement-store",
+ "substrate-frame-rpc-system",
+ "substrate-state-trie-migration-rpc",
+]
+
+[[package]]
 name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6602,7 +6901,7 @@ dependencies = [
 [[package]]
 name = "pallet-alliance"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "array-bytes 4.2.0",
  "frame-benchmarking",
@@ -6621,9 +6920,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-asset-rate"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "pallet-asset-tx-payment"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6641,7 +6954,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6656,7 +6969,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6672,7 +6985,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6688,7 +7001,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6702,7 +7015,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6726,7 +7039,7 @@ dependencies = [
 [[package]]
 name = "pallet-bags-list"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6746,7 +7059,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6761,7 +7074,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6780,7 +7093,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "array-bytes 4.2.0",
  "binary-merkle-tree",
@@ -6804,7 +7117,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6910,7 +7223,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6954,7 +7267,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6971,7 +7284,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "bitflags",
  "environmental",
@@ -7001,7 +7314,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-primitives"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "bitflags",
  "parity-scale-codec",
@@ -7014,7 +7327,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7024,7 +7337,7 @@ dependencies = [
 [[package]]
 name = "pallet-conviction-voting"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -7039,9 +7352,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-core-fellowship"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "pallet-democracy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7059,7 +7390,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -7082,7 +7413,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -7095,7 +7426,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "5.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7113,7 +7444,7 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -7129,9 +7460,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-glutton"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
+dependencies = [
+ "blake2",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "pallet-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7154,7 +7503,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -7170,7 +7519,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7190,7 +7539,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7207,7 +7556,7 @@ dependencies = [
 [[package]]
 name = "pallet-insecure-randomness-collective-flip"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7219,9 +7568,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-lottery"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "pallet-membership"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7236,9 +7599,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-message-queue"
+version = "7.0.0-dev"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+ "sp-weights",
+]
+
+[[package]]
 name = "pallet-mmr"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7255,7 +7637,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7271,7 +7653,7 @@ dependencies = [
 [[package]]
 name = "pallet-nfts"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -7289,7 +7671,7 @@ dependencies = [
 [[package]]
 name = "pallet-nfts-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "frame-support",
  "pallet-nfts",
@@ -7300,7 +7682,7 @@ dependencies = [
 [[package]]
 name = "pallet-nis"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7316,7 +7698,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7333,7 +7715,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -7353,7 +7735,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
 version = "1.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
@@ -7364,7 +7746,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7381,7 +7763,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -7420,7 +7802,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7437,7 +7819,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7452,7 +7834,7 @@ dependencies = [
 [[package]]
 name = "pallet-ranked-collective"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7470,7 +7852,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7485,7 +7867,7 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -7502,9 +7884,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-remark"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-root-testing"
+version = "1.0.0-dev"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-salary"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "pallet-scheduler"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7521,7 +7953,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7542,7 +7974,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7558,7 +7990,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7572,7 +8004,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -7595,7 +8027,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -7606,7 +8038,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -7615,7 +8047,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7624,7 +8056,7 @@ dependencies = [
 [[package]]
 name = "pallet-state-trie-migration"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7639,9 +8071,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-statement"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-api",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-statement-store",
+ "sp-std",
+]
+
+[[package]]
 name = "pallet-sudo"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7656,7 +8106,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7674,7 +8124,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7693,7 +8143,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7709,7 +8159,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -7725,7 +8175,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -7735,9 +8185,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-transaction-storage"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "log",
+ "pallet-balances",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-inherents",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+ "sp-transaction-storage-proof",
+]
+
+[[package]]
 name = "pallet-treasury"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7754,7 +8224,7 @@ dependencies = [
 [[package]]
 name = "pallet-uniques"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7769,7 +8239,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7785,7 +8255,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7800,7 +8270,7 @@ dependencies = [
 [[package]]
 name = "pallet-whitelist"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10895,7 +11365,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "4.1.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "log",
  "sp-core",
@@ -10906,7 +11376,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "async-trait",
  "futures",
@@ -10935,7 +11405,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "futures",
  "futures-timer",
@@ -10958,7 +11428,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -10973,7 +11443,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "memmap2",
  "sc-chain-spec-derive",
@@ -10992,7 +11462,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -11003,7 +11473,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "array-bytes 4.2.0",
  "chrono",
@@ -11043,7 +11513,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "fnv",
  "futures",
@@ -11070,7 +11540,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -11096,7 +11566,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "async-trait",
  "futures",
@@ -11121,7 +11591,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "async-trait",
  "futures",
@@ -11150,7 +11620,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -11186,7 +11656,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -11208,7 +11678,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "array-bytes 4.2.0",
  "async-trait",
@@ -11243,7 +11713,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -11262,7 +11732,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -11275,7 +11745,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "ahash 0.8.2",
  "array-bytes 4.2.0",
@@ -11315,7 +11785,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "finality-grandpa",
  "futures",
@@ -11335,7 +11805,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "async-trait",
  "futures",
@@ -11358,7 +11828,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "lru 0.8.1",
  "parity-scale-codec",
@@ -11382,7 +11852,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "sc-allocator",
  "sp-maybe-compressed-blob",
@@ -11395,7 +11865,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmi"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "log",
  "sc-allocator",
@@ -11408,7 +11878,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -11426,7 +11896,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "ansi_term",
  "futures",
@@ -11442,7 +11912,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "array-bytes 4.2.0",
  "parking_lot 0.12.1",
@@ -11456,7 +11926,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "array-bytes 4.2.0",
  "async-channel",
@@ -11501,7 +11971,7 @@ dependencies = [
 [[package]]
 name = "sc-network-bitswap"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "cid",
  "futures",
@@ -11521,7 +11991,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "array-bytes 4.2.0",
  "async-trait",
@@ -11549,7 +12019,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "ahash 0.8.2",
  "futures",
@@ -11568,7 +12038,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "array-bytes 4.2.0",
  "futures",
@@ -11588,9 +12058,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "sc-network-statement"
+version = "0.10.0-dev"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
+dependencies = [
+ "array-bytes 4.2.0",
+ "async-channel",
+ "futures",
+ "libp2p",
+ "log",
+ "parity-scale-codec",
+ "pin-project",
+ "sc-network",
+ "sc-network-common",
+ "sc-peerset",
+ "sp-consensus",
+ "sp-runtime",
+ "sp-statement-store",
+ "substrate-prometheus-endpoint",
+]
+
+[[package]]
 name = "sc-network-sync"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "array-bytes 4.2.0",
  "async-trait",
@@ -11624,7 +12115,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "array-bytes 4.2.0",
  "futures",
@@ -11644,7 +12135,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "array-bytes 4.2.0",
  "bytes",
@@ -11675,7 +12166,7 @@ dependencies = [
 [[package]]
 name = "sc-peerset"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "futures",
  "libp2p-identity",
@@ -11688,7 +12179,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -11697,7 +12188,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -11728,7 +12219,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -11747,7 +12238,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "http",
  "jsonrpsee",
@@ -11762,7 +12253,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "array-bytes 4.2.0",
  "futures",
@@ -11788,7 +12279,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "async-trait",
  "directories",
@@ -11854,7 +12345,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -11863,9 +12354,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "sc-statement-store"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
+dependencies = [
+ "async-trait",
+ "futures",
+ "futures-timer",
+ "log",
+ "parity-db",
+ "parity-scale-codec",
+ "parking_lot 0.12.1",
+ "sc-client-api",
+ "sp-api",
+ "sp-blockchain",
+ "sp-core",
+ "sp-runtime",
+ "sp-statement-store",
+ "sp-tracing",
+ "substrate-prometheus-endpoint",
+ "tokio",
+]
+
+[[package]]
 name = "sc-storage-monitor"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "clap 4.2.7",
  "fs4",
@@ -11881,7 +12395,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -11900,7 +12414,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "6.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "futures",
  "libc",
@@ -11919,7 +12433,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "chrono",
  "futures",
@@ -11938,7 +12452,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "ansi_term",
  "atty",
@@ -11969,7 +12483,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -11980,7 +12494,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "async-trait",
  "futures",
@@ -12007,7 +12521,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "async-trait",
  "futures",
@@ -12021,7 +12535,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "async-channel",
  "futures",
@@ -12579,7 +13093,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "hash-db",
  "log",
@@ -12599,7 +13113,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "Inflector",
  "blake2",
@@ -12613,7 +13127,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12626,7 +13140,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -12640,7 +13154,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12653,7 +13167,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -12665,7 +13179,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "futures",
  "log",
@@ -12683,7 +13197,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "async-trait",
  "futures",
@@ -12698,7 +13212,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -12716,7 +13230,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -12737,7 +13251,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-beefy"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "lazy_static",
  "parity-scale-codec",
@@ -12756,7 +13270,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -12774,7 +13288,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12786,7 +13300,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "array-bytes 4.2.0",
  "bitflags",
@@ -12830,7 +13344,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -12844,7 +13358,7 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12855,7 +13369,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.1",
@@ -12864,7 +13378,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12874,7 +13388,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.13.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -12885,7 +13399,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -12900,7 +13414,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "bytes",
  "ed25519",
@@ -12926,7 +13440,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -12937,7 +13451,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.13.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -12951,7 +13465,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "4.1.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "thiserror",
  "zstd 0.12.3+zstd.1.5.2",
@@ -12960,7 +13474,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",
@@ -12971,7 +13485,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "ckb-merkle-mountain-range",
  "log",
@@ -12989,7 +13503,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13003,7 +13517,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -13013,7 +13527,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -13023,7 +13537,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -13033,7 +13547,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "either",
  "hash256-std-hasher",
@@ -13055,7 +13569,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -13073,7 +13587,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
@@ -13085,7 +13599,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13099,7 +13613,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13112,7 +13626,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.13.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "hash-db",
  "log",
@@ -13132,7 +13646,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -13150,12 +13664,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 
 [[package]]
 name = "sp-storage"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -13168,7 +13682,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "async-trait",
  "futures-timer",
@@ -13183,7 +13697,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "6.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "parity-scale-codec",
  "sp-std",
@@ -13195,7 +13709,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -13204,7 +13718,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "async-trait",
  "log",
@@ -13220,7 +13734,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "ahash 0.8.2",
  "hash-db",
@@ -13243,7 +13757,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -13260,7 +13774,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -13271,7 +13785,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "7.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -13285,7 +13799,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "4.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -13620,15 +14134,28 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "platforms 2.0.0",
 ]
 
 [[package]]
+name = "substrate-frame-cli"
+version = "4.0.0-dev"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
+dependencies = [
+ "clap 4.2.7",
+ "frame-support",
+ "frame-system",
+ "sc-cli",
+ "sp-core",
+ "sp-runtime",
+]
+
+[[package]]
 name = "substrate-frame-rpc-system"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures",
@@ -13647,7 +14174,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "hyper",
  "log",
@@ -13659,7 +14186,7 @@ dependencies = [
 [[package]]
 name = "substrate-rpc-client"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "async-trait",
  "jsonrpsee",
@@ -13672,7 +14199,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-trie-migration-rpc"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "jsonrpsee",
  "log",
@@ -13691,7 +14218,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.1"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "array-bytes 4.2.0",
  "async-trait",
@@ -13717,7 +14244,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-utils"
 version = "4.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "futures",
  "substrate-test-utils-derive",
@@ -13727,7 +14254,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-utils-derive"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -13738,7 +14265,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "5.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "ansi_term",
  "build-helper",
@@ -14392,7 +14919,7 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 [[package]]
 name = "try-runtime-cli"
 version = "0.10.0-dev"
-source = "git+https://github.com/paritytech/substrate?branch=master#3919ca88d1dd0b06f26bd80fd0066a1ad7187081"
+source = "git+https://github.com/paritytech/substrate?branch=master#215336763d36401ea7a0b49564cbb6ad18b2a3c1"
 dependencies = [
  "async-trait",
  "clap 4.2.7",

--- a/test/client/src/lib.rs
+++ b/test/client/src/lib.rs
@@ -178,38 +178,7 @@ pub fn generate_extrinsic(
 	origin: sp_keyring::AccountKeyring,
 	function: impl Into<RuntimeCall>,
 ) -> UncheckedExtrinsic {
-	let current_block_hash = client.info().best_hash;
-	let current_block = client.info().best_number.saturated_into();
-	let genesis_block = client.hash(0).unwrap().unwrap();
-	let nonce = 0;
-	let period =
-		BlockHashCount::get().checked_next_power_of_two().map(|c| c / 2).unwrap_or(2) as u64;
-	let tip = 0;
-	let extra: SignedExtra = (
-		frame_system::CheckNonZeroSender::<Runtime>::new(),
-		frame_system::CheckSpecVersion::<Runtime>::new(),
-		frame_system::CheckGenesis::<Runtime>::new(),
-		frame_system::CheckEra::<Runtime>::from(Era::mortal(period, current_block)),
-		frame_system::CheckNonce::<Runtime>::from(nonce),
-		frame_system::CheckWeight::<Runtime>::new(),
-		pallet_transaction_payment::ChargeTransactionPayment::<Runtime>::from(tip),
-	);
-
-	let function = function.into();
-
-	let raw_payload = SignedPayload::from_raw(
-		function.clone(),
-		extra.clone(),
-		((), VERSION.spec_version, genesis_block, current_block_hash, (), (), ()),
-	);
-	let signature = raw_payload.using_encoded(|e| origin.sign(e));
-
-	UncheckedExtrinsic::new_signed(
-		function,
-		origin.public().into(),
-		Signature::Sr25519(signature),
-		extra,
-	)
+	generate_extrinsic_with_pair(client, origin.into(), function, None)
 }
 
 /// Transfer some token from one account to another using a provided test [`Client`].

--- a/test/runtime/Cargo.toml
+++ b/test/runtime/Cargo.toml
@@ -16,6 +16,7 @@ frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate"
 pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
 pallet-sudo = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
 pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
+pallet-glutton = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
 pallet-transaction-payment = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
 sp-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
 sp-block-builder = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }

--- a/test/runtime/src/lib.rs
+++ b/test/runtime/src/lib.rs
@@ -59,6 +59,7 @@ pub use frame_support::{
 };
 use frame_system::limits::{BlockLength, BlockWeights};
 pub use pallet_balances::Call as BalancesCall;
+pub use pallet_glutton::Call as GluttonCall;
 pub use pallet_sudo::Call as SudoCall;
 pub use pallet_timestamp::Call as TimestampCall;
 #[cfg(any(feature = "std", test))]
@@ -265,6 +266,11 @@ impl pallet_sudo::Config for Runtime {
 	type WeightInfo = pallet_sudo::weights::SubstrateWeight<Runtime>;
 }
 
+impl pallet_glutton::Config for Runtime {
+	type RuntimeEvent = RuntimeEvent;
+	type WeightInfo = pallet_glutton::weights::SubstrateWeight<Runtime>;
+}
+
 impl cumulus_pallet_parachain_system::Config for Runtime {
 	type SelfParaId = ParachainId;
 	type RuntimeEvent = RuntimeEvent;
@@ -296,6 +302,7 @@ construct_runtime! {
 		Sudo: pallet_sudo,
 		TransactionPayment: pallet_transaction_payment,
 		TestPallet: test_pallet,
+		Glutton: pallet_glutton,
 	}
 }
 

--- a/test/service/Cargo.toml
+++ b/test/service/Cargo.toml
@@ -72,8 +72,25 @@ cumulus-relay-chain-minimal-node = { path = "../../client/relay-chain-minimal-no
 cumulus-client-pov-recovery = { path = "../../client/pov-recovery" }
 
 [dev-dependencies]
+tempfile = "3.5.0"
 futures = "0.3.28"
 portpicker = "0.1.1"
+kitchensink-runtime = { git = "https://github.com/paritytech/substrate", branch = "master" }
+rococo-parachain-runtime = { path = "../../parachains/runtimes/testing/rococo-parachain" }
+node-cli = { git = "https://github.com/paritytech/substrate", branch = "master" }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "master" }
+pallet-im-online = { git = "https://github.com/paritytech/substrate", branch = "master" }
+node-primitives = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-block-builder = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-consensus = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-api = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-consensus-grandpa = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sp-authority-discovery = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-executor-common = { git = "https://github.com/paritytech/substrate", branch = "master" }
+sc-executor-wasmtime = { git = "https://github.com/paritytech/substrate", branch = "master" }
+cumulus-pallet-parachain-system = { path = "../../pallets/parachain-system", default-features = false }
+cumulus-test-relay-sproof-builder = { path = "../relay-sproof-builder" }
+cumulus-test-client = { path = "../client" }
 
 # Polkadot dependencies
 polkadot-test-service = { git = "https://github.com/paritytech/polkadot", branch = "master" }
@@ -87,4 +104,28 @@ runtime-benchmarks = ["polkadot-test-service/runtime-benchmarks"]
 
 [[bench]]
 name = "transaction_throughput"
+harness = false
+
+[[bench]]
+name = "block_import"
+harness = false
+
+[[bench]]
+name = "block_production"
+harness = false
+
+[[bench]]
+name = "block_production_compute"
+harness = false
+
+[[bench]]
+name = "block_import_compute"
+harness = false
+
+[[bench]]
+name = "validate_block"
+harness = false
+
+[[bench]]
+name = "validate_block_compute"
 harness = false

--- a/test/service/benches/block_import.rs
+++ b/test/service/benches/block_import.rs
@@ -46,8 +46,6 @@ fn benchmark_block_import(c: &mut Criterion) {
 	);
 	let client = alice.client;
 
-	// Building the very first block is around ~30x slower than any subsequent one,
-	// so let's make sure it's built and imported before we benchmark anything.
 	let mut block_builder = client.new_block(Default::default()).unwrap();
 	block_builder.push(utils::extrinsic_set_time(&client)).unwrap();
 	let parent_hash = client.usage_info().chain.best_hash;

--- a/test/service/benches/block_import.rs
+++ b/test/service/benches/block_import.rs
@@ -1,0 +1,91 @@
+// This file is part of Cumulus.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion, Throughput};
+
+use sc_client_api::UsageProvider;
+
+use core::time::Duration;
+use cumulus_primitives_core::ParaId;
+
+use sc_block_builder::{BlockBuilderProvider, RecordProof};
+use sp_keyring::Sr25519Keyring::Alice;
+
+mod utils;
+
+fn benchmark_block_import(c: &mut Criterion) {
+	sp_tracing::try_init_simple();
+
+	let runtime = tokio::runtime::Runtime::new().expect("creating tokio runtime doesn't fail; qed");
+	let para_id = ParaId::from(100);
+	let tokio_handle = runtime.handle();
+
+	// Create enough accounts to fill the block with transactions.
+	// Each account should only be included in one transfer.
+	let (src_accounts, dst_accounts, account_ids) = utils::create_benchmark_accounts();
+
+	let alice = runtime.block_on(
+		cumulus_test_service::TestNodeBuilder::new(para_id, tokio_handle.clone(), Alice)
+			// Preload all accounts with funds for the transfers
+			.endowed_accounts(account_ids)
+			.build(),
+	);
+	let client = alice.client;
+
+	// Building the very first block is around ~30x slower than any subsequent one,
+	// so let's make sure it's built and imported before we benchmark anything.
+	let mut block_builder = client.new_block(Default::default()).unwrap();
+	block_builder.push(utils::extrinsic_set_time(&client)).unwrap();
+	let parent_hash = client.usage_info().chain.best_hash;
+	let parent_header = client.header(parent_hash).expect("Just fetched this hash.").unwrap();
+	block_builder.push(utils::extrinsic_set_validation_data(parent_header)).unwrap();
+	let built_block = block_builder.build().unwrap();
+	runtime.block_on(utils::import_block(&client, &built_block.block, false));
+
+	let (max_transfer_count, extrinsics) =
+		utils::create_extrinsics(&client, &src_accounts, &dst_accounts);
+
+	// Build the block we will use for benchmarking
+	let parent_hash = client.usage_info().chain.best_hash;
+	let parent_header = client.header(parent_hash).expect("Just fetched this hash.").unwrap();
+	let set_validate_extrinsic = utils::extrinsic_set_validation_data(parent_header.clone());
+	let mut block_builder =
+		client.new_block_at(parent_hash, Default::default(), RecordProof::No).unwrap();
+	block_builder.push(set_validate_extrinsic.clone()).unwrap();
+	for extrinsic in extrinsics.clone() {
+		block_builder.push(extrinsic).unwrap();
+	}
+	let benchmark_block = block_builder.build().unwrap();
+
+	let mut group = c.benchmark_group("Block import");
+	group.sample_size(20);
+	group.measurement_time(Duration::from_secs(120));
+	group.throughput(Throughput::Elements(max_transfer_count as u64));
+
+	group.bench_function(format!("(transfers = {}) block import", max_transfer_count), |b| {
+		b.to_async(&runtime).iter_batched(
+			|| {},
+			|_| async {
+				utils::import_block(&*client, &benchmark_block.block, true).await;
+			},
+			BatchSize::SmallInput,
+		)
+	});
+}
+
+criterion_group!(benches, benchmark_block_import);
+criterion_main!(benches);

--- a/test/service/benches/block_import_compute.rs
+++ b/test/service/benches/block_import_compute.rs
@@ -39,12 +39,8 @@ fn benchmark_block_import(c: &mut Criterion) {
 	let para_id = ParaId::from(100);
 	let tokio_handle = runtime.handle();
 
-	let endowed_accounts = vec![AccountId::from(Alice.public())];
 	let alice = runtime.block_on(
-		cumulus_test_service::TestNodeBuilder::new(para_id, tokio_handle.clone(), Alice)
-			// Preload all accounts with funds for the transfers
-			.endowed_accounts(endowed_accounts)
-			.build(),
+		cumulus_test_service::TestNodeBuilder::new(para_id, tokio_handle.clone(), Alice).build(),
 	);
 	let client = alice.client;
 
@@ -122,7 +118,7 @@ fn set_glutton_parameters(
 				),
 			},
 			Alice.into(),
-			Some(last_nonce + 1),
+			Some(last_nonce),
 		));
 		last_nonce += 1;
 	}
@@ -133,7 +129,7 @@ fn set_glutton_parameters(
 			call: Box::new(GluttonCall::set_compute { compute: compute_percent.clone() }.into()),
 		},
 		Alice.into(),
-		Some(last_nonce + 1),
+		Some(last_nonce),
 	);
 	last_nonce += 1;
 	extrinsics.push(set_compute);
@@ -144,7 +140,7 @@ fn set_glutton_parameters(
 			call: Box::new(GluttonCall::set_storage { storage: storage_percent.clone() }.into()),
 		},
 		Alice.into(),
-		Some(last_nonce + 1),
+		Some(last_nonce),
 	);
 	extrinsics.push(set_storage);
 

--- a/test/service/benches/block_import_compute.rs
+++ b/test/service/benches/block_import_compute.rs
@@ -17,7 +17,7 @@
 
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 
-use cumulus_test_runtime::{AccountId, GluttonCall, NodeBlock, SudoCall};
+use cumulus_test_runtime::{GluttonCall, NodeBlock, SudoCall};
 use cumulus_test_service::{construct_extrinsic, Client as TestClient};
 use sc_client_api::UsageProvider;
 use sp_api::ProvideRuntimeApi;
@@ -98,8 +98,6 @@ fn set_glutton_parameters(
 	compute_percent: &Perbill,
 	storage_percent: &Perbill,
 ) -> NodeBlock {
-	// Building the very first block is around ~30x slower than any subsequent one,
-	// so let's make sure it's built and imported before we benchmark anything.
 	let parent_hash = client.usage_info().chain.best_hash;
 	let parent_header = client.header(parent_hash).expect("Just fetched this hash.").unwrap();
 
@@ -110,6 +108,7 @@ fn set_glutton_parameters(
 
 	let mut extrinsics = vec![];
 	if initialize {
+		// Initialize the pallet
 		extrinsics.push(construct_extrinsic(
 			&client,
 			SudoCall::sudo {
@@ -123,6 +122,7 @@ fn set_glutton_parameters(
 		last_nonce += 1;
 	}
 
+	// Set compute weight that should be consumed per block
 	let set_compute = construct_extrinsic(
 		&client,
 		SudoCall::sudo {
@@ -134,6 +134,7 @@ fn set_glutton_parameters(
 	last_nonce += 1;
 	extrinsics.push(set_compute);
 
+	// Set storage weight that should be consumed per block
 	let set_storage = construct_extrinsic(
 		&client,
 		SudoCall::sudo {

--- a/test/service/benches/block_import_compute.rs
+++ b/test/service/benches/block_import_compute.rs
@@ -1,0 +1,163 @@
+// This file is part of Cumulus.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+
+use cumulus_test_runtime::{AccountId, GluttonCall, NodeBlock, SudoCall};
+use cumulus_test_service::{construct_extrinsic, Client as TestClient};
+use sc_client_api::UsageProvider;
+use sp_api::ProvideRuntimeApi;
+use sp_arithmetic::Perbill;
+
+use core::time::Duration;
+use cumulus_primitives_core::ParaId;
+
+use frame_system_rpc_runtime_api::AccountNonceApi;
+use sc_block_builder::{BlockBuilderProvider, RecordProof};
+use sp_keyring::Sr25519Keyring::Alice;
+
+mod utils;
+
+fn benchmark_block_import(c: &mut Criterion) {
+	sp_tracing::try_init_simple();
+
+	let runtime = tokio::runtime::Runtime::new().expect("creating tokio runtime doesn't fail; qed");
+	let para_id = ParaId::from(100);
+	let tokio_handle = runtime.handle();
+
+	let endowed_accounts = vec![AccountId::from(Alice.public())];
+	let alice = runtime.block_on(
+		cumulus_test_service::TestNodeBuilder::new(para_id, tokio_handle.clone(), Alice)
+			// Preload all accounts with funds for the transfers
+			.endowed_accounts(endowed_accounts)
+			.build(),
+	);
+	let client = alice.client;
+
+	let mut group = c.benchmark_group("Block import");
+	group.sample_size(20);
+	group.measurement_time(Duration::from_secs(120));
+
+	let mut initialize_glutton_pallet = true;
+	for (compute_percent, storage_percent) in vec![
+		(Perbill::from_percent(100), Perbill::from_percent(0)),
+		(Perbill::from_percent(100), Perbill::from_percent(100)),
+	] {
+		let block = set_glutton_parameters(
+			&client,
+			initialize_glutton_pallet,
+			&compute_percent,
+			&compute_percent,
+		);
+		initialize_glutton_pallet = false;
+
+		runtime.block_on(utils::import_block(&client, &block, false));
+
+		// Build the block we will use for benchmarking
+		let parent_hash = client.usage_info().chain.best_hash;
+		let parent_header = client.header(parent_hash).expect("Just fetched this hash.").unwrap();
+		let mut block_builder =
+			client.new_block_at(parent_hash, Default::default(), RecordProof::No).unwrap();
+		block_builder
+			.push(utils::extrinsic_set_validation_data(parent_header.clone()).clone())
+			.unwrap();
+		block_builder.push(utils::extrinsic_set_time(&client)).unwrap();
+		let benchmark_block = block_builder.build().unwrap();
+
+		group.bench_function(
+			format!(
+				"(compute = {:?}, storage = {:?}) block import",
+				compute_percent, storage_percent
+			),
+			|b| {
+				b.to_async(&runtime).iter_batched(
+					|| {},
+					|_| async {
+						utils::import_block(&*client, &benchmark_block.block, true).await;
+					},
+					BatchSize::SmallInput,
+				)
+			},
+		);
+	}
+}
+
+fn set_glutton_parameters(
+	client: &TestClient,
+	initialize: bool,
+	compute_percent: &Perbill,
+	storage_percent: &Perbill,
+) -> NodeBlock {
+	// Building the very first block is around ~30x slower than any subsequent one,
+	// so let's make sure it's built and imported before we benchmark anything.
+	let parent_hash = client.usage_info().chain.best_hash;
+	let parent_header = client.header(parent_hash).expect("Just fetched this hash.").unwrap();
+
+	let mut last_nonce = client
+		.runtime_api()
+		.account_nonce(parent_hash, Alice.into())
+		.expect("Fetching account nonce works; qed");
+
+	let mut extrinsics = vec![];
+	if initialize {
+		extrinsics.push(construct_extrinsic(
+			&client,
+			SudoCall::sudo {
+				call: Box::new(
+					GluttonCall::initialize_pallet { new_count: 5000, witness_count: None }.into(),
+				),
+			},
+			Alice.into(),
+			Some(last_nonce + 1),
+		));
+		last_nonce += 1;
+	}
+
+	let set_compute = construct_extrinsic(
+		&client,
+		SudoCall::sudo {
+			call: Box::new(GluttonCall::set_compute { compute: compute_percent.clone() }.into()),
+		},
+		Alice.into(),
+		Some(last_nonce + 1),
+	);
+	last_nonce += 1;
+	extrinsics.push(set_compute);
+
+	let set_storage = construct_extrinsic(
+		&client,
+		SudoCall::sudo {
+			call: Box::new(GluttonCall::set_storage { storage: storage_percent.clone() }.into()),
+		},
+		Alice.into(),
+		Some(last_nonce + 1),
+	);
+	extrinsics.push(set_storage);
+
+	let mut block_builder = client.new_block(Default::default()).unwrap();
+	block_builder.push(utils::extrinsic_set_time(&client)).unwrap();
+	block_builder.push(utils::extrinsic_set_validation_data(parent_header)).unwrap();
+	for extrinsic in extrinsics {
+		block_builder.push(extrinsic.into()).unwrap();
+	}
+
+	let built_block = block_builder.build().unwrap();
+	built_block.block
+}
+
+criterion_group!(benches, benchmark_block_import);
+criterion_main!(benches);

--- a/test/service/benches/block_production.rs
+++ b/test/service/benches/block_production.rs
@@ -1,0 +1,116 @@
+// This file is part of Cumulus.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion, Throughput};
+
+use sc_client_api::UsageProvider;
+
+use core::time::Duration;
+use cumulus_primitives_core::ParaId;
+use sc_block_builder::{BlockBuilderProvider, RecordProof};
+
+use sp_keyring::Sr25519Keyring::Alice;
+
+mod utils;
+
+fn benchmark_block_production(c: &mut Criterion) {
+	sp_tracing::try_init_simple();
+
+	let runtime = tokio::runtime::Runtime::new().expect("creating tokio runtime doesn't fail; qed");
+	let tokio_handle = runtime.handle();
+
+	// Create enough accounts to fill the block with transactions.
+	// Each account should only be included in one transfer.
+	let (src_accounts, dst_accounts, account_ids) = utils::create_benchmark_accounts();
+
+	let para_id = ParaId::from(100);
+	let alice = runtime.block_on(
+		cumulus_test_service::TestNodeBuilder::new(para_id, tokio_handle.clone(), Alice)
+			// Preload all accounts with funds for the transfers
+			.endowed_accounts(account_ids)
+			.build(),
+	);
+	let client = alice.client;
+
+	// Building the very first block is around ~30x slower than any subsequent one,
+	// so let's make sure it's built and imported before we benchmark anything.
+	let parent_hash = client.usage_info().chain.best_hash;
+	let parent_header = client.header(parent_hash).expect("Just fetched this hash.").unwrap();
+	let set_validation_data_extrinsic = utils::extrinsic_set_validation_data(parent_header);
+
+	let mut block_builder = client.new_block(Default::default()).unwrap();
+	block_builder.push(utils::extrinsic_set_time(&client)).unwrap();
+	block_builder.push(set_validation_data_extrinsic.clone()).unwrap();
+	let built_block = block_builder.build().unwrap();
+	runtime.block_on(utils::import_block(&client, &built_block.block, false));
+
+	let (max_transfer_count, mut extrinsics) =
+		utils::create_extrinsics(&client, &src_accounts, &dst_accounts);
+	let parent_hash = client.usage_info().chain.best_hash;
+	let parent_header = client.header(parent_hash).expect("Just fetched this hash.").unwrap();
+	let set_validation_data_extrinsic = utils::extrinsic_set_validation_data(parent_header);
+	extrinsics.push(set_validation_data_extrinsic);
+
+	let mut group = c.benchmark_group("Block production");
+
+	group.sample_size(20);
+	group.measurement_time(Duration::from_secs(120));
+	group.throughput(Throughput::Elements(max_transfer_count as u64));
+
+	let best_hash = client.chain_info().best_hash;
+
+	group.bench_function(
+		format!("(proof = true, transfers = {}) block production", max_transfer_count),
+		|b| {
+			b.iter_batched(
+				|| extrinsics.clone(),
+				|extrinsics| {
+					let mut block_builder = client
+						.new_block_at(best_hash, Default::default(), RecordProof::Yes)
+						.unwrap();
+					for extrinsic in extrinsics {
+						block_builder.push(extrinsic).unwrap();
+					}
+					block_builder.build().unwrap()
+				},
+				BatchSize::SmallInput,
+			)
+		},
+	);
+
+	group.bench_function(
+		format!("(proof = false, transfers = {}) block production", max_transfer_count),
+		|b| {
+			b.iter_batched(
+				|| extrinsics.clone(),
+				|extrinsics| {
+					let mut block_builder = client
+						.new_block_at(best_hash, Default::default(), RecordProof::No)
+						.unwrap();
+					for extrinsic in extrinsics {
+						block_builder.push(extrinsic).unwrap();
+					}
+					block_builder.build().unwrap()
+				},
+				BatchSize::SmallInput,
+			)
+		},
+	);
+}
+
+criterion_group!(benches, benchmark_block_production);
+criterion_main!(benches);

--- a/test/service/benches/block_production.rs
+++ b/test/service/benches/block_production.rs
@@ -46,8 +46,6 @@ fn benchmark_block_production(c: &mut Criterion) {
 	);
 	let client = alice.client;
 
-	// Building the very first block is around ~30x slower than any subsequent one,
-	// so let's make sure it's built and imported before we benchmark anything.
 	let parent_hash = client.usage_info().chain.best_hash;
 	let parent_header = client.header(parent_hash).expect("Just fetched this hash.").unwrap();
 	let set_validation_data_extrinsic = utils::extrinsic_set_validation_data(parent_header);
@@ -56,6 +54,7 @@ fn benchmark_block_production(c: &mut Criterion) {
 	block_builder.push(utils::extrinsic_set_time(&client)).unwrap();
 	block_builder.push(set_validation_data_extrinsic.clone()).unwrap();
 	let built_block = block_builder.build().unwrap();
+
 	runtime.block_on(utils::import_block(&client, &built_block.block, false));
 
 	let (max_transfer_count, mut extrinsics) =

--- a/test/service/benches/block_production_compute.rs
+++ b/test/service/benches/block_production_compute.rs
@@ -17,7 +17,7 @@
 
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 
-use cumulus_test_runtime::{AccountId, GluttonCall, NodeBlock, SudoCall};
+use cumulus_test_runtime::{GluttonCall, NodeBlock, SudoCall};
 use cumulus_test_service::{construct_extrinsic, Client as TestClient};
 use sc_client_api::UsageProvider;
 use sp_arithmetic::Perbill;

--- a/test/service/benches/block_production_compute.rs
+++ b/test/service/benches/block_production_compute.rs
@@ -1,0 +1,185 @@
+// This file is part of Cumulus.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+
+use cumulus_test_runtime::{AccountId, GluttonCall, NodeBlock, SudoCall};
+use cumulus_test_service::{construct_extrinsic, Client as TestClient};
+use sc_client_api::UsageProvider;
+use sp_arithmetic::Perbill;
+
+use core::time::Duration;
+use cumulus_primitives_core::ParaId;
+use frame_system_rpc_runtime_api::AccountNonceApi;
+use sc_block_builder::{BlockBuilderProvider, RecordProof};
+use sp_api::ProvideRuntimeApi;
+
+use sp_keyring::Sr25519Keyring::Alice;
+
+mod utils;
+
+fn benchmark_block_production_compute(c: &mut Criterion) {
+	sp_tracing::try_init_simple();
+
+	let runtime = tokio::runtime::Runtime::new().expect("creating tokio runtime doesn't fail; qed");
+	let tokio_handle = runtime.handle();
+
+	let para_id = ParaId::from(100);
+	let endowed_accounts = vec![AccountId::from(Alice.public())];
+	let alice = runtime.block_on(
+		cumulus_test_service::TestNodeBuilder::new(para_id, tokio_handle.clone(), Alice)
+			// Preload all accounts with funds for the transfers
+			.endowed_accounts(endowed_accounts)
+			.build(),
+	);
+	let client = alice.client;
+
+	let mut group = c.benchmark_group("Block production");
+
+	group.sample_size(20);
+	group.measurement_time(Duration::from_secs(120));
+
+	let mut initialize_glutton_pallet = true;
+	for (compute_level, storage_level) in vec![
+		(Perbill::from_percent(100), Perbill::from_percent(0)),
+		(Perbill::from_percent(100), Perbill::from_percent(100)),
+	] {
+		let block = set_glutton_parameters(
+			&client,
+			initialize_glutton_pallet,
+			&compute_level,
+			&storage_level,
+		);
+		runtime.block_on(utils::import_block(&client, &block, false));
+		initialize_glutton_pallet = false;
+
+		let parent_hash = client.usage_info().chain.best_hash;
+		let parent_header = client.header(parent_hash).expect("Just fetched this hash.").unwrap();
+		let set_validation_data_extrinsic = utils::extrinsic_set_validation_data(parent_header);
+		let set_time_extrinsic = utils::extrinsic_set_time(&client);
+		let best_hash = client.chain_info().best_hash;
+
+		group.bench_function(
+			format!(
+				"(compute = {:?}, storage = {:?}, proof = true) block production",
+				compute_level, storage_level
+			),
+			|b| {
+				b.iter_batched(
+					|| (set_validation_data_extrinsic.clone(), set_time_extrinsic.clone()),
+					|(validation_data, time)| {
+						let mut block_builder = client
+							.new_block_at(best_hash, Default::default(), RecordProof::Yes)
+							.unwrap();
+						block_builder.push(validation_data).unwrap();
+						block_builder.push(time).unwrap();
+						block_builder.build().unwrap()
+					},
+					BatchSize::SmallInput,
+				)
+			},
+		);
+
+		group.bench_function(
+			format!(
+				"(compute = {:?}, storage = {:?}, proof = false) block production",
+				compute_level, storage_level
+			),
+			|b| {
+				b.iter_batched(
+					|| (set_validation_data_extrinsic.clone(), set_time_extrinsic.clone()),
+					|(validation_data, time)| {
+						let mut block_builder = client
+							.new_block_at(best_hash, Default::default(), RecordProof::No)
+							.unwrap();
+						block_builder.push(validation_data).unwrap();
+						block_builder.push(time).unwrap();
+						block_builder.build().unwrap()
+					},
+					BatchSize::SmallInput,
+				)
+			},
+		);
+	}
+}
+
+/// Initialize glutton pallet and set compute and storage limits.
+fn set_glutton_parameters(
+	client: &TestClient,
+	initialize: bool,
+	compute_percent: &Perbill,
+	storage_percent: &Perbill,
+) -> NodeBlock {
+	// Building the very first block is around ~30x slower than any subsequent one,
+	// so let's make sure it's built and imported before we benchmark anything.
+	let parent_hash = client.usage_info().chain.best_hash;
+	let parent_header = client.header(parent_hash).expect("Just fetched this hash.").unwrap();
+
+	let mut last_nonce = client
+		.runtime_api()
+		.account_nonce(parent_hash, Alice.into())
+		.expect("Fetching account nonce works; qed");
+
+	let mut extrinsics = vec![];
+	if initialize {
+		extrinsics.push(construct_extrinsic(
+			&client,
+			SudoCall::sudo {
+				call: Box::new(
+					GluttonCall::initialize_pallet { new_count: 5000, witness_count: None }.into(),
+				),
+			},
+			Alice.into(),
+			Some(last_nonce),
+		));
+		last_nonce += 1;
+	}
+
+	let set_compute = construct_extrinsic(
+		&client,
+		SudoCall::sudo {
+			call: Box::new(GluttonCall::set_compute { compute: compute_percent.clone() }.into()),
+		},
+		Alice.into(),
+		Some(last_nonce),
+	);
+	last_nonce += 1;
+	extrinsics.push(set_compute);
+
+	let set_storage = construct_extrinsic(
+		&client,
+		SudoCall::sudo {
+			call: Box::new(GluttonCall::set_storage { storage: storage_percent.clone() }.into()),
+		},
+		Alice.into(),
+		Some(last_nonce),
+	);
+	extrinsics.push(set_storage);
+
+	let mut block_builder = client.new_block(Default::default()).unwrap();
+	block_builder.push(utils::extrinsic_set_time(&client)).unwrap();
+	block_builder.push(utils::extrinsic_set_validation_data(parent_header)).unwrap();
+	for extrinsic in extrinsics {
+		block_builder.push(extrinsic.into()).unwrap();
+	}
+
+	let built_block = block_builder.build().unwrap();
+	built_block.block
+}
+
+criterion_group!(benches, benchmark_block_production_compute);
+criterion_main!(benches);

--- a/test/service/benches/block_production_compute.rs
+++ b/test/service/benches/block_production_compute.rs
@@ -113,15 +113,12 @@ fn benchmark_block_production_compute(c: &mut Criterion) {
 	}
 }
 
-/// Initialize glutton pallet and set compute and storage limits.
 fn set_glutton_parameters(
 	client: &TestClient,
 	initialize: bool,
 	compute_percent: &Perbill,
 	storage_percent: &Perbill,
 ) -> NodeBlock {
-	// Building the very first block is around ~30x slower than any subsequent one,
-	// so let's make sure it's built and imported before we benchmark anything.
 	let parent_hash = client.usage_info().chain.best_hash;
 	let parent_header = client.header(parent_hash).expect("Just fetched this hash.").unwrap();
 
@@ -132,6 +129,7 @@ fn set_glutton_parameters(
 
 	let mut extrinsics = vec![];
 	if initialize {
+		// Initialize the pallet
 		extrinsics.push(construct_extrinsic(
 			&client,
 			SudoCall::sudo {
@@ -145,6 +143,7 @@ fn set_glutton_parameters(
 		last_nonce += 1;
 	}
 
+	// Set compute weight that should be consumed per block
 	let set_compute = construct_extrinsic(
 		&client,
 		SudoCall::sudo {
@@ -156,6 +155,7 @@ fn set_glutton_parameters(
 	last_nonce += 1;
 	extrinsics.push(set_compute);
 
+	// Set storage weight that should be consumed per block
 	let set_storage = construct_extrinsic(
 		&client,
 		SudoCall::sudo {

--- a/test/service/benches/block_production_compute.rs
+++ b/test/service/benches/block_production_compute.rs
@@ -39,12 +39,8 @@ fn benchmark_block_production_compute(c: &mut Criterion) {
 	let tokio_handle = runtime.handle();
 
 	let para_id = ParaId::from(100);
-	let endowed_accounts = vec![AccountId::from(Alice.public())];
 	let alice = runtime.block_on(
-		cumulus_test_service::TestNodeBuilder::new(para_id, tokio_handle.clone(), Alice)
-			// Preload all accounts with funds for the transfers
-			.endowed_accounts(endowed_accounts)
-			.build(),
+		cumulus_test_service::TestNodeBuilder::new(para_id, tokio_handle.clone(), Alice).build(),
 	);
 	let client = alice.client;
 

--- a/test/service/benches/utils.rs
+++ b/test/service/benches/utils.rs
@@ -1,0 +1,204 @@
+// This file is part of Cumulus.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use codec::Encode;
+
+use cumulus_primitives_parachain_inherent::ParachainInherentData;
+use cumulus_test_relay_sproof_builder::RelayStateSproofBuilder;
+use cumulus_test_runtime::{BalancesCall, NodeBlock, UncheckedExtrinsic, WASM_BINARY};
+use cumulus_test_service::{construct_extrinsic, Client as TestClient};
+use polkadot_primitives::HeadData;
+use sc_client_api::UsageProvider;
+
+use cumulus_primitives_core::{relay_chain::AccountId, PersistedValidationData};
+use sc_block_builder::BlockBuilderProvider;
+use sc_consensus::{
+	block_import::{BlockImportParams, ForkChoiceStrategy},
+	BlockImport, ImportResult, StateAction,
+};
+use sc_executor::DEFAULT_HEAP_ALLOC_STRATEGY;
+use sc_executor_common::runtime_blob::RuntimeBlob;
+use sp_blockchain::{ApplyExtrinsicFailed::Validity, Error::ApplyExtrinsicFailed};
+use sp_consensus::BlockOrigin;
+use sp_core::{sr25519, Pair};
+use sp_keyring::Sr25519Keyring::Alice;
+use sp_runtime::{
+	transaction_validity::{InvalidTransaction, TransactionValidityError},
+	AccountId32, OpaqueExtrinsic,
+};
+
+// Accounts to use for transfer transactions. Enough for 5000 transactions.
+const NUM_ACCOUNTS: usize = 10000;
+
+pub(crate) fn create_benchmark_accounts(
+) -> (Vec<sr25519::Pair>, Vec<sr25519::Pair>, Vec<AccountId32>) {
+	let accounts: Vec<sr25519::Pair> = (0..NUM_ACCOUNTS)
+		.into_iter()
+		.map(|idx| {
+			Pair::from_string(&format!("{}/{}", Alice.to_seed(), idx), None)
+				.expect("Creates account pair")
+		})
+		.collect();
+	let account_ids = accounts
+		.iter()
+		.map(|account| AccountId::from(account.public()))
+		.collect::<Vec<AccountId>>();
+	let (src_accounts, dst_accounts) = accounts.split_at(NUM_ACCOUNTS / 2);
+	(src_accounts.to_vec(), dst_accounts.to_vec(), account_ids)
+}
+
+pub(crate) fn extrinsic_set_time(client: &TestClient) -> OpaqueExtrinsic {
+	let best_number = client.usage_info().chain.best_number;
+
+	let timestamp = best_number as u64 * cumulus_test_runtime::MinimumPeriod::get();
+	cumulus_test_runtime::UncheckedExtrinsic {
+		signature: None,
+		function: cumulus_test_runtime::RuntimeCall::Timestamp(pallet_timestamp::Call::set {
+			now: timestamp,
+		}),
+	}
+	.into()
+}
+
+pub(crate) fn extrinsic_set_validation_data(
+	parent_header: cumulus_test_runtime::Header,
+) -> OpaqueExtrinsic {
+	let mut sproof_builder = RelayStateSproofBuilder::default();
+	sproof_builder.para_id = 100.into();
+	let parent_head = HeadData(parent_header.encode());
+	let (relay_parent_storage_root, relay_chain_state) = sproof_builder.into_state_root_and_proof();
+	let data = ParachainInherentData {
+		validation_data: PersistedValidationData {
+			parent_head,
+			relay_parent_number: 10,
+			relay_parent_storage_root,
+			max_pov_size: 10000,
+		},
+		relay_chain_state,
+		downward_messages: Default::default(),
+		horizontal_messages: Default::default(),
+	};
+
+	cumulus_test_runtime::UncheckedExtrinsic {
+		signature: None,
+		function: cumulus_test_runtime::RuntimeCall::ParachainSystem(
+			cumulus_pallet_parachain_system::Call::set_validation_data { data },
+		),
+	}
+	.into()
+}
+
+pub(crate) async fn import_block(
+	mut client: &TestClient,
+	block: &NodeBlock,
+	import_existing: bool,
+) {
+	let mut params = BlockImportParams::new(BlockOrigin::File, block.header.clone());
+	params.body = Some(block.extrinsics.clone());
+	params.state_action = StateAction::Execute;
+	params.fork_choice = Some(ForkChoiceStrategy::LongestChain);
+	params.import_existing = import_existing;
+	let import_result = client.import_block(params).await;
+	assert_eq!(
+		true,
+		matches!(import_result, Ok(ImportResult::Imported(_))),
+		"Unexpected block import result: {:?}!",
+		import_result
+	);
+}
+
+pub(crate) fn create_extrinsics(
+	client: &TestClient,
+	src_accounts: &[sr25519::Pair],
+	dst_accounts: &[sr25519::Pair],
+) -> (usize, Vec<OpaqueExtrinsic>) {
+	// Add as many tranfer extrinsics as possible into a single block.
+	let mut block_builder = client.new_block(Default::default()).unwrap();
+	let mut max_transfer_count = 0;
+	let mut extrinsics = Vec::new();
+	// Every block needs one timestamp extrinsic.
+	let time_ext = extrinsic_set_time(client);
+	extrinsics.push(time_ext);
+
+	for (src, dst) in src_accounts.iter().zip(dst_accounts.iter()) {
+		let extrinsic: UncheckedExtrinsic = construct_extrinsic(
+			client,
+			BalancesCall::transfer_keep_alive {
+				dest: AccountId::from(dst.public()).into(),
+				value: 10000,
+			},
+			src.clone(),
+			Some(0),
+		);
+
+		match block_builder.push(extrinsic.clone().into()) {
+			Ok(_) => {},
+			Err(ApplyExtrinsicFailed(Validity(TransactionValidityError::Invalid(
+				InvalidTransaction::ExhaustsResources,
+			)))) => break,
+			Err(error) => panic!("{}", error),
+		}
+
+		extrinsics.push(extrinsic.into());
+		max_transfer_count += 1;
+	}
+
+	if max_transfer_count >= src_accounts.len() {
+		panic!("Block could fit more transfers, increase NUM_ACCOUNTS to generate more accounts.");
+	}
+
+	(max_transfer_count, extrinsics)
+}
+
+pub(crate) fn get_wasm_module() -> Box<dyn sc_executor_common::wasm_runtime::WasmModule> {
+	let blob = RuntimeBlob::uncompress_if_needed(
+		WASM_BINARY.expect("You need to build the WASM binaries to run the benchmark!"),
+	)
+	.unwrap();
+
+	let allow_missing_func_imports = true;
+
+	let config = sc_executor_wasmtime::Config {
+		allow_missing_func_imports,
+		cache_path: None,
+		semantics: sc_executor_wasmtime::Semantics {
+			heap_alloc_strategy: DEFAULT_HEAP_ALLOC_STRATEGY,
+			instantiation_strategy: sc_executor::WasmtimeInstantiationStrategy::PoolingCopyOnWrite,
+			deterministic_stack_limit: None,
+			canonicalize_nans: false,
+			parallel_compilation: true,
+			wasm_multi_value: false,
+			wasm_bulk_memory: false,
+			wasm_reference_types: false,
+			wasm_simd: false,
+		},
+	};
+	let prepared_blob =
+		sc_executor_wasmtime::prepare_runtime_artifact(blob, &config.semantics).unwrap();
+
+	let tmpdir = tempfile::tempdir().expect("Should be able to create temp dir.");
+	let path = tmpdir.path().join("module.bin");
+	std::fs::write(&path, &prepared_blob).unwrap();
+	unsafe {
+		Box::new(
+			sc_executor_wasmtime::create_runtime_from_artifact::<sp_io::SubstrateHostFunctions>(
+				&path, config,
+			)
+			.expect("works"),
+		)
+	}
+}

--- a/test/service/benches/validate_block.rs
+++ b/test/service/benches/validate_block.rs
@@ -126,7 +126,7 @@ fn benchmark_block_validation(c: &mut Criterion) {
 	// we expect.
 	verify_expected_result(&runtime, &encoded_params, parachain_block.into_block());
 
-	let mut group = c.benchmark_group("Block production");
+	let mut group = c.benchmark_group("Block validation");
 	group.sample_size(20);
 	group.measurement_time(Duration::from_secs(120));
 	group.throughput(Throughput::Elements(max_transfer_count as u64));

--- a/test/service/benches/validate_block.rs
+++ b/test/service/benches/validate_block.rs
@@ -1,0 +1,169 @@
+// This file is part of Cumulus.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use codec::{Decode, Encode};
+use core::time::Duration;
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion, Throughput};
+use cumulus_primitives_core::{relay_chain::AccountId, PersistedValidationData, ValidationParams};
+use cumulus_test_client::{
+	generate_extrinsic_with_pair, BuildParachainBlockData, InitBlockBuilder, TestClientBuilder,
+	ValidationResult,
+};
+use cumulus_test_relay_sproof_builder::RelayStateSproofBuilder;
+use cumulus_test_runtime::{BalancesCall, Block, Header, UncheckedExtrinsic};
+use polkadot_primitives::HeadData;
+use sc_block_builder::BlockBuilderProvider;
+use sc_client_api::UsageProvider;
+use sc_executor_common::wasm_runtime::WasmModule;
+
+use sp_blockchain::{ApplyExtrinsicFailed::Validity, Error::ApplyExtrinsicFailed};
+
+use sp_core::{sr25519, Pair};
+
+use sp_runtime::{
+	traits::Header as HeaderT,
+	transaction_validity::{InvalidTransaction, TransactionValidityError},
+};
+
+mod utils;
+
+fn create_extrinsics(
+	client: &cumulus_test_client::Client,
+	src_accounts: &[sr25519::Pair],
+	dst_accounts: &[sr25519::Pair],
+) -> (usize, Vec<UncheckedExtrinsic>) {
+	// Add as many tranfer extrinsics as possible into a single block.
+	let mut block_builder = client.new_block(Default::default()).unwrap();
+	let mut max_transfer_count = 0;
+	let mut extrinsics = Vec::new();
+
+	for (src, dst) in src_accounts.iter().zip(dst_accounts.iter()) {
+		let extrinsic: UncheckedExtrinsic = generate_extrinsic_with_pair(
+			client,
+			src.clone(),
+			BalancesCall::transfer_keep_alive {
+				dest: AccountId::from(dst.public()).into(),
+				value: 10000,
+			},
+			None,
+		);
+
+		match block_builder.push(extrinsic.clone().into()) {
+			Ok(_) => {},
+			Err(ApplyExtrinsicFailed(Validity(TransactionValidityError::Invalid(
+				InvalidTransaction::ExhaustsResources,
+			)))) => break,
+			Err(error) => panic!("{}", error),
+		}
+
+		extrinsics.push(extrinsic.into());
+		max_transfer_count += 1;
+	}
+
+	(max_transfer_count, extrinsics)
+}
+
+fn benchmark_block_validation(c: &mut Criterion) {
+	sp_tracing::try_init_simple();
+	// Create enough accounts to fill the block with transactions.
+	// Each account should only be included in one transfer.
+	let (src_accounts, dst_accounts, account_ids) = utils::create_benchmark_accounts();
+
+	let mut test_client_builder = TestClientBuilder::with_default_backend()
+		.set_execution_strategy(sc_client_api::ExecutionStrategy::AlwaysWasm);
+	let genesis_init = test_client_builder.genesis_init_mut();
+	*genesis_init = cumulus_test_client::GenesisParameters { endowed_accounts: account_ids };
+	let client = test_client_builder.build_with_native_executor(None).0;
+
+	let (max_transfer_count, extrinsics) = create_extrinsics(&client, &src_accounts, &dst_accounts);
+
+	let parent_hash = client.usage_info().chain.best_hash;
+	let parent_header = client.header(parent_hash).expect("Just fetched this hash.").unwrap();
+
+	let validation_data = PersistedValidationData {
+		relay_parent_number: 1,
+		parent_head: parent_header.encode().into(),
+		..Default::default()
+	};
+
+	let mut block_builder =
+		client.init_block_builder(Some(validation_data.clone()), Default::default());
+	for extrinsic in extrinsics.clone() {
+		block_builder.push(extrinsic).unwrap();
+	}
+
+	let parachain_block = block_builder.build_parachain_block(*parent_header.state_root());
+
+	let proof_size_in_kb = parachain_block.storage_proof().encode().len() as f64 / 1024f64;
+	let runtime = utils::get_wasm_module();
+
+	let sproof_builder: RelayStateSproofBuilder = Default::default();
+	let (relay_parent_storage_root, _) = sproof_builder.clone().into_state_root_and_proof();
+	let encoded_params = ValidationParams {
+		block_data: cumulus_test_client::BlockData(parachain_block.clone().encode()),
+		parent_head: HeadData(parent_header.encode()),
+		relay_parent_number: 1,
+		relay_parent_storage_root: relay_parent_storage_root.clone(),
+	}
+	.encode();
+
+	// This is not strictly necessary for this benchmark, but
+	// let us make sure that the result of `validate_block` is what
+	// we expect.
+	verify_expected_result(&runtime, &encoded_params, parachain_block.into_block());
+
+	let mut group = c.benchmark_group("Block production");
+	group.sample_size(20);
+	group.measurement_time(Duration::from_secs(120));
+	group.throughput(Throughput::Elements(max_transfer_count as u64));
+
+	group.bench_function(
+		format!(
+			"(transfers = {}, proof_size = {}kb) block validation",
+			max_transfer_count, proof_size_in_kb
+		),
+		|b| {
+			b.iter_batched(
+				|| runtime.new_instance().unwrap(),
+				|mut instance| {
+					instance.call_export("validate_block", &encoded_params).unwrap();
+				},
+				BatchSize::SmallInput,
+			)
+		},
+	);
+}
+
+fn verify_expected_result(
+	runtime: &Box<dyn WasmModule>,
+	encoded_params: &Vec<u8>,
+	parachain_block: Block,
+) {
+	let res = runtime
+		.new_instance()
+		.unwrap()
+		.call_export("validate_block", encoded_params)
+		.expect("Call `validate_block`.");
+	let validation_result =
+		ValidationResult::decode(&mut &res[..]).expect("Decode `ValidationResult`.");
+	let header =
+		Header::decode(&mut &validation_result.head_data.0[..]).expect("Decodes `Header`.");
+	assert_eq!(parachain_block.header, header);
+}
+
+criterion_group!(benches, benchmark_block_validation);
+criterion_main!(benches);

--- a/test/service/benches/validate_block_compute.rs
+++ b/test/service/benches/validate_block_compute.rs
@@ -149,8 +149,6 @@ fn set_glutton_parameters(
 	compute_percent: &Perbill,
 	storage_percent: &Perbill,
 ) -> ParachainBlockData {
-	// Building the very first block is around ~30x slower than any subsequent one,
-	// so let's make sure it's built and imported before we benchmark anything.
 	let parent_hash = client.usage_info().chain.best_hash;
 	let parent_header = client.header(parent_hash).expect("Just fetched this hash.").unwrap();
 

--- a/test/service/benches/validate_block_compute.rs
+++ b/test/service/benches/validate_block_compute.rs
@@ -1,0 +1,215 @@
+// This file is part of Cumulus.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use codec::{Decode, Encode};
+use core::time::Duration;
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use cumulus_primitives_core::{relay_chain::AccountId, PersistedValidationData, ValidationParams};
+use cumulus_test_client::{
+	generate_extrinsic_with_pair, BuildParachainBlockData, Client, InitBlockBuilder,
+	ParachainBlockData, TestClientBuilder, ValidationResult,
+};
+use cumulus_test_relay_sproof_builder::RelayStateSproofBuilder;
+use cumulus_test_runtime::{Block, GluttonCall, Header, SudoCall};
+use polkadot_primitives::HeadData;
+use sc_client_api::UsageProvider;
+use sc_consensus::{BlockImport, BlockImportParams, ForkChoiceStrategy, ImportResult, StateAction};
+use sc_executor_common::wasm_runtime::WasmModule;
+use sp_api::ProvideRuntimeApi;
+
+use frame_system_rpc_runtime_api::AccountNonceApi;
+use sp_arithmetic::Perbill;
+use sp_consensus::BlockOrigin;
+use sp_keyring::Sr25519Keyring::Alice;
+use sp_runtime::traits::Header as HeaderT;
+
+mod utils;
+
+async fn import_block(
+	mut client: &cumulus_test_client::Client,
+	built: cumulus_test_runtime::Block,
+	import_existing: bool,
+) {
+	let mut params = BlockImportParams::new(BlockOrigin::File, built.header.clone());
+	params.body = Some(built.extrinsics.clone());
+	params.state_action = StateAction::Execute;
+	params.fork_choice = Some(ForkChoiceStrategy::LongestChain);
+	params.import_existing = import_existing;
+	let import_result = client.import_block(params).await;
+	assert_eq!(true, matches!(import_result, Ok(ImportResult::Imported(_))));
+}
+
+fn benchmark_block_validation(c: &mut Criterion) {
+	sp_tracing::try_init_simple();
+	let runtime = tokio::runtime::Runtime::new().expect("creating tokio runtime doesn't fail; qed");
+
+	let endowed_accounts = vec![AccountId::from(Alice.public())];
+	let mut test_client_builder = TestClientBuilder::with_default_backend()
+		.set_execution_strategy(sc_client_api::ExecutionStrategy::NativeElseWasm);
+	let genesis_init = test_client_builder.genesis_init_mut();
+	*genesis_init = cumulus_test_client::GenesisParameters { endowed_accounts };
+
+	let client = test_client_builder.build_with_native_executor(None).0;
+
+	let mut group = c.benchmark_group("Block validation");
+	group.sample_size(20);
+	group.measurement_time(Duration::from_secs(120));
+
+	// In the first iteration we want to initialie the glutton pallet
+	let mut is_first = true;
+	for (compute_percent, storage_percent) in vec![
+		(Perbill::from_percent(100), Perbill::from_percent(0)),
+		(Perbill::from_percent(100), Perbill::from_percent(100)),
+	] {
+		let parachain_block =
+			set_glutton_parameters(&client, is_first, &compute_percent, &storage_percent);
+		is_first = false;
+
+		runtime.block_on(import_block(&client, parachain_block.clone().into_block(), false));
+
+		// Build benchmark block
+		let parent_hash = client.usage_info().chain.best_hash;
+		let parent_header = client.header(parent_hash).expect("Just fetched this hash.").unwrap();
+		let validation_data = PersistedValidationData {
+			relay_parent_number: 1,
+			parent_head: parent_header.encode().into(),
+			..Default::default()
+		};
+		let block_builder =
+			client.init_block_builder(Some(validation_data.clone()), Default::default());
+		let parachain_block = block_builder.build_parachain_block(*parent_header.state_root());
+
+		let proof_size_in_kb = parachain_block.storage_proof().encode().len() as f64 / 1024f64;
+		runtime.block_on(import_block(&client, parachain_block.clone().into_block(), false));
+		let runtime = utils::get_wasm_module();
+
+		let sproof_builder: RelayStateSproofBuilder = Default::default();
+		let (relay_parent_storage_root, _) = sproof_builder.clone().into_state_root_and_proof();
+		let encoded_params = ValidationParams {
+			block_data: cumulus_test_client::BlockData(parachain_block.clone().encode()),
+			parent_head: HeadData(parent_header.encode()),
+			relay_parent_number: 1,
+			relay_parent_storage_root: relay_parent_storage_root.clone(),
+		}
+		.encode();
+
+		// This is not strictly necessary for this benchmark, but
+		// let us make sure that the result of `validate_block` is what
+		// we expect.
+		verify_expected_result(&runtime, &encoded_params, parachain_block.into_block());
+
+		group.bench_function(
+			format!(
+				"(compute = {:?}, storage = {:?}, proof_size = {}kb) block validation",
+				compute_percent, storage_percent, proof_size_in_kb
+			),
+			|b| {
+				b.iter_batched(
+					|| runtime.new_instance().unwrap(),
+					|mut instance| {
+						instance.call_export("validate_block", &encoded_params).unwrap();
+					},
+					BatchSize::SmallInput,
+				)
+			},
+		);
+	}
+}
+
+fn verify_expected_result(runtime: &Box<dyn WasmModule>, encoded_params: &Vec<u8>, block: Block) {
+	let res = runtime
+		.new_instance()
+		.unwrap()
+		.call_export("validate_block", encoded_params)
+		.expect("Call `validate_block`.");
+	let validation_result =
+		ValidationResult::decode(&mut &res[..]).expect("Decode `ValidationResult`.");
+	let header =
+		Header::decode(&mut &validation_result.head_data.0[..]).expect("Decodes `Header`.");
+	assert_eq!(block.header, header);
+}
+
+fn set_glutton_parameters(
+	client: &Client,
+	initialize: bool,
+	compute_percent: &Perbill,
+	storage_percent: &Perbill,
+) -> ParachainBlockData {
+	// Building the very first block is around ~30x slower than any subsequent one,
+	// so let's make sure it's built and imported before we benchmark anything.
+	let parent_hash = client.usage_info().chain.best_hash;
+	let parent_header = client.header(parent_hash).expect("Just fetched this hash.").unwrap();
+
+	let mut last_nonce = client
+		.runtime_api()
+		.account_nonce(parent_hash, Alice.into())
+		.expect("Fetching account nonce works; qed");
+
+	let validation_data = PersistedValidationData {
+		relay_parent_number: 1,
+		parent_head: parent_header.encode().into(),
+		..Default::default()
+	};
+
+	let mut extrinsics = vec![];
+	if initialize {
+		extrinsics.push(generate_extrinsic_with_pair(
+			&client,
+			Alice.into(),
+			SudoCall::sudo {
+				call: Box::new(
+					GluttonCall::initialize_pallet { new_count: 5000, witness_count: None }.into(),
+				),
+			},
+			Some(last_nonce),
+		));
+		last_nonce += 1;
+	}
+
+	let set_compute = generate_extrinsic_with_pair(
+		&client,
+		Alice.into(),
+		SudoCall::sudo {
+			call: Box::new(GluttonCall::set_compute { compute: compute_percent.clone() }.into()),
+		},
+		Some(last_nonce),
+	);
+	last_nonce += 1;
+	extrinsics.push(set_compute);
+
+	let set_storage = generate_extrinsic_with_pair(
+		&client,
+		Alice.into(),
+		SudoCall::sudo {
+			call: Box::new(GluttonCall::set_storage { storage: storage_percent.clone() }.into()),
+		},
+		Some(last_nonce),
+	);
+	extrinsics.push(set_storage);
+
+	let mut block_builder =
+		client.init_block_builder(Some(validation_data.clone()), Default::default());
+
+	for extrinsic in extrinsics {
+		block_builder.push(extrinsic.into()).unwrap();
+	}
+
+	block_builder.build_parachain_block(*parent_header.state_root())
+}
+
+criterion_group!(benches, benchmark_block_validation);
+criterion_main!(benches);

--- a/test/service/src/chain_spec.rs
+++ b/test/service/src/chain_spec.rs
@@ -80,12 +80,37 @@ where
 }
 
 /// Get the chain spec for a specific parachain ID.
-pub fn get_chain_spec(id: ParaId) -> ChainSpec {
+/// The given accounts are initialized with funds.
+pub fn get_chain_spec_with_endowed(
+	id: ParaId,
+	mut extra_endowed_accounts: Vec<AccountId>,
+) -> ChainSpec {
+	let mut default_endowed = vec![
+		get_account_id_from_seed::<sr25519::Public>("Alice"),
+		get_account_id_from_seed::<sr25519::Public>("Bob"),
+		get_account_id_from_seed::<sr25519::Public>("Charlie"),
+		get_account_id_from_seed::<sr25519::Public>("Dave"),
+		get_account_id_from_seed::<sr25519::Public>("Eve"),
+		get_account_id_from_seed::<sr25519::Public>("Ferdie"),
+		get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
+		get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
+		get_account_id_from_seed::<sr25519::Public>("Charlie//stash"),
+		get_account_id_from_seed::<sr25519::Public>("Dave//stash"),
+		get_account_id_from_seed::<sr25519::Public>("Eve//stash"),
+		get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"),
+	];
+	extra_endowed_accounts.append(&mut default_endowed);
 	ChainSpec::from_genesis(
 		"Local Testnet",
 		"local_testnet",
 		ChainType::Local,
-		move || GenesisExt { runtime_genesis_config: local_testnet_genesis(), para_id: id },
+		move || GenesisExt {
+			runtime_genesis_config: testnet_genesis(
+				get_account_id_from_seed::<sr25519::Public>("Alice"),
+				extra_endowed_accounts.clone(),
+			),
+			para_id: id,
+		},
 		Vec::new(),
 		None,
 		None,
@@ -93,6 +118,11 @@ pub fn get_chain_spec(id: ParaId) -> ChainSpec {
 		None,
 		Extensions { para_id: id.into() },
 	)
+}
+
+/// Get the chain spec for a specific parachain ID.
+pub fn get_chain_spec(id: ParaId) -> ChainSpec {
+	get_chain_spec_with_endowed(id, Default::default())
 }
 
 /// Local testnet genesis for testing.
@@ -116,7 +146,7 @@ pub fn local_testnet_genesis() -> cumulus_test_runtime::GenesisConfig {
 	)
 }
 
-fn testnet_genesis(
+pub fn testnet_genesis(
 	root_key: AccountId,
 	endowed_accounts: Vec<AccountId>,
 ) -> cumulus_test_runtime::GenesisConfig {

--- a/test/service/src/lib.rs
+++ b/test/service/src/lib.rs
@@ -21,7 +21,10 @@
 pub mod chain_spec;
 mod genesis;
 
-use sc_executor::{HeapAllocStrategy, WasmExecutor, DEFAULT_HEAP_ALLOC_STRATEGY};
+use runtime::AccountId;
+use sc_executor::{
+	HeapAllocStrategy, WasmExecutor, WasmtimeInstantiationStrategy, DEFAULT_HEAP_ALLOC_STRATEGY,
+};
 use std::{
 	future::Future,
 	net::{IpAddr, Ipv4Addr, SocketAddr},
@@ -501,6 +504,7 @@ pub struct TestNodeBuilder {
 	storage_update_func_relay_chain: Option<Box<dyn Fn()>>,
 	consensus: Consensus,
 	relay_chain_full_node_url: Vec<Url>,
+	endowed_accounts: Vec<AccountId>,
 }
 
 impl TestNodeBuilder {
@@ -523,6 +527,7 @@ impl TestNodeBuilder {
 			storage_update_func_relay_chain: None,
 			consensus: Consensus::RelayChain,
 			relay_chain_full_node_url: vec![],
+			endowed_accounts: Default::default(),
 		}
 	}
 
@@ -629,6 +634,12 @@ impl TestNodeBuilder {
 		self
 	}
 
+	/// Accounts which will have an initial balance.
+	pub fn endowed_accounts(mut self, accounts: Vec<AccountId>) -> TestNodeBuilder {
+		self.endowed_accounts = accounts;
+		self
+	}
+
 	/// Build the [`TestNode`].
 	pub async fn build(self) -> TestNode {
 		let parachain_config = node_config(
@@ -639,6 +650,7 @@ impl TestNodeBuilder {
 			self.parachain_nodes_exclusive,
 			self.para_id,
 			self.collator_key.is_some(),
+			self.endowed_accounts,
 		)
 		.expect("could not generate Configuration");
 
@@ -692,12 +704,13 @@ pub fn node_config(
 	nodes_exlusive: bool,
 	para_id: ParaId,
 	is_collator: bool,
+	endowed_accounts: Vec<AccountId>,
 ) -> Result<Configuration, ServiceError> {
 	let base_path = BasePath::new_temp_dir()?;
 	let root = base_path.path().join(format!("cumulus_test_service_{}", key));
 	let role = if is_collator { Role::Authority } else { Role::Full };
 	let key_seed = key.to_seed();
-	let mut spec = Box::new(chain_spec::get_chain_spec(para_id));
+	let mut spec = Box::new(chain_spec::get_chain_spec_with_endowed(para_id, endowed_accounts));
 
 	let mut storage = spec.as_storage_builder().build_storage().expect("could not build storage");
 
@@ -740,14 +753,15 @@ pub fn node_config(
 		state_pruning: Some(PruningMode::ArchiveAll),
 		blocks_pruning: BlocksPruning::KeepAll,
 		chain_spec: spec,
-		wasm_method: WasmExecutionMethod::Interpreted,
-		// NOTE: we enforce the use of the native runtime to make the errors more debuggable
+		wasm_method: WasmExecutionMethod::Compiled {
+			instantiation_strategy: WasmtimeInstantiationStrategy::PoolingCopyOnWrite,
+		},
 		execution_strategies: ExecutionStrategies {
-			syncing: sc_client_api::ExecutionStrategy::NativeWhenPossible,
-			importing: sc_client_api::ExecutionStrategy::NativeWhenPossible,
-			block_construction: sc_client_api::ExecutionStrategy::NativeWhenPossible,
-			offchain_worker: sc_client_api::ExecutionStrategy::NativeWhenPossible,
-			other: sc_client_api::ExecutionStrategy::NativeWhenPossible,
+			syncing: sc_client_api::ExecutionStrategy::AlwaysWasm,
+			importing: sc_client_api::ExecutionStrategy::AlwaysWasm,
+			block_construction: sc_client_api::ExecutionStrategy::AlwaysWasm,
+			offchain_worker: sc_client_api::ExecutionStrategy::AlwaysWasm,
+			other: sc_client_api::ExecutionStrategy::AlwaysWasm,
 		},
 		rpc_addr: None,
 		rpc_max_connections: Default::default(),


### PR DESCRIPTION
Closes https://github.com/paritytech/cumulus/issues/2048

This PR adds some benchmarks to work on. The requirements are specified in https://github.com/paritytech/cumulus/issues/2048.
The goal is to capture the current performance of block import/block production/block validation.

# Transfers
First, we have a benchmark that fills a block with transfer_keep_alive transactions until the block is full.
This block is then built/imported/validated.

1313 transfer transactions per block.

**Triecache Enabled:**
| Benchmark            | Time (ms) | Throughput (Kelem/s) |
| -------------------- | --------- | -------------------- |
| Import               | 174.85    | 7.5092               |
| Production w/o proof | 192.13    | 6.8339               |
| Production w/ proof  | 220.21    | 5.9624               |
| Validation           | -         | -                    |

**Triecache Disabled:**
| Benchmark            | Time (ms) | Throughput (Kelem/s) |
| -------------------- | --------- | -------------------- |
| Import               | 362.62    | 3.6208               |
| Production w/o proof | 261.81    | 5.0151               |
| Production w/ proof  | 270.22    | 4.8580               |
| Validation           | 263.20    | 4.9886               |

# Compute/IO
In addition to the benchmarking of blocks with transfer extrinsics, I used the glutton pallet 
to fully use the weight of a block with configurable compute/IO part. The glutton pallet will just "burn" the leftover weight
of the current block in the `on_idle` hook of the pallet. The weight consumed for PoV size and time
can be chosen using the glutton pallets extrinsics.

Note: Throughput is not available for this benchmark since we add no extrinsics.

**Triecache Enabled:**
| Benchmark            | compute = 100%, storage = 0% (ms) | compute = 100%, storage = 100% (ms) |
| -------------------- | --------------------------------- | ----------------------------------- |
| Import               | 260.20                            | 269.92                              |
| Production w/o proof | 271.31                            | 267.88                              |
| Production w/ proof  | 272.64                            | 275.72                              |
| Validation           | -                                 | -                                   |

**Triecache Disabled:**
| Benchmark            | compute = 100%, storage = 0% (ms) | compute = 100%, storage = 100% (ms) |
| -------------------- | --------------------------------- | ----------------------------------- |
| Import               | 279.71                            | 277.99                              |
| Production w/o proof | 267.13                            | 268.32                              |
| Production w/ proof  | 264.57                            | 276.60                              |
| Validation           | 271.59                            | 284.26                              |

---
Overall, these benchmark results raise some questions. For the benchmarks that use the glutton pallet, I was expecting the PoV size to have a much larger impact 
on the execution time. The import and block production benchmarks use the cumulus test-service which uses RocksDB behind the scenes. I was expecting that the in-memory processing of validate_block would provide some benefit. Also interesting is the high impact of the trie cache on the block import performance in the transfer benchmark.
