### PR TITLE
Symlink chain-specs json files to crate where they are used

### DIFF
--- a/polkadot-parachain/chain-specs/asset-hub-kusama.json
+++ b/polkadot-parachain/chain-specs/asset-hub-kusama.json
@@ -1,0 +1,1 @@
+../../parachains/chain-specs/asset-hub-kusama.json

--- a/polkadot-parachain/chain-specs/asset-hub-polkadot.json
+++ b/polkadot-parachain/chain-specs/asset-hub-polkadot.json
@@ -1,0 +1,1 @@
+../../parachains/chain-specs/asset-hub-polkadot.json

--- a/polkadot-parachain/chain-specs/asset-hub-westend.json
+++ b/polkadot-parachain/chain-specs/asset-hub-westend.json
@@ -1,0 +1,1 @@
+../../parachains/chain-specs/asset-hub-westend.json

--- a/polkadot-parachain/chain-specs/bridge-hub-kusama.json
+++ b/polkadot-parachain/chain-specs/bridge-hub-kusama.json
@@ -1,0 +1,1 @@
+../../parachains/chain-specs/bridge-hub-kusama.json

--- a/polkadot-parachain/chain-specs/bridge-hub-polkadot.json
+++ b/polkadot-parachain/chain-specs/bridge-hub-polkadot.json
@@ -1,0 +1,1 @@
+../../parachains/chain-specs/bridge-hub-polkadot.json

--- a/polkadot-parachain/chain-specs/bridge-hub-rococo.json
+++ b/polkadot-parachain/chain-specs/bridge-hub-rococo.json
@@ -1,0 +1,1 @@
+../../parachains/chain-specs/bridge-hub-rococo.json

--- a/polkadot-parachain/chain-specs/bridge-hub-westend.json
+++ b/polkadot-parachain/chain-specs/bridge-hub-westend.json
@@ -1,0 +1,1 @@
+../../parachains/chain-specs/bridge-hub-westend.json

--- a/polkadot-parachain/chain-specs/bridge-hub-wococo.json
+++ b/polkadot-parachain/chain-specs/bridge-hub-wococo.json
@@ -1,0 +1,1 @@
+../../parachains/chain-specs/bridge-hub-wococo.json

--- a/polkadot-parachain/chain-specs/collectives-polkadot.json
+++ b/polkadot-parachain/chain-specs/collectives-polkadot.json
@@ -1,0 +1,1 @@
+../../parachains/chain-specs/collectives-polkadot.json

--- a/polkadot-parachain/chain-specs/collectives-westend.json
+++ b/polkadot-parachain/chain-specs/collectives-westend.json
@@ -1,0 +1,1 @@
+../../parachains/chain-specs/collectives-westend.json

--- a/polkadot-parachain/chain-specs/contracts-rococo.json
+++ b/polkadot-parachain/chain-specs/contracts-rococo.json
@@ -1,0 +1,1 @@
+../../parachains/chain-specs/contracts-rococo.json

--- a/polkadot-parachain/chain-specs/tick.json
+++ b/polkadot-parachain/chain-specs/tick.json
@@ -1,0 +1,1 @@
+../../parachains/chain-specs/tick.json

--- a/polkadot-parachain/chain-specs/track.json
+++ b/polkadot-parachain/chain-specs/track.json
@@ -1,0 +1,1 @@
+../../parachains/chain-specs/track.json

--- a/polkadot-parachain/chain-specs/trick.json
+++ b/polkadot-parachain/chain-specs/trick.json
@@ -1,0 +1,1 @@
+../../parachains/chain-specs/trick.json

