### PR TITLE
removed `without_storage_info` from `pallet-collective`

### DIFF
--- a/parachains/runtimes/collectives/collectives-polkadot/src/impls.rs
+++ b/parachains/runtimes/collectives/collectives-polkadot/src/impls.rs
@@ -127,7 +127,7 @@ where
 	}
 
 	fn proposal_of(proposal_hash: HashOf<T>) -> Option<ProposalOf<T, I>> {
-		pallet_collective::Pallet::<T, I>::proposal_of(proposal_hash)
+		pallet_collective::Pallet::<T, I>::proposal_of(&proposal_hash)
 	}
 }
 


### PR DESCRIPTION
companion for [substrate#14585](https://github.com/paritytech/substrate/pull/14585)