### PR TITLE
Companion: Add xcm context to weight trader

### DIFF
--- a/primitives/utility/src/lib.rs
+++ b/primitives/utility/src/lib.rs
@@ -144,6 +144,7 @@ impl<
 	// If everything goes well, we charge.
 	fn buy_weight(
 		&mut self,
+		_ctx: &XcmContext,
 		weight: Weight,
 		payment: xcm_executor::Assets,
 	) -> Result<xcm_executor::Assets, XcmError> {
@@ -196,7 +197,7 @@ impl<
 		Ok(unused)
 	}
 
-	fn refund_weight(&mut self, weight: Weight) -> Option<MultiAsset> {
+	fn refund_weight(&mut self, _ctx: &XcmContext, weight: Weight) -> Option<MultiAsset> {
 		log::trace!(target: "xcm::weight", "TakeFirstAssetTrader::refund_weight weight: {:?}", weight);
 		if let Some(AssetTraderRefunder {
 			mut weight_outstanding,


### PR DESCRIPTION
Companion to https://github.com/paritytech/polkadot/pull/7561