### PR TITLE
Explicitly set `full-node` feature for emulated tests

### DIFF
--- a/parachains/integration-tests/emulated/common/Cargo.toml
+++ b/parachains/integration-tests/emulated/common/Cargo.toml
@@ -26,7 +26,7 @@ beefy-primitives = { package = "sp-consensus-beefy", git = "https://github.com/p
 # Polkadot
 polkadot-core-primitives = { default-features = false, git = "https://github.com/paritytech/polkadot", branch = "master" }
 polkadot-parachain = { default-features = false, git = "https://github.com/paritytech/polkadot", branch = "master" }
-polkadot-service = { default-features = false, git = "https://github.com/paritytech/polkadot", branch = "master" }
+polkadot-service = { default-features = false, git = "https://github.com/paritytech/polkadot", branch = "master", features = ["full-node"] }
 polkadot-primitives = { default-features = false, git = "https://github.com/paritytech/polkadot", branch = "master" }
 polkadot-runtime-parachains = { git = "https://github.com/paritytech/polkadot", branch = "master" }
 polkadot-runtime = { git = "https://github.com/paritytech/polkadot", branch = "master" }


### PR DESCRIPTION
Was implicitly turned on before by a dep that has been recently removed by #2925 .

(without this if you go to `parachains/integration-tests/emulated/assets/asset-hub-westend` and run `cargo test` it will lead to compile errors.)