### PR TITLE
fix failing gha because of the wrong assignee

### DIFF
--- a/.github/workflows/release-10_rc-automation.yml
+++ b/.github/workflows/release-10_rc-automation.yml
@@ -59,7 +59,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.compute_tag.outputs.version }}
         with:
-          assignees: release-engineering
           filename: .github/ISSUE_TEMPLATE/release-client.md
 
       - id: create-issue-checklist-runtime
@@ -70,7 +69,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.compute_tag.outputs.version }}
         with:
-          assignees: release-engineering
           filename: .github/ISSUE_TEMPLATE/release-runtime.md
 
       - name: Matrix notification to ${{ matrix.channel.name }}

--- a/.github/workflows/release-10_rc-automation.yml
+++ b/.github/workflows/release-10_rc-automation.yml
@@ -59,6 +59,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.compute_tag.outputs.version }}
         with:
+          assignees: EgorPopelyaev, coderobe, chevdor
           filename: .github/ISSUE_TEMPLATE/release-client.md
 
       - id: create-issue-checklist-runtime
@@ -69,6 +70,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.compute_tag.outputs.version }}
         with:
+          assignees: EgorPopelyaev, coderobe, chevdor
           filename: .github/ISSUE_TEMPLATE/release-runtime.md
 
       - name: Matrix notification to ${{ matrix.channel.name }}


### PR DESCRIPTION
Tiny fix to avoid failures while creating the release checklists due to wrong assignees