### PR TITLE
Girazoki make emulator functions more generic

### DIFF
--- a/xcm/xcm-emulator/src/lib.rs
+++ b/xcm/xcm-emulator/src/lib.rs
@@ -455,19 +455,19 @@ macro_rules! __impl_relay {
 				(Ancestor(0), Parachain(id.into())).into()
 			}
 
-			pub fn account_id_of(seed: &str) -> $crate::AccountId {
+			pub fn account_id_of(seed: &str) -> <<Self as RelayChain>::Runtime as frame_system::Config>::AccountId {
 				$crate::get_account_id_from_seed::<sr25519::Public>(seed)
 			}
 
-			pub fn account_data_of(account: AccountId) -> $crate::AccountData<Balance> {
+			pub fn account_data_of(account: <<Self as RelayChain>::Runtime as frame_system::Config>::AccountId) -> $crate::AccountData<<<Self as RelayChain>::Runtime as pallet_balances::Config>::Balance> {
 				Self::ext_wrapper(|| <Self as RelayChain>::System::account(account).data)
 			}
 
-			pub fn sovereign_account_id_of(location: $crate::MultiLocation) -> $crate::AccountId {
-				<Self as RelayChain>::SovereignAccountOf::convert_location(&location).unwrap()
+			pub fn sovereign_account_id_of(location: $crate::MultiLocation) -> <<Self as RelayChain>::Runtime as frame_system::Config>::AccountId {
+				<Self as RelayChain>::SovereignAccountOf::convert(location.into()).unwrap()
 			}
 
-			pub fn fund_accounts(accounts: Vec<(AccountId, Balance)>) {
+			pub fn fund_accounts(accounts: Vec<(<<Self as RelayChain>::Runtime as frame_system::Config>::AccountId, <<Self as RelayChain>::Runtime as pallet_balances::Config>::Balance)>) {
 				Self::ext_wrapper(|| {
 					for account in accounts {
 						let _ = <Self as RelayChain>::Balances::force_set_balance(
@@ -740,15 +740,15 @@ macro_rules! __impl_parachain {
 				$crate::get_account_id_from_seed::<sr25519::Public>(seed)
 			}
 
-			pub fn account_data_of(account: AccountId) -> $crate::AccountData<Balance> {
+			pub fn account_data_of(account: <<Self as Parachain>::Runtime as frame_system::Config>::AccountId) -> $crate::AccountData<<<Self as Parachain>::Runtime as pallet_balances::Config>::Balance> {
 				Self::ext_wrapper(|| <Self as Parachain>::System::account(account).data)
 			}
 
-			pub fn sovereign_account_id_of(location: $crate::MultiLocation) -> $crate::AccountId {
-				<Self as Parachain>::LocationToAccountId::convert_location(&location).unwrap()
+			pub fn sovereign_account_id_of(location: $crate::MultiLocation) -> <<Self as Parachain>::Runtime as frame_system::Config>::AccountId {
+				<Self as Parachain>::LocationToAccountId::convert(location.into()).unwrap()
 			}
 
-			pub fn fund_accounts(accounts: Vec<(AccountId, Balance)>) {
+			pub fn fund_accounts(accounts: Vec<(<<Self as Parachain>::Runtime as frame_system::Config>::AccountId, <<Self as Parachain>::Runtime as pallet_balances::Config>::Balance)>) {
 				Self::ext_wrapper(|| {
 					for account in accounts {
 						let _ = <Self as Parachain>::Balances::force_set_balance(

--- a/xcm/xcm-emulator/src/lib.rs
+++ b/xcm/xcm-emulator/src/lib.rs
@@ -464,7 +464,7 @@ macro_rules! __impl_relay {
 			}
 
 			pub fn sovereign_account_id_of(location: $crate::MultiLocation) -> <<Self as RelayChain>::Runtime as frame_system::Config>::AccountId {
-				<Self as RelayChain>::SovereignAccountOf::convert(location.into()).unwrap()
+				<Self as RelayChain>::SovereignAccountOf::convert_location(&location).unwrap()
 			}
 
 			pub fn fund_accounts(accounts: Vec<(<<Self as RelayChain>::Runtime as frame_system::Config>::AccountId, <<Self as RelayChain>::Runtime as pallet_balances::Config>::Balance)>) {
@@ -745,7 +745,7 @@ macro_rules! __impl_parachain {
 			}
 
 			pub fn sovereign_account_id_of(location: $crate::MultiLocation) -> <<Self as Parachain>::Runtime as frame_system::Config>::AccountId {
-				<Self as Parachain>::LocationToAccountId::convert(location.into()).unwrap()
+				<Self as Parachain>::LocationToAccountId::convert_location(&location).unwrap()
 			}
 
 			pub fn fund_accounts(accounts: Vec<(<<Self as Parachain>::Runtime as frame_system::Config>::AccountId, <<Self as Parachain>::Runtime as pallet_balances::Config>::Balance)>) {


### PR DESCRIPTION
Makes emulator a bit more generic with respect to the location to account id and account data. Prior to this PR always the accountID32 type was being used, which made the emulator unusable with 20 byte accounts like Moonbeam. This PR makes the macro compatible with these except for one single case: the `account_id_of` of the Parachain impl. The main reason I did not want to touch this function is because:

- 20 byte account generation probably has to be done with ecdsa and it would cause a lot of conflicts
- It is not critical as currently its mostly used to declare senders and receivers, which we can already do through `parameter_types`