### PR TITLE
Allow functions to work over both parachains and relay chains

### DIFF
--- a/parachains/integration-tests/emulated/assets/asset-hub-westend/src/lib.rs
+++ b/parachains/integration-tests/emulated/assets/asset-hub-westend/src/lib.rs
@@ -38,7 +38,7 @@ pub use xcm::{
 	},
 };
 pub use xcm_emulator::{
-	assert_expected_events, bx, cumulus_pallet_dmp_queue, helpers::weight_within_threshold,
+	assert_expected_events, bx, cumulus_pallet_dmp_queue, helpers::weight_within_threshold, Chain,
 	Parachain as Para, RelayChain as Relay, TestExt,
 };
 

--- a/parachains/integration-tests/emulated/assets/asset-hub-westend/src/tests/reserve_transfer.rs
+++ b/parachains/integration-tests/emulated/assets/asset-hub-westend/src/tests/reserve_transfer.rs
@@ -24,7 +24,7 @@ fn reserve_transfer_native_asset_from_relay_to_assets() {
 	let para_receiver_balance_before =
 		AssetHubWestend::account_data_of(AssetHubWestendReceiver::get()).free;
 
-	let origin = <Westend as Relay>::RuntimeOrigin::signed(WestendSender::get());
+	let origin = <Westend as Chain>::RuntimeOrigin::signed(WestendSender::get());
 	let assets_para_destination: VersionedMultiLocation =
 		Westend::child_location_of(AssetHubWestend::para_id()).into();
 	let beneficiary: VersionedMultiLocation =
@@ -44,7 +44,7 @@ fn reserve_transfer_native_asset_from_relay_to_assets() {
 			weight_limit,
 		));
 
