### PR TITLE
Change Matrix to new secrets and V2 server

### DIFF
--- a/.github/workflows/release-10_rc-automation.yml
+++ b/.github/workflows/release-10_rc-automation.yml
@@ -81,7 +81,7 @@ jobs:
           access_token: ${{ secrets.RELEASENOTES_MATRIX_V2_ACCESS_TOKEN }}
           server: "m.parity.io"
           message: |
-            The Release Process for Cumulus ${{ steps.compute_tag.outputs.version }} has been started.
+            The Release Process for Cumulus ${{ steps.compute_tag.outputs.version }} has been started.<br/>
             Tracking issues:
               - client: ${{ steps.create-issue-checklist-client.outputs.url }}"
               - runtime: ${{ steps.create-issue-checklist-runtime.outputs.url }}"

--- a/.github/workflows/release-10_rc-automation.yml
+++ b/.github/workflows/release-10_rc-automation.yml
@@ -79,7 +79,7 @@ jobs:
         with:
           room_id: ${{ matrix.channel.room }}
           access_token: ${{ secrets.RELEASENOTES_MATRIX_V2_ACCESS_TOKEN }}
-          server: "matrix.parity.io"
+          server: "m.parity.io"
           message: |
             The Release Process for Cumulus ${{ steps.compute_tag.outputs.version }} has been started.
             Tracking issues:

--- a/.github/workflows/release-10_rc-automation.yml
+++ b/.github/workflows/release-10_rc-automation.yml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       matrix:
         channel:
-          - name: 'Cumulus Release Coordination'
-            room: '!ZrLPsivsytpkdJfVaa:matrix.parity.io'
+          - name: 'RelEng: Cumulus Release Coordination'
+            room: '!NAEMyPAHWOiOQHsvus:parity.io'
             pre-releases: true
     steps:
       - name: Checkout sources

--- a/.github/workflows/release-10_rc-automation.yml
+++ b/.github/workflows/release-10_rc-automation.yml
@@ -78,7 +78,7 @@ jobs:
         if: steps.create-issue-checklist-client.outputs.url != '' && steps.create-issue-checklist-runtime.outputs.url != ''
         with:
           room_id: ${{ matrix.channel.room }}
-          access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
+          access_token: ${{ secrets.RELEASENOTES_MATRIX_V2_ACCESS_TOKEN }}
           server: "matrix.parity.io"
           message: |
             The Release Process for Cumulus ${{ steps.compute_tag.outputs.version }} has been started.

--- a/.github/workflows/release-30_create-draft.yml
+++ b/.github/workflows/release-30_create-draft.yml
@@ -292,8 +292,8 @@ jobs:
     strategy:
       matrix:
         channel:
-          - name: 'Cumulus Release Coordination'
-            room: '!ZrLPsivsytpkdJfVaa:matrix.parity.io'
+          - name: 'RelEng: Cumulus Release Coordination'
+            room: '!NAEMyPAHWOiOQHsvus:parity.io'
             pre-releases: true
     steps:
       - name: Matrix notification to ${{ matrix.channel.name }}

--- a/.github/workflows/release-30_create-draft.yml
+++ b/.github/workflows/release-30_create-draft.yml
@@ -300,7 +300,7 @@ jobs:
         uses: s3krit/matrix-message-action@70ad3fb812ee0e45ff8999d6af11cafad11a6ecf # v0.0.3
         with:
           room_id: ${{ matrix.channel.room }}
-          access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
+          access_token: ${{ secrets.RELEASENOTES_MATRIX_V2_ACCESS_TOKEN }}
           message: |
             **New draft for ${{ github.repository }}**: ${{ github.event.inputs.ref2 }}<br/>
 

--- a/.github/workflows/release-30_create-draft.yml
+++ b/.github/workflows/release-30_create-draft.yml
@@ -308,4 +308,4 @@ jobs:
 
             NOTE: The link above will no longer be valid if the draft is edited. You can then use the following link:
             [${{ github.server_url }}/${{ github.repository }}/releases](${{ github.server_url }}/${{ github.repository }}/releases)
