### PR TITLE
Xcm Emulator: prepare XCMP on init

### DIFF
--- a/parachains/integration-tests/emulated/assets/asset-hub-kusama/src/lib.rs
+++ b/parachains/integration-tests/emulated/assets/asset-hub-kusama/src/lib.rs
@@ -1,3 +1,19 @@
+// Copyright Parity Technologies (UK) Ltd.
+// This file is part of Cumulus.
+
+// Cumulus is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Cumulus is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
+
 pub use codec::Encode;
 pub use frame_support::{
 	assert_ok, instances::Instance1, pallet_prelude::Weight, traits::fungibles::Inspect,

--- a/parachains/integration-tests/emulated/assets/asset-hub-kusama/src/tests/mod.rs
+++ b/parachains/integration-tests/emulated/assets/asset-hub-kusama/src/tests/mod.rs
@@ -1,3 +1,19 @@
+// Copyright Parity Technologies (UK) Ltd.
+// This file is part of Cumulus.
+
+// Cumulus is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Cumulus is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
+
 mod reserve_transfer;
 mod teleport;
 mod transact;

--- a/parachains/integration-tests/emulated/assets/asset-hub-kusama/src/tests/reserve_transfer.rs
+++ b/parachains/integration-tests/emulated/assets/asset-hub-kusama/src/tests/reserve_transfer.rs
@@ -1,3 +1,19 @@
+// Copyright Parity Technologies (UK) Ltd.
+// This file is part of Cumulus.
+
+// Cumulus is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Cumulus is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
+
 use crate::*;
 
 #[test]

--- a/parachains/integration-tests/emulated/assets/asset-hub-kusama/src/tests/teleport.rs
+++ b/parachains/integration-tests/emulated/assets/asset-hub-kusama/src/tests/teleport.rs
@@ -1,3 +1,19 @@
+// Copyright Parity Technologies (UK) Ltd.
+// This file is part of Cumulus.
+
+// Cumulus is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Cumulus is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
+
 use crate::*;
 
 #[test]

--- a/parachains/integration-tests/emulated/assets/asset-hub-kusama/src/tests/transact.rs
+++ b/parachains/integration-tests/emulated/assets/asset-hub-kusama/src/tests/transact.rs
@@ -1,3 +1,19 @@
+// Copyright Parity Technologies (UK) Ltd.
+// This file is part of Cumulus.
+
+// Cumulus is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Cumulus is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
+
 use crate::*;
 
 #[test]

--- a/parachains/integration-tests/emulated/assets/asset-hub-polkadot/src/lib.rs
+++ b/parachains/integration-tests/emulated/assets/asset-hub-polkadot/src/lib.rs
@@ -1,3 +1,19 @@
+// Copyright Parity Technologies (UK) Ltd.
+// This file is part of Cumulus.
+
+// Cumulus is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Cumulus is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
+
 pub use codec::Encode;
 pub use frame_support::{
 	assert_ok, instances::Instance1, pallet_prelude::Weight, traits::fungibles::Inspect,

--- a/parachains/integration-tests/emulated/assets/asset-hub-polkadot/src/tests/mod.rs
+++ b/parachains/integration-tests/emulated/assets/asset-hub-polkadot/src/tests/mod.rs
@@ -1,3 +1,19 @@
+// Copyright Parity Technologies (UK) Ltd.
+// This file is part of Cumulus.
+
+// Cumulus is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Cumulus is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
+
 mod reserve_transfer;
 mod teleport;
 mod transact;

--- a/parachains/integration-tests/emulated/assets/asset-hub-polkadot/src/tests/reserve_transfer.rs
+++ b/parachains/integration-tests/emulated/assets/asset-hub-polkadot/src/tests/reserve_transfer.rs
@@ -1,3 +1,19 @@
+// Copyright Parity Technologies (UK) Ltd.
+// This file is part of Cumulus.
+
+// Cumulus is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Cumulus is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
+
 use crate::*;
 
 #[test]

--- a/parachains/integration-tests/emulated/assets/asset-hub-polkadot/src/tests/teleport.rs
+++ b/parachains/integration-tests/emulated/assets/asset-hub-polkadot/src/tests/teleport.rs
@@ -1,3 +1,19 @@
+// Copyright Parity Technologies (UK) Ltd.
+// This file is part of Cumulus.
+
+// Cumulus is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Cumulus is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
+
 use crate::*;
 
 #[test]

--- a/parachains/integration-tests/emulated/assets/asset-hub-polkadot/src/tests/transact.rs
+++ b/parachains/integration-tests/emulated/assets/asset-hub-polkadot/src/tests/transact.rs
@@ -1,3 +1,19 @@
+// Copyright Parity Technologies (UK) Ltd.
+// This file is part of Cumulus.
+
+// Cumulus is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Cumulus is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
+
 use crate::*;
 
 #[test]

--- a/parachains/integration-tests/emulated/assets/asset-hub-westend/src/lib.rs
+++ b/parachains/integration-tests/emulated/assets/asset-hub-westend/src/lib.rs
@@ -1,3 +1,19 @@
+// Copyright Parity Technologies (UK) Ltd.
+// This file is part of Cumulus.
+
+// Cumulus is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Cumulus is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
+
 pub use codec::Encode;
 pub use frame_support::{
 	assert_ok, instances::Instance1, pallet_prelude::Weight, traits::fungibles::Inspect,

--- a/parachains/integration-tests/emulated/assets/asset-hub-westend/src/tests/mod.rs
+++ b/parachains/integration-tests/emulated/assets/asset-hub-westend/src/tests/mod.rs
@@ -1,3 +1,19 @@
+// Copyright Parity Technologies (UK) Ltd.
+// This file is part of Cumulus.
+
+// Cumulus is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Cumulus is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
+
 mod reserve_transfer;
 mod teleport;
 mod transact;

--- a/parachains/integration-tests/emulated/assets/asset-hub-westend/src/tests/reserve_transfer.rs
+++ b/parachains/integration-tests/emulated/assets/asset-hub-westend/src/tests/reserve_transfer.rs
@@ -1,3 +1,19 @@
+// Copyright Parity Technologies (UK) Ltd.
+// This file is part of Cumulus.
+
+// Cumulus is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Cumulus is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
+
 use crate::*;
 
 #[test]

--- a/parachains/integration-tests/emulated/assets/asset-hub-westend/src/tests/teleport.rs
+++ b/parachains/integration-tests/emulated/assets/asset-hub-westend/src/tests/teleport.rs
@@ -1,3 +1,19 @@
+// Copyright Parity Technologies (UK) Ltd.
+// This file is part of Cumulus.
+
+// Cumulus is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Cumulus is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
+
 use crate::*;
 
 #[test]

--- a/parachains/integration-tests/emulated/assets/asset-hub-westend/src/tests/transact.rs
+++ b/parachains/integration-tests/emulated/assets/asset-hub-westend/src/tests/transact.rs
@@ -1,3 +1,19 @@
+// Copyright Parity Technologies (UK) Ltd.
+// This file is part of Cumulus.
+
+// Cumulus is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Cumulus is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
+
 use crate::*;
 
 #[test]

--- a/parachains/integration-tests/emulated/collectives/collectives-polkadot/src/tests/fellowship.rs
+++ b/parachains/integration-tests/emulated/collectives/collectives-polkadot/src/tests/fellowship.rs
@@ -23,7 +23,7 @@ use frame_support::traits::{
 	tokens::Pay,
 };
 use sp_core::crypto::Ss58Codec;
-use xcm_emulator::{Network, TestExt};
+use xcm_emulator::TestExt;
 
 #[test]
 fn pay_salary() {
@@ -33,9 +33,6 @@ fn pay_salary() {
 			.unwrap();
 	let pay_to = Polkadot::account_id_of(ALICE);
 	let pay_amount = 9000;
-
-	PolkadotMockNet::_init();
-	PolkadotMockNet::reset();
 
 	AssetHub::execute_with(|| {
 		type AssetHubAssets = <AssetHub as AssetHubPallet>::Assets;

--- a/test/runtime/Cargo.toml
+++ b/test/runtime/Cargo.toml
@@ -51,6 +51,7 @@ std = [
 	"pallet-sudo/std",
 	"pallet-timestamp/std",
 	"pallet-transaction-payment/std",
+	"pallet-glutton/std",
 	"sp-api/std",
 	"sp-block-builder/std",
 	"sp-core/std",

--- a/xcm/xcm-emulator/src/lib.rs
+++ b/xcm/xcm-emulator/src/lib.rs
@@ -740,6 +740,8 @@ macro_rules! decl_test_networks {
 						$crate::HORIZONTAL_MESSAGES.with(|b| b.borrow_mut().insert(stringify!($name).to_string(), $crate::VecDeque::new()));
 						$crate::RELAY_BLOCK_NUMBER.with(|b| b.borrow_mut().insert(stringify!($name).to_string(), 1));
 						$crate::PARA_IDS.with(|b| b.borrow_mut().insert(stringify!($name).to_string(), Self::_para_ids()));
+
+						$( <$parachain>::prepare_for_xcmp(); )*
 					}
 				}
 


### PR DESCRIPTION
The XCM messages are not passing between parachains right now, without manually calling `init` and `reset` before a test.
In the PR we preparing/opening the XCMP channels on a network initialization which happens once when `execute_with` invoke on any chain.
Calling just `reset` like in the examples [here](https://github.com/shaunxw/xcm-simulator/blob/d011e5ca62b93e8f688c2042c1f92cdbafc5d1d0/xcm-emulator/example/src/lib.rs#L195) does not help, since static params like PARA_IDS are not initialized. 

The PR also includes missing license headers for it tests.