### PR TITLE
Fix typo in test

### DIFF
--- a/parachains/integration-tests/emulated/assets/statemint/src/tests/teleport.rs
+++ b/parachains/integration-tests/emulated/assets/statemint/src/tests/teleport.rs
@@ -45,7 +45,7 @@ fn teleport_native_assets_from_relay_to_assets_para() {
 			Statemint,
 			vec![
 				RuntimeEvent::Balances(pallet_balances::Event::Deposit { who, .. }) => {
-					who: *who == StatemineReceiver::get().into(),
+					who: *who == StatemintReceiver::get().into(),
 				},
 			]
 		);


### PR DESCRIPTION
Joe spotted a typo in a new emulator test. statemine/t is being renamed but that might take a while to land.