### PR TITLE
Add account nonce api to Glutton Parachain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4734,6 +4734,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "frame-system-benchmarking",
+ "frame-system-rpc-runtime-api",
  "frame-try-runtime",
  "pallet-glutton",
  "pallet-sudo",

--- a/parachains/runtimes/glutton/glutton-kusama/Cargo.toml
+++ b/parachains/runtimes/glutton/glutton-kusama/Cargo.toml
@@ -13,6 +13,7 @@ frame-benchmarking = { git = "https://github.com/paritytech/substrate", optional
 frame-executive = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
 frame-support = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
 frame-system = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
+frame-system-rpc-runtime-api = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "master" }
 frame-system-benchmarking = { git = "https://github.com/paritytech/substrate", optional = true, default-features = false, branch = "master" }
 frame-try-runtime = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "master" }
 pallet-glutton = { git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "master" }
@@ -59,6 +60,7 @@ std = [
 	"frame-executive/std",
 	"frame-support/std",
 	"frame-system/std",
+	"frame-system-rpc-runtime-api/std",
 	"pallet-glutton/std",
 	"pallet-sudo/std",
 	"sp-api/std",

--- a/parachains/runtimes/glutton/glutton-kusama/src/lib.rs
+++ b/parachains/runtimes/glutton/glutton-kusama/src/lib.rs
@@ -352,6 +352,12 @@ impl_runtime_apis! {
 		}
 	}
 
+  impl frame_system_rpc_runtime_api::AccountNonceApi<Block, AccountId, Index> for Runtime {
+		fn account_nonce(account: AccountId) -> Index {
+			System::account_nonce(account)
+		}
+	}
+
 	#[cfg(feature = "runtime-benchmarks")]
 	impl frame_benchmarking::Benchmark<Block> for Runtime {
 		fn benchmark_metadata(extra: bool) -> (


### PR DESCRIPTION
Now that there is `sudo` in the Glutton's runtime, runtime API is needed to check sudo txs `nonce`.
Needed for https://github.com/paritytech/parachains-utils/pull/1 to work