### PR TITLE
Allow polkadot-parachain bin to be a dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9904,7 +9904,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "polkadot-parachain-bin"
+name = "polkadot-parachain-node"
 version = "0.9.430"
 dependencies = [
  "assert_cmd",

--- a/polkadot-parachain/Cargo.toml
+++ b/polkadot-parachain/Cargo.toml
@@ -1,14 +1,17 @@
 [package]
-name = "polkadot-parachain-bin"
+name = "polkadot-parachain-node"
 version = "0.9.430"
 authors = ["Parity Technologies <admin@parity.io>"]
 build = "build.rs"
 edition = "2021"
 description = "Runs a polkadot parachain node which could be a collator."
 
+[lib]
+path = "src/lib.rs"
+
 [[bin]]
 name = "polkadot-parachain"
-path = "src/main.rs"
+path = "src/bin/main.rs"
 
 [dependencies]
 async-trait = "0.1.70"

--- a/polkadot-parachain/src/bin/main.rs
+++ b/polkadot-parachain/src/bin/main.rs
@@ -1,0 +1,24 @@
+// Copyright 2019-2021 Parity Technologies (UK) Ltd.
+// This file is part of Cumulus.
+
+// Cumulus is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Cumulus is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Cumulus test parachain collator
+
+#![warn(missing_docs)]
+#![warn(unused_extern_crates)]
+
+fn main() -> sc_cli::Result<()> {
+	polkadot_parachain_node::run()
+}

--- a/polkadot-parachain/src/lib.rs
+++ b/polkadot-parachain/src/lib.rs
@@ -26,6 +26,7 @@ mod cli;
 mod command;
 mod rpc;
 
-fn main() -> sc_cli::Result<()> {
+/// Process command line arguments and execute them.
+pub fn run() -> sc_cli::Result<()> {
 	command::run()
 }


### PR DESCRIPTION
(for example integration tests currently duplicate genesis information because it can't pull this info in as a dep)