--- a/polkadot-parachain/src/chain_spec/bridge_hubs.rs
+++ b/polkadot-parachain/src/chain_spec/bridge_hubs.rs
@@ -97,7 +97,7 @@ impl BridgeHubRuntimeType {
 		match self {
 			BridgeHubRuntimeType::Polkadot =>
 				Ok(Box::new(polkadot::BridgeHubChainSpec::from_json_bytes(
-					&include_bytes!("../../../parachains/chain-specs/bridge-hub-polkadot.json")[..],
+					&include_bytes!("../../chain-specs/bridge-hub-polkadot.json")[..],
 				)?)),
 			BridgeHubRuntimeType::PolkadotLocal => Ok(Box::new(polkadot::local_config(
 				polkadot::BRIDGE_HUB_POLKADOT_LOCAL,
@@ -113,7 +113,7 @@ impl BridgeHubRuntimeType {
 			))),
 			BridgeHubRuntimeType::Kusama =>
 				Ok(Box::new(kusama::BridgeHubChainSpec::from_json_bytes(
-					&include_bytes!("../../../parachains/chain-specs/bridge-hub-kusama.json")[..],
+					&include_bytes!("../../chain-specs/bridge-hub-kusama.json")[..],
 				)?)),
 			BridgeHubRuntimeType::KusamaLocal => Ok(Box::new(kusama::local_config(
 				kusama::BRIDGE_HUB_KUSAMA_LOCAL,
@@ -129,11 +129,11 @@ impl BridgeHubRuntimeType {
 			))),
 			BridgeHubRuntimeType::Westend =>
 				Ok(Box::new(westend::BridgeHubChainSpec::from_json_bytes(
-					&include_bytes!("../../../parachains/chain-specs/bridge-hub-westend.json")[..],
+					&include_bytes!("../../chain-specs/bridge-hub-westend.json")[..],
 				)?)),
 			BridgeHubRuntimeType::Rococo =>
 				Ok(Box::new(rococo::BridgeHubChainSpec::from_json_bytes(
-					&include_bytes!("../../../parachains/chain-specs/bridge-hub-rococo.json")[..],
+					&include_bytes!("../../chain-specs/bridge-hub-rococo.json")[..],
 				)?)),
 			BridgeHubRuntimeType::RococoLocal => Ok(Box::new(rococo::local_config(
 				rococo::BRIDGE_HUB_ROCOCO_LOCAL,
@@ -153,7 +153,7 @@ impl BridgeHubRuntimeType {
 			))),
 			BridgeHubRuntimeType::Wococo =>
 				Ok(Box::new(wococo::BridgeHubChainSpec::from_json_bytes(
-					&include_bytes!("../../../parachains/chain-specs/bridge-hub-wococo.json")[..],
+					&include_bytes!("../../chain-specs/bridge-hub-wococo.json")[..],
 				)?)),
 			BridgeHubRuntimeType::WococoLocal => Ok(Box::new(wococo::local_config(
 				wococo::BRIDGE_HUB_WOCOCO_LOCAL,

--- a/polkadot-parachain/src/command.rs
+++ b/polkadot-parachain/src/command.rs
@@ -121,15 +121,15 @@ fn load_spec(id: &str) -> std::result::Result<Box<dyn ChainSpec>, String> {
 			Box::new(chain_spec::rococo_parachain::staging_rococo_parachain_local_config()),
 		"tick" =>
 			Box::new(chain_spec::rococo_parachain::RococoParachainChainSpec::from_json_bytes(
-				&include_bytes!("../../parachains/chain-specs/tick.json")[..],
+				&include_bytes!("../chain-specs/tick.json")[..],
 			)?),
 		"trick" =>
 			Box::new(chain_spec::rococo_parachain::RococoParachainChainSpec::from_json_bytes(
-				&include_bytes!("../../parachains/chain-specs/trick.json")[..],
+				&include_bytes!("../chain-specs/trick.json")[..],
 			)?),
 		"track" =>
 			Box::new(chain_spec::rococo_parachain::RococoParachainChainSpec::from_json_bytes(
-				&include_bytes!("../../parachains/chain-specs/track.json")[..],
+				&include_bytes!("../chain-specs/track.json")[..],
 			)?),
 
 		// -- Starters
@@ -147,7 +147,7 @@ fn load_spec(id: &str) -> std::result::Result<Box<dyn ChainSpec>, String> {
 		// the shell-based chain spec as used for syncing
 		"asset-hub-polkadot" | "statemint" =>
 			Box::new(chain_spec::asset_hubs::AssetHubPolkadotChainSpec::from_json_bytes(
-				&include_bytes!("../../parachains/chain-specs/asset-hub-polkadot.json")[..],
+				&include_bytes!("../chain-specs/asset-hub-polkadot.json")[..],
 			)?),
 
 		// -- Asset Hub Kusama
@@ -161,7 +161,7 @@ fn load_spec(id: &str) -> std::result::Result<Box<dyn ChainSpec>, String> {
 		// the shell-based chain spec as used for syncing
 		"asset-hub-kusama" | "statemine" =>
 			Box::new(chain_spec::asset_hubs::AssetHubKusamaChainSpec::from_json_bytes(
-				&include_bytes!("../../parachains/chain-specs/asset-hub-kusama.json")[..],
+				&include_bytes!("../chain-specs/asset-hub-kusama.json")[..],
 			)?),
 
 		// -- Asset Hub Westend
@@ -175,7 +175,7 @@ fn load_spec(id: &str) -> std::result::Result<Box<dyn ChainSpec>, String> {
 		// the shell-based chain spec as used for syncing
 		"asset-hub-westend" | "westmint" =>
 			Box::new(chain_spec::asset_hubs::AssetHubWestendChainSpec::from_json_bytes(
-				&include_bytes!("../../parachains/chain-specs/asset-hub-westend.json")[..],
+				&include_bytes!("../chain-specs/asset-hub-westend.json")[..],
 			)?),
 
 		// -- Polkadot Collectives
@@ -185,11 +185,11 @@ fn load_spec(id: &str) -> std::result::Result<Box<dyn ChainSpec>, String> {
 			Box::new(chain_spec::collectives::collectives_polkadot_local_config()),
 		"collectives-polkadot" =>
 			Box::new(chain_spec::collectives::CollectivesPolkadotChainSpec::from_json_bytes(
-				&include_bytes!("../../parachains/chain-specs/collectives-polkadot.json")[..],
+				&include_bytes!("../chain-specs/collectives-polkadot.json")[..],
 			)?),
 		"collectives-westend" =>
 			Box::new(chain_spec::collectives::CollectivesPolkadotChainSpec::from_json_bytes(
-				&include_bytes!("../../parachains/chain-specs/collectives-westend.json")[..],
+				&include_bytes!("../chain-specs/collectives-westend.json")[..],
 			)?),
 
 		// -- Contracts on Rococo
@@ -200,7 +200,7 @@ fn load_spec(id: &str) -> std::result::Result<Box<dyn ChainSpec>, String> {
 		"contracts-rococo-genesis" => Box::new(chain_spec::contracts::contracts_rococo_config()),
 		"contracts-rococo" =>
 			Box::new(chain_spec::contracts::ContractsRococoChainSpec::from_json_bytes(
-				&include_bytes!("../../parachains/chain-specs/contracts-rococo.json")[..],
+				&include_bytes!("../chain-specs/contracts-rococo.json")[..],
 			)?),
 
 		// -- BridgeHub


### PR DESCRIPTION
When publishing crates, each crate becomes it's own tarball that can't access files from other crates. So symlink the files to be crate local and cargo will replace the symlinks with real files at publish time.