### PR TITLE
Fix Unused Variable for PoolAssets Benchmark

### DIFF
--- a/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
+++ b/parachains/runtimes/assets/asset-hub-westend/src/lib.rs
@@ -858,7 +858,7 @@ mod benches {
 		[frame_system, SystemBench::<Runtime>]
 		[pallet_assets, Local]
 		[pallet_assets, Foreign]
-		[pallet_assets, PoolAssets]
+		[pallet_assets, Pool]
 		[pallet_asset_conversion, AssetConversion]
 		[pallet_balances, Balances]
 		[pallet_multisig, Multisig]


### PR DESCRIPTION
Fixes compiler warning:

```
warning: type alias `Pool` is never used
    --> parachains/runtimes/assets/asset-hub-westend/src/lib.rs:1169:9
     |
1169 |             type Pool = pallet_assets::Pallet::<Runtime, PoolAssetsInstance>;
     |                  ^^^^
     |
     = note: `#[warn(dead_code)]` on by default

warning: type alias `Pool` is never used
    --> parachains/runtimes/assets/asset-hub-westend/src/lib.rs:1307:9
     |
1307 |             type Pool = pallet_assets::Pallet::<Runtime, PoolAssetsInstance>;
     |                  ^^^^
```