### PR TITLE
Bump subwasm to latest

### DIFF
--- a/.github/workflows/srtool.yml
+++ b/.github/workflows/srtool.yml
@@ -1,7 +1,7 @@
 name: Srtool build
 
 env:
-  SUBWASM_VERSION: 0.17.0
+  SUBWASM_VERSION: 0.20.0
 
 on:
   push:


### PR DESCRIPTION
There are important fixes in subwasm v0.20.0. This PR ensures we install the latest version.