### PR TITLE
CI: fix gha set-output command

### DIFF
--- a/.github/workflows/release-10_rc-automation.yml
+++ b/.github/workflows/release-10_rc-automation.yml
@@ -27,7 +27,7 @@ jobs:
           # Get last rc tag if exists, else set it to {version}-rc1
           version=${GITHUB_REF#refs/heads/release-}
           echo "$version"
-          echo "::set-output name=version::$version"
+          echo "version=$version" >> $GITHUB_OUTPUT
           git tag -l
           last_rc=$(git tag -l "$version-rc*" | sort -V | tail -n 1)
           if [ -n "$last_rc" ]; then
@@ -35,11 +35,11 @@ jobs:
             echo $suffix
             ((suffix++))
             echo $suffix
-            echo "::set-output name=new_tag::$version-rc$suffix"
-            echo "::set-output name=first_rc::false"
+            echo "new_tag=$version-rc$suffix" >> $GITHUB_OUTPUT
+            echo "first_rc=false" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=new_tag::$version-rc1"
-            echo "::set-output name=first_rc::true"
+            echo "new_tag=$version-rc1" >> $GITHUB_OUTPUT
+            echo "first_rc=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Apply new tag

--- a/.github/workflows/release-30_create-draft.yml
+++ b/.github/workflows/release-30_create-draft.yml
@@ -34,8 +34,8 @@ jobs:
     steps:
       - id: get-rust-versions
         run: |
-          echo "::set-output name=stable::$(rustc +stable --version)"
-          echo "::set-output name=nightly::$(rustc +nightly --version)"
+          echo "stable=$(rustc +stable --version)" >> $GITHUB_OUTPUT
+          echo "nightly=$(rustc +nightly --version)" >> $GITHUB_OUTPUT
 
   # We do not skip the entire job for client builds (although we don't need it)
   # because it is a dep of the next job. However we skip the time consuming steps.
@@ -267,7 +267,7 @@ jobs:
           ls "$RUNTIME_DIR/${{ matrix.category }}/${{ matrix.runtime }}"
           runtime_ver=$(ruby script.rb)
           echo "Found version: >$runtime_ver<"
-          echo "::set-output name=runtime_ver::$runtime_ver"
+          echo "runtime_ver=$runtime_ver" >> $GITHUB_OUTPUT
 
       - name: Fix runtime name
         id: fix-runtime-path


### PR DESCRIPTION
GitHub is going to deprecate `save-state` and `set-output` commands. [More info](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

This PR adjusts GHA workflow to use new syntax.

Part of https://github.com/paritytech/ci_cd/issues/805