### PR TITLE
set-metadata is a safe call

### DIFF
--- a/parachains/runtimes/assets/asset-hub-kusama/src/xcm_config.rs
+++ b/parachains/runtimes/assets/asset-hub-kusama/src/xcm_config.rs
@@ -237,6 +237,7 @@ impl Contains<RuntimeCall> for SafeCallFilter {
 						pallet_assets::Call::thaw_asset { .. } |
 						pallet_assets::Call::transfer_ownership { .. } |
 						pallet_assets::Call::set_team { .. } |
+						pallet_assets::Call::set_metadata { .. } |
 						pallet_assets::Call::clear_metadata { .. } |
 						pallet_assets::Call::force_clear_metadata { .. } |
 						pallet_assets::Call::force_asset_status { .. } |

--- a/parachains/runtimes/assets/asset-hub-westend/src/xcm_config.rs
+++ b/parachains/runtimes/assets/asset-hub-westend/src/xcm_config.rs
@@ -293,6 +293,7 @@ impl Contains<RuntimeCall> for SafeCallFilter {
 					pallet_assets::Call::thaw_asset { .. } |
 					pallet_assets::Call::transfer_ownership { .. } |
 					pallet_assets::Call::set_team { .. } |
+					pallet_assets::Call::set_metadata { .. } |
 					pallet_assets::Call::clear_metadata { .. } |
 					pallet_assets::Call::force_clear_metadata { .. } |
 					pallet_assets::Call::force_asset_status { .. } |


### PR DESCRIPTION
There's a bit of inconsistency in the diffs, most allow set-metadata, some don't. Set metadata is bounded by `StringLength` so it should be safe to call. This PR removes these inconsistencies to allow it everywhere.