### PR TITLE
[Substrate companion] update libp2p to 0.52.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14575,9 +14575,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.5.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c1c1d5a42b6245520c249549ec267180beaffcc0615401ac8e31853d4b6d8d2"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
 dependencies = [
  "tinyvec_macros",
 ]


### PR DESCRIPTION
https://github.com/paritytech/substrate/pull/14429