-          server: "matrix.parity.io"
+          server: "m.parity.io"

--- a/.github/workflows/release-30_create-draft.yml
+++ b/.github/workflows/release-30_create-draft.yml
@@ -301,6 +301,7 @@ jobs:
         with:
           room_id: ${{ matrix.channel.room }}
           access_token: ${{ secrets.RELEASENOTES_MATRIX_V2_ACCESS_TOKEN }}
+          server: "m.parity.io"
           message: |
             **New draft for ${{ github.repository }}**: ${{ github.event.inputs.ref2 }}<br/>
 
@@ -308,4 +309,3 @@ jobs:
 
             NOTE: The link above will no longer be valid if the draft is edited. You can then use the following link:
             [${{ github.server_url }}/${{ github.repository }}/releases](${{ github.server_url }}/${{ github.repository }}/releases)
-          server: "m.parity.io"

--- a/.github/workflows/release-99_bot-announce.yml
+++ b/.github/workflows/release-99_bot-announce.yml
@@ -10,11 +10,17 @@ jobs:
     strategy:
       matrix:
         channel:
-          - name: 'Cumulus Release Coordination'
-            room: '!ZrLPsivsytpkdJfVaa:matrix.parity.io'
+          - name: 'RelEng: Cumulus Release Coordination'
+            room: '!NAEMyPAHWOiOQHsvus:parity.io'
             pre-releases: true
           - name: 'Ledger <> Polkadot Coordination'
             room: '!EoIhaKfGPmFOBrNSHT:web3.foundation'
+            pre-release: true
+          - name: 'General: Rust, Polkadot, Substrate'
+            room: '!aJymqQYtCjjqImFLSb:parity.io'
+            pre-release: false
+          - name: 'Team: DevOps'
+            room: '!lUslSijLMgNcEKcAiE:parity.io'
             pre-release: true
 
     steps:

--- a/.github/workflows/release-99_bot-announce.yml
+++ b/.github/workflows/release-99_bot-announce.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           room_id: ${{ matrix.channel.room }}
           access_token: ${{ secrets.RELEASENOTES_MATRIX_V2_ACCESS_TOKEN }}
-          server: "matrix.parity.io"
+          server: "m.parity.io"
           message: |
             A (pre)release has been ${{github.event.action}} in **${{github.event.repository.full_name}}:**<br/>
             Release version: [${{github.event.release.tag_name}}](${{github.event.release.html_url}})

--- a/.github/workflows/release-99_bot-announce.yml
+++ b/.github/workflows/release-99_bot-announce.yml
@@ -22,7 +22,7 @@ jobs:
         uses: s3krit/matrix-message-action@70ad3fb812ee0e45ff8999d6af11cafad11a6ecf # v0.0.3
         with:
           room_id: ${{ matrix.channel.room }}
-          access_token: ${{ secrets.MATRIX_ACCESS_TOKEN }}
+          access_token: ${{ secrets.RELEASENOTES_MATRIX_V2_ACCESS_TOKEN }}
           server: "matrix.parity.io"
           message: |
             A (pre)release has been ${{github.event.action}} in **${{github.event.repository.full_name}}:**<br/>


### PR DESCRIPTION
WIP !
Similar to https://github.com/paritytech/polkadot/pull/7143

Move to the new matrix server and fix a few related things

## Todo

- [x] rename `MATRIX_ACCESS_TOKEN` into `RELEASENOTES_MATRIX_V2_ACCESS_TOKEN`
- [x] create new `RELEASENOTES_MATRIX_V2_ACCESS_TOKEN` secret in GH
- [x] Invite bot to required rooms:
   - [x] Cumulus Release Coordination
   - [x] Ledger <> Polkadot Coordination
- [x] Add release annoucements to `Rust, Polkadot, Substrate`

## After merge

- [ ] delete secret `MATRIX_ACCESS_TOKEN`

cc @lazam @EgorPopelyaev @dartamendi-parity 