### PR TITLE
doc fix

### DIFF
--- a/pallets/parachain-system/src/lib.rs
+++ b/pallets/parachain-system/src/lib.rs
@@ -553,10 +553,8 @@ pub mod pallet {
 
 	/// In case of a scheduled upgrade, this storage field contains the validation code to be applied.
 	///
-	/// As soon as the relay chain gives us the go-ahead signal, we will overwrite the [`:code`][well_known_keys::CODE]
+	/// As soon as the relay chain gives us the go-ahead signal, we will overwrite the [`:code`][sp_core::storage::well_known_keys::CODE]
 	/// which will result the next block process with the new validation code. This concludes the upgrade process.
-	///
-	/// [well_known_keys::CODE]: sp_core::storage::well_known_keys::CODE
 	#[pallet::storage]
 	#[pallet::getter(fn new_validation_function)]
 	pub(super) type PendingValidationCode<T: Config> = StorageValue<_, Vec<u8>, ValueQuery>;


### PR DESCRIPTION
fixing error:
```
warning: unresolved link to `well_known_keys::CODE`
   --> pallets/parachain-system/src/lib.rs:560:12
    |
560 |     #[pallet::storage]
    |               ^^^^^^^
    |
    = note: the link appears in this line:
            " As soon as the relay chain gives us the go-ahead signal, we will overwrite the [`:code`][well_known_keys::CODE]"
                                                                                                       ^^^^^^^^^^^^^^^^^^^^^
    = note: no item named `well_known_keys` in scope
    = note: `#[warn(rustdoc::broken_intra_doc_links)]` on by default
```
