### PR TITLE
Fix for `xcm-emulator` - Wrong Parachain processing message

### DIFF
--- a/xcm/xcm-emulator/src/lib.rs
+++ b/xcm/xcm-emulator/src/lib.rs
@@ -780,6 +780,8 @@ macro_rules! decl_test_networks {
 					while let Some((to_para_id, messages))
 						= $crate::DOWNWARD_MESSAGES.with(|b| b.borrow_mut().get_mut(stringify!($name)).unwrap().pop_front()) {
 						$(
+							let para_id: u32 = <$parachain>::para_id().into();
+
 							if $crate::PARA_IDS.with(|b| b.borrow_mut().get_mut(stringify!($name)).unwrap().contains(&to_para_id)) && para_id == to_para_id {
 								let mut msg_dedup: Vec<(RelayChainBlockNumber, Vec<u8>)> = Vec::new();
 								for m in &messages {
@@ -810,6 +812,8 @@ macro_rules! decl_test_networks {
 						= $crate::HORIZONTAL_MESSAGES.with(|b| b.borrow_mut().get_mut(stringify!($name)).unwrap().pop_front()) {
 						let iter = messages.iter().map(|(p, b, m)| (*p, *b, &m[..])).collect::<Vec<_>>().into_iter();
 						$(
+							let para_id: u32 = <$parachain>::para_id().into();
+
 							if $crate::PARA_IDS.with(|b| b.borrow_mut().get_mut(stringify!($name)).unwrap().contains(&to_para_id)) && para_id == to_para_id {
 								<$parachain>::handle_xcmp_messages(iter.clone(), $crate::Weight::max_value());
 							}

--- a/xcm/xcm-emulator/src/lib.rs
+++ b/xcm/xcm-emulator/src/lib.rs
@@ -798,8 +798,6 @@ macro_rules! decl_test_networks {
 										$crate::DMP_DONE.with(|b| b.borrow_mut().get_mut(stringify!($name)).unwrap().push_back((to_para_id, m.0, m.1)));
 									}
 								}
-							} else {
-								unreachable!();
 							}
 						)*
 					}

--- a/xcm/xcm-emulator/src/lib.rs
+++ b/xcm/xcm-emulator/src/lib.rs
@@ -780,7 +780,7 @@ macro_rules! decl_test_networks {
 					while let Some((to_para_id, messages))
 						= $crate::DOWNWARD_MESSAGES.with(|b| b.borrow_mut().get_mut(stringify!($name)).unwrap().pop_front()) {
 						$(
-							if $crate::PARA_IDS.with(|b| b.borrow_mut().get_mut(stringify!($name)).unwrap().contains(&to_para_id)) {
+							if $crate::PARA_IDS.with(|b| b.borrow_mut().get_mut(stringify!($name)).unwrap().contains(&to_para_id)) && para_id == to_para_id {
 								let mut msg_dedup: Vec<(RelayChainBlockNumber, Vec<u8>)> = Vec::new();
 								for m in &messages {
 									msg_dedup.push((m.0, m.1.clone()));
@@ -810,7 +810,7 @@ macro_rules! decl_test_networks {
 						= $crate::HORIZONTAL_MESSAGES.with(|b| b.borrow_mut().get_mut(stringify!($name)).unwrap().pop_front()) {
 						let iter = messages.iter().map(|(p, b, m)| (*p, *b, &m[..])).collect::<Vec<_>>().into_iter();
 						$(
-							if $crate::PARA_IDS.with(|b| b.borrow_mut().get_mut(stringify!($name)).unwrap().contains(&to_para_id)) {
+							if $crate::PARA_IDS.with(|b| b.borrow_mut().get_mut(stringify!($name)).unwrap().contains(&to_para_id)) && para_id == to_para_id {
 								<$parachain>::handle_xcmp_messages(iter.clone(), $crate::Weight::max_value());
 							}
 						)*


### PR DESCRIPTION
I found out that the condition to process messages by a Parachain is incomplete.

We did not notice because of the coincidence that for all our tests, the destination Parachain that is supposed to receive/process the message, had been declared always before the other Parachains.

Example of failing case:
We send a message to `PenpalPolkadot`. The message will never reach its destination because `AssetHubPolkadot` will try to process it first as it is a message to the same `Network` `AssetHubPolkadot` and `PenpalPolkadot` live.
```rust
		parachains = vec![
			AssetHubPolkadot,
			PenpalPolkadot,
		],
```
Same test would pass just switching Parachains order declarations.
```rust
		parachains = vec![
			PenpalPolkadot,
			AssetHubPolkadot,
		],
```

Solution: filter also by `para_id` and not only by `Network`.