### PR TITLE
Backport `xcm-emulator` fixes #2800 and #2711

### DIFF
--- a/parachains/integration-tests/emulated/assets/statemine/src/lib.rs
+++ b/parachains/integration-tests/emulated/assets/statemine/src/lib.rs
@@ -1,3 +1,19 @@
+// Copyright Parity Technologies (UK) Ltd.
+// This file is part of Cumulus.
+
+// Cumulus is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Cumulus is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
+
 pub use codec::Encode;
 pub use frame_support::{
 	assert_ok, instances::Instance1, pallet_prelude::Weight, traits::fungibles::Inspect,

--- a/parachains/integration-tests/emulated/assets/statemine/src/tests/mod.rs
+++ b/parachains/integration-tests/emulated/assets/statemine/src/tests/mod.rs
@@ -1,3 +1,19 @@
+// Copyright Parity Technologies (UK) Ltd.
+// This file is part of Cumulus.
+
+// Cumulus is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Cumulus is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
+
 mod reserve_transfer;
 mod teleport;
 mod transact;

--- a/parachains/integration-tests/emulated/assets/statemine/src/tests/reserve_transfer.rs
+++ b/parachains/integration-tests/emulated/assets/statemine/src/tests/reserve_transfer.rs
@@ -1,3 +1,19 @@
+// Copyright Parity Technologies (UK) Ltd.
+// This file is part of Cumulus.
+
+// Cumulus is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Cumulus is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
+
 use crate::*;
 
 #[test]

--- a/parachains/integration-tests/emulated/assets/statemine/src/tests/teleport.rs
+++ b/parachains/integration-tests/emulated/assets/statemine/src/tests/teleport.rs
@@ -1,3 +1,19 @@
+// Copyright Parity Technologies (UK) Ltd.
+// This file is part of Cumulus.
+
+// Cumulus is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Cumulus is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
+
 use crate::*;
 
 #[test]

--- a/parachains/integration-tests/emulated/assets/statemine/src/tests/transact.rs
+++ b/parachains/integration-tests/emulated/assets/statemine/src/tests/transact.rs
@@ -1,3 +1,19 @@
+// Copyright Parity Technologies (UK) Ltd.
+// This file is part of Cumulus.
+
+// Cumulus is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Cumulus is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
+
 use crate::*;
 
 #[test]

--- a/parachains/integration-tests/emulated/assets/statemint/src/lib.rs
+++ b/parachains/integration-tests/emulated/assets/statemint/src/lib.rs
@@ -1,3 +1,19 @@
+// Copyright Parity Technologies (UK) Ltd.
+// This file is part of Cumulus.
+
+// Cumulus is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Cumulus is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
+
 pub use codec::Encode;
 pub use frame_support::{
 	assert_ok, instances::Instance1, pallet_prelude::Weight, traits::fungibles::Inspect,

--- a/parachains/integration-tests/emulated/assets/statemint/src/tests/mod.rs
+++ b/parachains/integration-tests/emulated/assets/statemint/src/tests/mod.rs
@@ -1,3 +1,19 @@
+// Copyright Parity Technologies (UK) Ltd.
+// This file is part of Cumulus.
+
+// Cumulus is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Cumulus is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
+
 mod reserve_transfer;
 mod teleport;
 mod transact;

--- a/parachains/integration-tests/emulated/assets/statemint/src/tests/reserve_transfer.rs
+++ b/parachains/integration-tests/emulated/assets/statemint/src/tests/reserve_transfer.rs
@@ -1,3 +1,19 @@
+// Copyright Parity Technologies (UK) Ltd.
+// This file is part of Cumulus.
+
+// Cumulus is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Cumulus is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
+
 use crate::*;
 
 #[test]

--- a/parachains/integration-tests/emulated/assets/statemint/src/tests/teleport.rs
+++ b/parachains/integration-tests/emulated/assets/statemint/src/tests/teleport.rs
@@ -1,3 +1,19 @@
+// Copyright Parity Technologies (UK) Ltd.
+// This file is part of Cumulus.
+
+// Cumulus is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Cumulus is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
+
 use crate::*;
 
 #[test]

--- a/parachains/integration-tests/emulated/assets/statemint/src/tests/transact.rs
+++ b/parachains/integration-tests/emulated/assets/statemint/src/tests/transact.rs
@@ -1,3 +1,19 @@
+// Copyright Parity Technologies (UK) Ltd.
+// This file is part of Cumulus.
+
+// Cumulus is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Cumulus is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
+
 use crate::*;
 
 #[test]

--- a/parachains/integration-tests/emulated/collectives/collectives-polkadot/src/tests/fellowship.rs
+++ b/parachains/integration-tests/emulated/collectives/collectives-polkadot/src/tests/fellowship.rs
@@ -1,0 +1,77 @@
+// Copyright Parity Technologies (UK) Ltd.
+// This file is part of Cumulus.
+
+// Cumulus is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Cumulus is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Integration tests concerning the Fellowship.
+
+use crate::*;
+use collectives_polkadot_runtime::fellowship::FellowshipSalaryPaymaster;
+use frame_support::traits::{
+	fungibles::{Create, Mutate},
+	tokens::Pay,
+};
+use sp_core::crypto::Ss58Codec;
+use xcm_emulator::TestExt;
+
+#[test]
+fn pay_salary() {
+	let asset_id: u32 = 1984;
+	let pay_from: AccountId =
+		<AccountId as Ss58Codec>::from_string("13w7NdvSR1Af8xsQTArDtZmVvjE8XhWNdL4yed3iFHrUNCnS")
+			.unwrap();
+	let pay_to = Polkadot::account_id_of(ALICE);
+	let pay_amount = 9000;
+
+	AssetHub::execute_with(|| {
+		type AssetHubAssets = <AssetHub as AssetHubPallet>::Assets;
+
+		assert_ok!(<AssetHubAssets as Create<_>>::create(
+			asset_id,
+			pay_to.clone(),
+			true,
+			pay_amount / 2
+		));
+		assert_ok!(<AssetHubAssets as Mutate<_>>::mint_into(asset_id, &pay_from, pay_amount * 2));
+	});
+
+	Collectives::execute_with(|| {
+		type RuntimeEvent = <Collectives as Parachain>::RuntimeEvent;
+
+		assert_ok!(FellowshipSalaryPaymaster::pay(&pay_to, (), pay_amount));
+		assert_expected_events!(
+			Collectives,
+			vec![
+				RuntimeEvent::XcmpQueue(cumulus_pallet_xcmp_queue::Event::XcmpMessageSent { .. }) => {},
+			]
+		);
+	});
+
+	AssetHub::execute_with(|| {
+		type RuntimeEvent = <AssetHub as Parachain>::RuntimeEvent;
+
+		assert_expected_events!(
+			AssetHub,
+			vec![
+				RuntimeEvent::Assets(pallet_assets::Event::Transferred { asset_id: id, from, to, amount }) => {
+					asset_id: id == &asset_id,
+					from: from == &pay_from,
+					to: to == &pay_to,
+					amount: amount == &pay_amount,
+				},
+				RuntimeEvent::XcmpQueue(cumulus_pallet_xcmp_queue::Event::Success { .. }) => {},
+			]
+		);
+	});
+}

--- a/test/runtime/Cargo.toml
+++ b/test/runtime/Cargo.toml
@@ -50,6 +50,7 @@ std = [
 	"pallet-sudo/std",
 	"pallet-timestamp/std",
 	"pallet-transaction-payment/std",
+	"pallet-glutton/std",
 	"sp-api/std",
 	"sp-block-builder/std",
 	"sp-core/std",

--- a/test/runtime/Cargo.toml
+++ b/test/runtime/Cargo.toml
@@ -50,7 +50,6 @@ std = [
 	"pallet-sudo/std",
 	"pallet-timestamp/std",
 	"pallet-transaction-payment/std",
-	"pallet-glutton/std",
 	"sp-api/std",
 	"sp-block-builder/std",
 	"sp-core/std",

--- a/xcm/xcm-emulator/src/lib.rs
+++ b/xcm/xcm-emulator/src/lib.rs
@@ -779,7 +779,9 @@ macro_rules! decl_test_networks {
 					while let Some((to_para_id, messages))
 						= $crate::DOWNWARD_MESSAGES.with(|b| b.borrow_mut().get_mut(stringify!($name)).unwrap().pop_front()) {
 						$(
-							if $crate::PARA_IDS.with(|b| b.borrow_mut().get_mut(stringify!($name)).unwrap().contains(&to_para_id)) {
+							let para_id: u32 = <$parachain>::para_id().into();
+
+							if $crate::PARA_IDS.with(|b| b.borrow_mut().get_mut(stringify!($name)).unwrap().contains(&to_para_id)) && para_id == to_para_id {
 								let mut msg_dedup: Vec<(RelayChainBlockNumber, Vec<u8>)> = Vec::new();
 								for m in &messages {
 									msg_dedup.push((m.0, m.1.clone()));
@@ -795,8 +797,6 @@ macro_rules! decl_test_networks {
 										$crate::DMP_DONE.with(|b| b.borrow_mut().get_mut(stringify!($name)).unwrap().push_back((to_para_id, m.0, m.1)));
 									}
 								}
-							} else {
-								unreachable!();
 							}
 						)*
 					}
@@ -809,7 +809,9 @@ macro_rules! decl_test_networks {
 						= $crate::HORIZONTAL_MESSAGES.with(|b| b.borrow_mut().get_mut(stringify!($name)).unwrap().pop_front()) {
 						let iter = messages.iter().map(|(p, b, m)| (*p, *b, &m[..])).collect::<Vec<_>>().into_iter();
 						$(
-							if $crate::PARA_IDS.with(|b| b.borrow_mut().get_mut(stringify!($name)).unwrap().contains(&to_para_id)) {
+							let para_id: u32 = <$parachain>::para_id().into();
+
+							if $crate::PARA_IDS.with(|b| b.borrow_mut().get_mut(stringify!($name)).unwrap().contains(&to_para_id)) && para_id == to_para_id {
 								<$parachain>::handle_xcmp_messages(iter.clone(), $crate::Weight::max_value());
 							}
 						)*

--- a/xcm/xcm-emulator/src/lib.rs
+++ b/xcm/xcm-emulator/src/lib.rs
@@ -739,6 +739,8 @@ macro_rules! decl_test_networks {
 						$crate::HORIZONTAL_MESSAGES.with(|b| b.borrow_mut().insert(stringify!($name).to_string(), $crate::VecDeque::new()));
 						$crate::RELAY_BLOCK_NUMBER.with(|b| b.borrow_mut().insert(stringify!($name).to_string(), 1));
 						$crate::PARA_IDS.with(|b| b.borrow_mut().insert(stringify!($name).to_string(), Self::_para_ids()));
+
+						$( <$parachain>::prepare_for_xcmp(); )*
 					}
 				}
 


### PR DESCRIPTION
Backporting `xcm-emulator` #2800 and #2711  fixes for a proper functioning in the release branch.