### PR TITLE
benchmark script: remove file name for --output argument

### DIFF
--- a/scripts/benchmarks-ci.sh
+++ b/scripts/benchmarks-ci.sh
@@ -31,11 +31,11 @@ fi
 
 for pallet in ${pallets[@]}
 do
-	output_file="${pallet//::/_}"
+	output_dir=""
 	extra_args=""
 	# a little hack for pallet_xcm_benchmarks - we want to force custom implementation for XcmWeightInfo
 	if [[ "$pallet" == "pallet_xcm_benchmarks::generic" ]] || [[ "$pallet" == "pallet_xcm_benchmarks::fungible" ]]; then
-		output_file="xcm/$output_file"
+		output_dir="xcm/"
 		extra_args="--template=./templates/xcm-bench-template.hbs"
 	fi
 	$artifactsDir/polkadot-parachain benchmark pallet \
@@ -48,5 +48,5 @@ do
 		--repeat=$repeat \
 		--json \
 		--header=./file_header.txt \
-		--output="${benchmarkOutput}/${output_file}.rs" >> $artifactsDir/${pallet}_benchmark.json
+		--output="${benchmarkOutput}/${output_dir}" >> $artifactsDir/${pallet}_benchmark.json
 done


### PR DESCRIPTION
RRemove the file name from the --output argument for the command that benchmarks the runtimes.

The benchmark CLI tool will automatically resolve the name if it's not provided. In cases where there are multiple instances of one pallet within a single runtime, the file name needs an instance name to avoid a collision. This is already supported by the CLI tool if the file name is omitted in the --output.

The current change to the script does not affect the name resolutions for the existing weights' files.
This change is required for this PR. - https://github.com/paritytech/cumulus/pull/2002