### PR TITLE
Runtime: Success value and reachable location for Polkadot Collectives benchmarks

### DIFF
--- a/parachains/runtimes/collectives/collectives-polkadot/src/fellowship/mod.rs
+++ b/parachains/runtimes/collectives/collectives-polkadot/src/fellowship/mod.rs
@@ -105,9 +105,14 @@ pub type FellowshipCollectiveInstance = pallet_ranked_collective::Instance1;
 impl pallet_ranked_collective::Config<FellowshipCollectiveInstance> for Runtime {
 	type WeightInfo = weights::pallet_ranked_collective::WeightInfo<Runtime>;
 	type RuntimeEvent = RuntimeEvent;
+
+	#[cfg(not(feature = "runtime-benchmarks"))]
 	// Promotions and the induction of new members are serviced by `FellowshipCore` pallet instance.
+	type PromoteOrigin = frame_system::EnsureNever<pallet_ranked_collective::Rank>;
+	#[cfg(feature = "runtime-benchmarks")]
 	// The maximum value of `u16` set as a success value for the root to ensure the benchmarks will pass.
 	type PromoteOrigin = EnsureRootWithSuccess<Self::AccountId, ConstU16<65535>>;
+
 	// Demotion is by any of:
 	// - Root can demote arbitrarily.
 	// - the FellowshipAdmin origin (i.e. token holder referendum);

--- a/parachains/runtimes/collectives/collectives-polkadot/src/fellowship/mod.rs
+++ b/parachains/runtimes/collectives/collectives-polkadot/src/fellowship/mod.rs
@@ -106,12 +106,15 @@ impl pallet_ranked_collective::Config<FellowshipCollectiveInstance> for Runtime 
 	type WeightInfo = weights::pallet_ranked_collective::WeightInfo<Runtime>;
 	type RuntimeEvent = RuntimeEvent;
 	// Promotions and the induction of new members are serviced by `FellowshipCore` pallet instance.
-	type PromoteOrigin = EnsureRootWithSuccess<Self::AccountId, ConstU16<{ ranks::DAN_9 }>>;
+	// The maximum value of `u16` set as a success value for the root to ensure the benchmarks will pass.
+	type PromoteOrigin = EnsureRootWithSuccess<Self::AccountId, ConstU16<65535>>;
 	// Demotion is by any of:
 	// - Root can demote arbitrarily.
 	// - the FellowshipAdmin origin (i.e. token holder referendum);
+	//
+	// The maximum value of `u16` set as a success value for the root to ensure the benchmarks will pass.
 	type DemoteOrigin = EitherOf<
-		EnsureRootWithSuccess<Self::AccountId, ConstU16<{ ranks::DAN_9 }>>,
+		EnsureRootWithSuccess<Self::AccountId, ConstU16<65535>>,
 		MapSuccess<
 			EnsureXcm<IsVoiceOfBody<GovernanceLocation, FellowshipAdminBodyId>>,
 			Replace<ConstU16<{ ranks::DAN_9 }>>,
@@ -182,8 +185,18 @@ pub type FellowshipSalaryInstance = pallet_salary::Instance1;
 
 use xcm::prelude::*;
 
+#[cfg(not(feature = "runtime-benchmarks"))]
 parameter_types! {
 	pub AssetHub: MultiLocation = (Parent, Parachain(1000)).into();
+}
+
+#[cfg(feature = "runtime-benchmarks")]
+parameter_types! {
+	// The reachable location within the benchmark environment.
+	pub AssetHub: MultiLocation = Parent.into();
+}
+
+parameter_types! {
 	pub AssetHubUsdtId: AssetId = (PalletInstance(50), GeneralIndex(1984)).into();
 	pub UsdtAsset: LocatableAssetId = LocatableAssetId {
 		location: AssetHub::get(),


### PR DESCRIPTION
This Pull Request addresses two issues encountered during the benchmark run:

1. Ranked collectives benchmarks:
An error occurs when the benchmarks attempt to promote a member above rank 9.
To resolve this, we have set the success value for the Root as the maximum value of u16.
We have employed a similar approach in the Polkadot runtime.

2. Salary pallet benchmarks:
In the benchmark environment, sending a message to a Parachain fails due to the absence of a channel between the Parachains.
To address this, we wrap the Pay implementation to open a channel with ensure_successful.