-		type RuntimeEvent = <Westend as Relay>::RuntimeEvent;
+		type RuntimeEvent = <Westend as Chain>::RuntimeEvent;
 
 		assert_expected_events!(
 			Westend,
@@ -58,7 +58,7 @@ fn reserve_transfer_native_asset_from_relay_to_assets() {
 
 	// Receive XCM message in Assets Parachain
 	AssetHubWestend::execute_with(|| {
-		type RuntimeEvent = <AssetHubWestend as Para>::RuntimeEvent;
+		type RuntimeEvent = <AssetHubWestend as Chain>::RuntimeEvent;
 
 		assert_expected_events!(
 			AssetHubWestend,

--- a/parachains/integration-tests/emulated/assets/asset-hub-westend/src/tests/swap.rs
+++ b/parachains/integration-tests/emulated/assets/asset-hub-westend/src/tests/swap.rs
@@ -1,6 +1,6 @@
 use crate::*;
 use frame_support::{instances::Instance2, BoundedVec};
-use xcm_emulator::Parachain;
+use xcm_emulator::{Chain, Parachain};
 
 #[test]
 fn swap_locally_on_chain_using_local_assets() {
@@ -13,10 +13,10 @@ fn swap_locally_on_chain_using_local_assets() {
 	});
 
 	AssetHubWestend::execute_with(|| {
-		type RuntimeEvent = <AssetHubWestend as Parachain>::RuntimeEvent;
+		type RuntimeEvent = <AssetHubWestend as Chain>::RuntimeEvent;
 
 		assert_ok!(<AssetHubWestend as AssetHubWestendPallet>::Assets::create(
-			<AssetHubWestend as Parachain>::RuntimeOrigin::signed(AssetHubWestendSender::get()),
+			<AssetHubWestend as Chain>::RuntimeOrigin::signed(AssetHubWestendSender::get()),
 			ASSET_ID.into(),
 			AssetHubWestendSender::get().into(),
 			1000,
@@ -24,14 +24,14 @@ fn swap_locally_on_chain_using_local_assets() {
 		assert!(<AssetHubWestend as AssetHubWestendPallet>::Assets::asset_exists(ASSET_ID));
 
 		assert_ok!(<AssetHubWestend as AssetHubWestendPallet>::Assets::mint(
-			<AssetHubWestend as Parachain>::RuntimeOrigin::signed(AssetHubWestendSender::get()),
+			<AssetHubWestend as Chain>::RuntimeOrigin::signed(AssetHubWestendSender::get()),
 			ASSET_ID.into(),
 			AssetHubWestendSender::get().into(),
 			3_000_000_000_000,
 		));
 
 		assert_ok!(<AssetHubWestend as AssetHubWestendPallet>::AssetConversion::create_pool(
-			<AssetHubWestend as Parachain>::RuntimeOrigin::signed(AssetHubWestendSender::get()),
+			<AssetHubWestend as Chain>::RuntimeOrigin::signed(AssetHubWestendSender::get()),
 			asset_native.clone(),
 			asset_one.clone(),
 		));
@@ -44,7 +44,7 @@ fn swap_locally_on_chain_using_local_assets() {
 		);
 
 		assert_ok!(<AssetHubWestend as AssetHubWestendPallet>::AssetConversion::add_liquidity(
-			<AssetHubWestend as Parachain>::RuntimeOrigin::signed(AssetHubWestendSender::get()),
+			<AssetHubWestend as Chain>::RuntimeOrigin::signed(AssetHubWestendSender::get()),
 			asset_native.clone(),
 			asset_one.clone(),
 			1_000_000_000_000,
@@ -64,7 +64,7 @@ fn swap_locally_on_chain_using_local_assets() {
 		let path = BoundedVec::<_, _>::truncate_from(vec![asset_native.clone(), asset_one.clone()]);
 
 		assert_ok!(<AssetHubWestend as AssetHubWestendPallet>::AssetConversion::swap_exact_tokens_for_tokens(
-			<AssetHubWestend as Parachain>::RuntimeOrigin::signed(AssetHubWestendSender::get()),
+			<AssetHubWestend as Chain>::RuntimeOrigin::signed(AssetHubWestendSender::get()),
 			path,
 			100,
 			1,
@@ -83,7 +83,7 @@ fn swap_locally_on_chain_using_local_assets() {
 		);
 
 		assert_ok!(<AssetHubWestend as AssetHubWestendPallet>::AssetConversion::remove_liquidity(
-			<AssetHubWestend as Parachain>::RuntimeOrigin::signed(AssetHubWestendSender::get()),
+			<AssetHubWestend as Chain>::RuntimeOrigin::signed(AssetHubWestendSender::get()),
 			asset_native,
 			asset_one,
 			1414213562273 - 2_000_000_000, // all but the 2 EDs can't be retrieved.
@@ -120,7 +120,7 @@ fn swap_locally_on_chain_using_foreign_assets() {
 	// 1. Create asset on penpal:
 	PenpalWestend::execute_with(|| {
 		assert_ok!(<PenpalWestend as PenpalWestendPallet>::Assets::create(
-			<PenpalWestend as Parachain>::RuntimeOrigin::signed(PenpalWestendSender::get()),
+			<PenpalWestend as Chain>::RuntimeOrigin::signed(PenpalWestendSender::get()),
 			ASSET_ID.into(),
 			PenpalWestendSender::get().into(),
 			1000,
@@ -149,8 +149,8 @@ fn swap_locally_on_chain_using_foreign_assets() {
 	};
 
 	let call_foreign_assets_create =
-		<AssetHubWestend as Para>::RuntimeCall::ForeignAssets(pallet_assets::Call::<
-			<AssetHubWestend as Para>::Runtime,
+		<AssetHubWestend as Chain>::RuntimeCall::ForeignAssets(pallet_assets::Call::<
+			<AssetHubWestend as Chain>::Runtime,
 			Instance2,
 		>::create {
 			id: *foreign_asset1_at_asset_hub_westend,
@@ -182,7 +182,7 @@ fn swap_locally_on_chain_using_foreign_assets() {
 	]));
 
 	// Send XCM message from penpal => asset_hub_westend
-	let sudo_penpal_origin = <PenpalWestend as Parachain>::RuntimeOrigin::root();
+	let sudo_penpal_origin = <PenpalWestend as Chain>::RuntimeOrigin::root();
 	PenpalWestend::execute_with(|| {
 		assert_ok!(<PenpalWestend as PenpalWestendPallet>::PolkadotXcm::send(
 			sudo_penpal_origin.clone(),
@@ -190,7 +190,7 @@ fn swap_locally_on_chain_using_foreign_assets() {
 			bx!(xcm),
 		));
 
-		type RuntimeEvent = <PenpalWestend as Parachain>::RuntimeEvent;
+		type RuntimeEvent = <PenpalWestend as Chain>::RuntimeEvent;
 
 		assert_expected_events!(
 			PenpalWestend,
@@ -211,10 +211,10 @@ fn swap_locally_on_chain_using_foreign_assets() {
 		// (While it might be nice to use batch,
 		// currently that's disabled due to safe call filters.)
 
-		type RuntimeEvent = <AssetHubWestend as Parachain>::RuntimeEvent;
+		type RuntimeEvent = <AssetHubWestend as Chain>::RuntimeEvent;
 		// 3. Mint foreign asset (in reality this should be a teleport or some such)
 		assert_ok!(<AssetHubWestend as AssetHubWestendPallet>::ForeignAssets::mint(
-			<AssetHubWestend as Parachain>::RuntimeOrigin::signed(
+			<AssetHubWestend as Chain>::RuntimeOrigin::signed(
 				sov_penpal_on_asset_hub_westend.clone().into()
 			),
 			*foreign_asset1_at_asset_hub_westend,
@@ -231,7 +231,7 @@ fn swap_locally_on_chain_using_foreign_assets() {
 
 		// 4. Create pool:
 		assert_ok!(<AssetHubWestend as AssetHubWestendPallet>::AssetConversion::create_pool(
-			<AssetHubWestend as Parachain>::RuntimeOrigin::signed(AssetHubWestendSender::get()),
+			<AssetHubWestend as Chain>::RuntimeOrigin::signed(AssetHubWestendSender::get()),
 			asset_native.clone(),
 			foreign_asset1_at_asset_hub_westend.clone(),
 		));
@@ -245,7 +245,7 @@ fn swap_locally_on_chain_using_foreign_assets() {
 
 		// 5. Add liquidity:
 		assert_ok!(<AssetHubWestend as AssetHubWestendPallet>::AssetConversion::add_liquidity(
-			<AssetHubWestend as Parachain>::RuntimeOrigin::signed(
+			<AssetHubWestend as Chain>::RuntimeOrigin::signed(
 				sov_penpal_on_asset_hub_westend.clone()
 			),
 			asset_native.clone(),
@@ -273,7 +273,7 @@ fn swap_locally_on_chain_using_foreign_assets() {
 		]);
 
 		assert_ok!(<AssetHubWestend as AssetHubWestendPallet>::AssetConversion::swap_exact_tokens_for_tokens(
-			<AssetHubWestend as Parachain>::RuntimeOrigin::signed(AssetHubWestendSender::get()),
+			<AssetHubWestend as Chain>::RuntimeOrigin::signed(AssetHubWestendSender::get()),
 			path,
 			100000,
 			1000,
@@ -293,7 +293,7 @@ fn swap_locally_on_chain_using_foreign_assets() {
 
 		// 7. Remove liquidity
 		assert_ok!(<AssetHubWestend as AssetHubWestendPallet>::AssetConversion::remove_liquidity(
-			<AssetHubWestend as Parachain>::RuntimeOrigin::signed(
+			<AssetHubWestend as Chain>::RuntimeOrigin::signed(
 				sov_penpal_on_asset_hub_westend.clone()
 			),
 			asset_native,

--- a/parachains/integration-tests/emulated/assets/asset-hub-westend/src/tests/teleport.rs
+++ b/parachains/integration-tests/emulated/assets/asset-hub-westend/src/tests/teleport.rs
@@ -24,7 +24,7 @@ fn teleport_native_assets_from_relay_to_assets_para() {
 	let para_receiver_balance_before =
 		AssetHubWestend::account_data_of(AssetHubWestendReceiver::get()).free;
 
-	let origin = <Westend as Relay>::RuntimeOrigin::signed(WestendSender::get());
+	let origin = <Westend as Chain>::RuntimeOrigin::signed(WestendSender::get());
 	let assets_para_destination: VersionedMultiLocation =
 		Westend::child_location_of(AssetHubWestend::para_id()).into();
 	let beneficiary: VersionedMultiLocation =
@@ -44,7 +44,7 @@ fn teleport_native_assets_from_relay_to_assets_para() {
 			weight_limit,
 		));
 
-		type RuntimeEvent = <Westend as Relay>::RuntimeEvent;
+		type RuntimeEvent = <Westend as Chain>::RuntimeEvent;
 
 		assert_expected_events!(
 			Westend,
@@ -56,7 +56,7 @@ fn teleport_native_assets_from_relay_to_assets_para() {
 
 	// Receive XCM message in Assets Parachain
 	AssetHubWestend::execute_with(|| {
-		type RuntimeEvent = <AssetHubWestend as Para>::RuntimeEvent;
+		type RuntimeEvent = <AssetHubWestend as Chain>::RuntimeEvent;
 
 		assert_expected_events!(
 			AssetHubWestend,

--- a/parachains/integration-tests/emulated/assets/asset-hub-westend/src/tests/transact.rs
+++ b/parachains/integration-tests/emulated/assets/asset-hub-westend/src/tests/transact.rs
@@ -22,8 +22,8 @@ fn transact_sudo_from_relay_to_assets_para() {
 	// Call to be executed in Assets Parachain
 	const ASSET_ID: u32 = 1;
 
-	let call = <AssetHubWestend as Para>::RuntimeCall::Assets(pallet_assets::Call::<
-		<AssetHubWestend as Para>::Runtime,
+	let call = <AssetHubWestend as Chain>::RuntimeCall::Assets(pallet_assets::Call::<
+		<AssetHubWestend as Chain>::Runtime,
 		Instance1,
 	>::force_create {
 		id: ASSET_ID.into(),
@@ -35,7 +35,7 @@ fn transact_sudo_from_relay_to_assets_para() {
 	.into();
 
 	// XcmPallet send arguments
-	let sudo_origin = <Westend as Relay>::RuntimeOrigin::root();
+	let sudo_origin = <Westend as Chain>::RuntimeOrigin::root();
 	let assets_para_destination: VersionedMultiLocation =
 		Westend::child_location_of(AssetHubWestend::para_id()).into();
 
@@ -57,7 +57,7 @@ fn transact_sudo_from_relay_to_assets_para() {
 			bx!(xcm),
 		));
 
-		type RuntimeEvent = <Westend as Relay>::RuntimeEvent;
+		type RuntimeEvent = <Westend as Chain>::RuntimeEvent;
 
 		assert_expected_events!(
 			Westend,

--- a/parachains/integration-tests/emulated/common/src/lib.rs
+++ b/parachains/integration-tests/emulated/common/src/lib.rs
@@ -10,7 +10,7 @@ pub use parachains_common::{AccountId, AssetHubPolkadotAuraId, AuraId, Balance, 
 pub use sp_core::{sr25519, storage::Storage, Get};
 use xcm::prelude::*;
 use xcm_emulator::{
-	decl_test_networks, decl_test_parachains, decl_test_relay_chains, Parachain, RelayChain,
+	decl_test_networks, decl_test_parachains, decl_test_relay_chains, Chain, Parachain, RelayChain,
 	TestExt,
 };
 use xcm_executor::traits::ConvertLocation;


### PR DESCRIPTION
Moving common types into a common `Chain` trait so that generic functions can be written against them.

(Should Balances also move? I don't think Balances pallet should be essential to a parachain so have not pulled that type up.)