### PR TITLE
init para ids when reseting network

### DIFF
--- a/parachains/integration-tests/emulated/assets/asset-hub-kusama/src/tests/reserve_transfer.rs
+++ b/parachains/integration-tests/emulated/assets/asset-hub-kusama/src/tests/reserve_transfer.rs
@@ -18,6 +18,7 @@ use crate::*;
 
 #[test]
 fn reserve_transfer_native_asset_from_relay_to_assets() {
+	KusamaMockNet::reset();
 	// Init tests variables
 	let amount = KUSAMA_ED * 1000;
 	let relay_sender_balance_before = Kusama::account_data_of(KusamaSender::get()).free;

--- a/parachains/integration-tests/emulated/assets/asset-hub-kusama/src/tests/reserve_transfer.rs
+++ b/parachains/integration-tests/emulated/assets/asset-hub-kusama/src/tests/reserve_transfer.rs
@@ -18,7 +18,6 @@ use crate::*;
 
 #[test]
 fn reserve_transfer_native_asset_from_relay_to_assets() {
-	KusamaMockNet::reset();
 	// Init tests variables
 	let amount = KUSAMA_ED * 1000;
 	let relay_sender_balance_before = Kusama::account_data_of(KusamaSender::get()).free;

--- a/xcm/xcm-emulator/src/lib.rs
+++ b/xcm/xcm-emulator/src/lib.rs
@@ -809,7 +809,7 @@ macro_rules! decl_test_networks {
 
 			impl $name {
 				pub fn reset() {
-					use $crate::{TestExt, VecDeque};
+					use $crate::{TestExt, VecDeque, Network};
 
 					$crate::INITIALIZED.with(|b| b.borrow_mut().remove(stringify!($name)));
 					$crate::DOWNWARD_MESSAGES.with(|b| b.borrow_mut().remove(stringify!($name)));
@@ -818,6 +818,7 @@ macro_rules! decl_test_networks {
 					$crate::HORIZONTAL_MESSAGES.with(|b| b.borrow_mut().remove(stringify!($name)));
 					$crate::BRIDGED_MESSAGES.with(|b| b.borrow_mut().remove(stringify!($name)));
 					$crate::RELAY_BLOCK_NUMBER.with(|b| b.borrow_mut().remove(stringify!($name)));
+					$crate::PARA_IDS.with(|b| b.borrow_mut().insert(stringify!($name).to_string(), Self::_para_ids()));
 
 					<$relay_chain>::reset_ext();
 					$( <$parachain>::reset_ext(); )*

--- a/xcm/xcm-emulator/src/lib.rs
+++ b/xcm/xcm-emulator/src/lib.rs
@@ -818,7 +818,7 @@ macro_rules! decl_test_networks {
 					$crate::HORIZONTAL_MESSAGES.with(|b| b.borrow_mut().remove(stringify!($name)));
 					$crate::BRIDGED_MESSAGES.with(|b| b.borrow_mut().remove(stringify!($name)));
 					$crate::RELAY_BLOCK_NUMBER.with(|b| b.borrow_mut().remove(stringify!($name)));
-					$crate::PARA_IDS.with(|b| b.borrow_mut().insert(stringify!($name).to_string(), Self::para_ids()));
+					$crate::PARA_IDS.with(|b| b.borrow_mut().remove(stringify!($name)));
 
 					<$relay_chain>::reset_ext();
 					$( <$parachain>::reset_ext(); )*

--- a/xcm/xcm-emulator/src/lib.rs
+++ b/xcm/xcm-emulator/src/lib.rs
@@ -809,7 +809,7 @@ macro_rules! decl_test_networks {
 
 			impl $name {
 				pub fn reset() {
-					use $crate::{TestExt, VecDeque, Network};
+					use $crate::{TestExt, VecDeque};
 
 					$crate::INITIALIZED.with(|b| b.borrow_mut().remove(stringify!($name)));
 					$crate::DOWNWARD_MESSAGES.with(|b| b.borrow_mut().remove(stringify!($name)));

--- a/xcm/xcm-emulator/src/lib.rs
+++ b/xcm/xcm-emulator/src/lib.rs
@@ -818,7 +818,7 @@ macro_rules! decl_test_networks {
 					$crate::HORIZONTAL_MESSAGES.with(|b| b.borrow_mut().remove(stringify!($name)));
 					$crate::BRIDGED_MESSAGES.with(|b| b.borrow_mut().remove(stringify!($name)));
 					$crate::RELAY_BLOCK_NUMBER.with(|b| b.borrow_mut().remove(stringify!($name)));
-					$crate::PARA_IDS.with(|b| b.borrow_mut().insert(stringify!($name).to_string(), Self::_para_ids()));
+					$crate::PARA_IDS.with(|b| b.borrow_mut().insert(stringify!($name).to_string(), Self::para_ids()));
 
 					<$relay_chain>::reset_ext();
 					$( <$parachain>::reset_ext(); )*


### PR DESCRIPTION
I noticed that resetting the network in tests fails because PARA_IDs are not initialized. This is a small fix for that 