### PR TITLE
fixed one member of two teams prs counting individually

### DIFF
--- a/.github/pr-custom-review.yml
+++ b/.github/pr-custom-review.yml
@@ -7,7 +7,7 @@ rules:
   - name: Runtime files
     check_type: changed_files
     condition: ^parachains/runtimes/assets/(asset-hub-kusama|asset-hub-polkadot)/src/[^/]+\.rs$|^parachains/runtimes/bridge-hubs/(bridge-hub-kusama|bridge-hub-polkadot)/src/[^/]+\.rs$|^parachains/runtimes/collectives/collectives-polkadot/src/[^/]+\.rs$|^parachains/common/src/[^/]+\.rs$
-    all_distinct:
+    all:
       - min_approvals: 1
         teams:
           - cumulus-locks-review


### PR DESCRIPTION
Fixed the problem that, if a member of two of the required teams reviews a Pr that belongs to `^parachains/runtimes/assets/(asset-hub-kusama|asset-hub-polkadot)/src/[^/]+\.rs$|^parachains/runtimes/bridge-hubs/(bridge-hub-kusama|bridge-hub-polkadot)/src/[^/]+\.rs$|^parachains/runtimes/collectives/collectives-polkadot/src/[^/]+\.rs$|^parachains/common/src/[^/]+\.rs$` it won't count as enough reviews.

By changing the `all_distinct` to `all` this will allow one member of both teams to fulfill the requirements for the PR