### PR TITLE
Remove collators from bootnodes list

### DIFF
--- a/parachains/chain-specs/bridge-hub-kusama.json
+++ b/parachains/chain-specs/bridge-hub-kusama.json
@@ -3,10 +3,6 @@
   "id": "bridge-hub-kusama",
   "chainType": "Live",
   "bootNodes": [
-    "/dns/kusama-bridge-hub-collator-ew1-0.polkadot.io/tcp/30334/p2p/12D3KooWP2Gngt4tt2sz5BgDaAbMTxasPWk3V2Z99bQTmFcAorqa",
-    "/dns/kusama-bridge-hub-collator-ew1-1.polkadot.io/tcp/30334/p2p/12D3KooWMmL3FQuYmruBui1sbY4MwNmvicinrePi1Yq4QMRSYHoR",
-    "/dns/kusama-bridge-hub-collator-ue4-0.polkadot.io/tcp/30334/p2p/12D3KooWQpTocTck1tNBzMNTHJ3kSv4vzv8Yf9FpVkfGnungbez4",
-    "/dns/kusama-bridge-hub-collator-ue4-1.polkadot.io/tcp/30334/p2p/12D3KooWRgtJqKEaMi7hkU4VMiGhpHTJeL8N7JgL7d9gwooPv4eW",
     "/dns/kusama-bridge-hub-connect-ew1-0.polkadot.io/tcp/30334/p2p/12D3KooWPQQPivrqQ51kRTDc2R1mtqwKT4GGtk2rapkY4FrwHrEp",
     "/dns/kusama-bridge-hub-connect-ew1-1.polkadot.io/tcp/30334/p2p/12D3KooWPcF9Yk4gYrMju9CyWCV69hAFXbYsnxCLogwLGu9QFTRn",
     "/dns/kusama-bridge-hub-connect-ue4-0.polkadot.io/tcp/30334/p2p/12D3KooWMf1sVnJDTkKWtaThqvrgcSPLbfGXttSqbwhM2DJp9BUG",

--- a/parachains/chain-specs/collectives-polkadot.json
+++ b/parachains/chain-specs/collectives-polkadot.json
@@ -3,10 +3,6 @@
   "id": "collectives_polkadot",
   "chainType": "Live",
   "bootNodes": [
-    "/dns/polkadot-collectives-collator-ew6-0.polkadot.io/tcp/30334/p2p/12D3KooWKgrivNBkMswNNNYqUkhEBvnyRzt6TLPQ2shu4eoPuuRi",
-    "/dns/polkadot-collectives-collator-ew6-1.polkadot.io/tcp/30334/p2p/12D3KooWQen2oX7hWqhUiJ4sxj7WA4Qa3WoAmz6rQbmYPCYjeCk9",
-    "/dns/polkadot-collectives-collator-uw1-0.polkadot.io/tcp/30334/p2p/12D3KooWJXwJS1d2UcdkKd8a6vM4TFB79gvtHtsp4bm4c8fYdpY7",
-    "/dns/polkadot-collectives-collator-uw1-1.polkadot.io/tcp/30334/p2p/12D3KooWRjdypZdMT9rjajYM2L2P5mYaxPGErP9ExGBsY3PBdYDy",
     "/dns/polkadot-collectives-connect-ew6-0.polkadot.io/tcp/30334/p2p/12D3KooWLDZT5gAjMtC8fojiCwiz17SC61oeX2C7GWBCqqf9TwVD",
     "/dns/polkadot-collectives-connect-ew6-1.polkadot.io/tcp/30334/p2p/12D3KooWC9BwKMDyRUTXsE7teSmoKMgbyxqAp3zi2MTGRJR5nhCL",
     "/dns/polkadot-collectives-connect-uw1-0.polkadot.io/tcp/30334/p2p/12D3KooWPrJ9VTn3GEs2e7GQs4zoEFiTFcjXFNbQ2iDxFDQAbstQ",


### PR DESCRIPTION
We are no longer using collators in the bootnode list; instead, we have replaced them with "connect" nodes. This change serves two purposes: first, it removes unnecessary load from collators, and secondly, it enables us to proceed with the planned decommission of collators nodes as outlined in [Referendum 84](https://polkadot.subsquare.io/referenda/referendum/84)