### PR TITLE
exclude polkadot-parachain.asc and .sha256 from .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,8 @@
 **/*.md
 /docker/
 !/target/release/polkadot-parachain
+!/target/release/polkadot-parachain.asc
+!/target/release/polkadot-parachain.sha256
 
 # dotfiles in the repo root
 /.*

--- a/.dockerignore
+++ b/.dockerignore
@@ -3,9 +3,7 @@
 **/*.txt
 **/*.md
 /docker/
-!/target/release/polkadot-parachain
-!/target/release/polkadot-parachain.asc
-!/target/release/polkadot-parachain.sha256
+!/target/release-artifacts/**/*
 
 # dotfiles in the repo root
 /.*

--- a/.github/workflows/release-50_docker-manual.yml
+++ b/.github/workflows/release-50_docker-manual.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Prepare temp folder
         run: |
           TMP=$(mktemp -d)
+          echo "TMP folder: $TMP"
           echo "TMP=$TMP" >> "$GITHUB_ENV"
           pwd
           ls -al "${{ env.TMP }}"

--- a/.github/workflows/release-50_docker-manual.yml
+++ b/.github/workflows/release-50_docker-manual.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           TMP=$(mktemp -d)
           echo "TMP folder: $TMP"
-          echo "TMP=$TMP" >> "$GITHUB_ENV"
+          echo "TMP=$TMP" >> $GITHUB_ENV
           pwd
           ls -al "${{ env.TMP }}"
 

--- a/.github/workflows/release-50_docker-manual.yml
+++ b/.github/workflows/release-50_docker-manual.yml
@@ -34,7 +34,7 @@ jobs:
           echo "TMP folder: $TMP"
           echo "TMP=$TMP" >> $GITHUB_ENV
           pwd
-          # ls -al "${{ env.TMP }}"
+          ls -al "$TMP"
 
       - name: Fetch files from release
         working-directory: ${{ env.TMP }}
@@ -78,7 +78,7 @@ jobs:
             gpg --keyserver $KEYSERVER --receive-keys $KEY_PARITY_SEC
             echo -e "5\ny\n" | gpg --no-tty --command-fd 0 --expert --edit-key $KEY_PARITY_SEC trust;
 
-            if [[ ${{ github.event.release.prerelease }} == "true" ]]; then
+            if [[ "${{ github.event.release.prerelease }}" == "true" ]]; then
                 for key in $KEY_CHEVDOR $KEY_EGOR; do
                   (
                     echo "Importing GPG key $key"

--- a/.github/workflows/release-50_docker-manual.yml
+++ b/.github/workflows/release-50_docker-manual.yml
@@ -20,7 +20,6 @@ jobs:
   docker_build_publish:
     env:
       BINARY: polkadot-parachain
-      TMP: tmp
     runs-on: ubuntu-latest
 
     steps:
@@ -31,8 +30,10 @@ jobs:
 
       - name: Prepare temp folder
         run: |
-          mkdir ${TMP}
-          ls -al
+          TMP=$(mktemp -d)
+          echo "TMP=$TMP" >> "$GITHUB_ENV"
+          pwd
+          ls -al "${{ env.TMP }}"
 
       - name: Fetch files from release
         working-directory: ${{ env.TMP }}
@@ -49,45 +50,65 @@ jobs:
           chmod a+x $BINARY
           ls -al
 
-      - name: Check files
+      - name: Check SHA256
         working-directory: ${{ env.TMP }}
         run: |
           ls -al *$BINARY*
           shasum -a 256 -c $BINARY.sha256
           sha_result=$?
 
-          KEY_PARITY_SEC=9D4B2B6EB8F97156D19669A9FF0812D491B96798
-          KEY_CHEVDOR=2835EAF92072BC01D188AF2C4A092B93E97CE1E2
-          KEYSERVER=keyserver.ubuntu.com
-
-          gpg --keyserver $KEYSERVER --receive-keys $KEY_PARITY_SEC
-          if [[ ${{ github.event.inputs.prerelease }} == "true" ]]; then
-              gpg --keyserver $KEYSERVER --receive-keys $KEY_CHEVDOR
-          fi
-
-          gpg --verify $BINARY.asc
-          gpg_result=$?
-
           echo sha_result: $sha_result
-          echo gpg_result: $gpg_result
 
-          # If it fails, it would fail earlier but a second check
-          # does not hurt in case of refactoring...
-          if [[ $sha_result -ne 0 || $gpg_result -ne 0 ]]; then
-            echo "Check failed, exiting with error"
+          if [[ $sha_result -ne 0 ]]; then
+            echo "SHA256 check failed, exiting with error"
             exit 1
           else
-            echo "Checks passed"
+            echo "SHA256 check passed"
           fi
+
+      - name: Check GPG
+        working-directory: ${{ env.TMP }}
+        run: |
+            KEY_PARITY_SEC=9D4B2B6EB8F97156D19669A9FF0812D491B96798
+            KEY_CHEVDOR=2835EAF92072BC01D188AF2C4A092B93E97CE1E2
+            KEY_EGOR=E6FC4D4782EB0FA64A4903CCDB7D3555DD3932D3
+            KEYSERVER=keyserver.ubuntu.com
+
+            gpg --keyserver $KEYSERVER --receive-keys $KEY_PARITY_SEC
+            echo -e "5\ny\n" | gpg --no-tty --command-fd 0 --expert --edit-key $KEY_PARITY_SEC trust;
+
+            if [[ ${{ github.event.release.prerelease }} == "true" ]]; then
+                for key in $KEY_CHEVDOR $KEY_EGOR; do
+                  (
+                    echo "Importing GPG key $key"
+                    gpg --no-tty --quiet --keyserver $GPG_KEYSERVER --recv-keys $key
+                    echo -e "4\ny\n" | gpg --no-tty --command-fd 0 --expert --edit-key $key trust;
+                  ) &
+                done
+                wait
+            fi
+
+            gpg --no-tty --verify $BINARY.asc
+            gpg_result=$?
+
+            echo gpg_result: $gpg_result
+
+            if [[ $gpg_result -ne 0 ]]; then
+              echo "GPG check failed, exiting with error"
+              exit 1
+            else
+              echo "GPG check passed"
+            fi
 
       - name: Build injected image
         env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_ORG: parity
+          OWNER: ${{ env.DOCKERHUB_ORG }}
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          IMAGE_NAME: polkadot-parachain
         run: |
-          export OWNER=$DOCKERHUB_ORG
-          mkdir -p target/release
-          cp -f ${TMP}/$BINARY* target/release/
+          mkdir -p target/release-artifacts
+          cp -f ${TMP}/$BINARY* target/release-artifacts/
           ./docker/scripts/build-injected-image.sh
 
       - name: Login to Dockerhub
@@ -131,4 +152,4 @@ jobs:
             docker push $DOCKERHUB_ORG/$BINARY:$SEMVER
           fi
 
-          docker images | grep $DOCKERHUB_ORG/$BINARY
+          docker images

--- a/.github/workflows/release-50_docker-manual.yml
+++ b/.github/workflows/release-50_docker-manual.yml
@@ -34,7 +34,7 @@ jobs:
           echo "TMP folder: $TMP"
           echo "TMP=$TMP" >> $GITHUB_ENV
           pwd
-          ls -al "${{ env.TMP }}"
+          # ls -al "${{ env.TMP }}"
 
       - name: Fetch files from release
         working-directory: ${{ env.TMP }}

--- a/.github/workflows/release-50_docker.yml
+++ b/.github/workflows/release-50_docker.yml
@@ -15,7 +15,6 @@ jobs:
   docker_build_publish:
     env:
       BINARY: polkadot-parachain
-      TMP: tmp
     runs-on: ubuntu-latest
 
     steps:
@@ -26,8 +25,10 @@ jobs:
 
       - name: Prepare temp folder
         run: |
-          mkdir ${TMP}
-          ls -al
+          TMP=$(mktemp -d)
+          echo "TMP=$TMP" >> "$GITHUB_ENV"
+          pwd
+          ls -al "${{ env.TMP }}"
 
       - name: Fetch files from release
         working-directory: ${{ env.TMP }}
@@ -48,45 +49,65 @@ jobs:
           chmod a+x $BINARY
           ls -al
 
-      - name: Check files
+      - name: Check SHA256
         working-directory: ${{ env.TMP }}
         run: |
           ls -al *$BINARY*
           shasum -a 256 -c $BINARY.sha256
           sha_result=$?
 
+          echo sha_result: $sha_result
+
+          if [[ $sha_result -ne 0 ]]; then
+            echo "SHA256 check failed, exiting with error"
+            exit 1
+          else
+            echo "SHA256 check passed"
+          fi
+
+      - name: Check GPG
+        working-directory: ${{ env.TMP }}
+        run: |
           KEY_PARITY_SEC=9D4B2B6EB8F97156D19669A9FF0812D491B96798
           KEY_CHEVDOR=2835EAF92072BC01D188AF2C4A092B93E97CE1E2
+          KEY_EGOR=E6FC4D4782EB0FA64A4903CCDB7D3555DD3932D3
           KEYSERVER=keyserver.ubuntu.com
 
           gpg --keyserver $KEYSERVER --receive-keys $KEY_PARITY_SEC
+          echo -e "5\ny\n" | gpg --no-tty --command-fd 0 --expert --edit-key $KEY_PARITY_SEC trust;
+
           if [[ ${{ github.event.release.prerelease }} == "true" ]]; then
-              gpg --keyserver $KEYSERVER --receive-keys $KEY_CHEVDOR
+              for key in $KEY_CHEVDOR $KEY_EGOR; do
+                (
+                  echo "Importing GPG key $key"
+                  gpg --no-tty --quiet --keyserver $GPG_KEYSERVER --recv-keys $key
+                  echo -e "4\ny\n" | gpg --no-tty --command-fd 0 --expert --edit-key $key trust;
+                ) &
+              done
+              wait
           fi
 
-          gpg --verify $BINARY.asc
+          gpg --no-tty --verify $BINARY.asc
           gpg_result=$?
 
-          echo sha_result: $sha_result
           echo gpg_result: $gpg_result
 
-          # If it fails, it would fail earlier but a second check
-          # does not hurt in case of refactoring...
-          if [[ $sha_result -ne 0 || $gpg_result -ne 0 ]]; then
-            echo "Check failed, exiting with error"
+          if [[ $gpg_result -ne 0 ]]; then
+            echo "GPG check failed, exiting with error"
             exit 1
           else
-            echo "Checks passed"
+            echo "GPG check passed"
           fi
 
       - name: Build injected image
         env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_ORG: parity
+          OWNER: ${{ env.DOCKERHUB_ORG }}
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          IMAGE_NAME: polkadot-parachain
         run: |
-          export OWNER=$DOCKERHUB_ORG
-          mkdir -p target/release
-          cp -f ${TMP}/$BINARY* target/release/
+          mkdir -p target/release-artifacts
+          cp -f ${TMP}/$BINARY* target/release-artifacts/
           ./docker/scripts/build-injected-image.sh
 
       - name: Login to Dockerhub
@@ -130,4 +151,4 @@ jobs:
             docker push $DOCKERHUB_ORG/$BINARY:$SEMVER
           fi
 
-          docker images | grep $DOCKERHUB_ORG/$BINARY
+          docker images

--- a/.github/workflows/release-50_docker.yml
+++ b/.github/workflows/release-50_docker.yml
@@ -28,7 +28,7 @@ jobs:
           TMP=$(mktemp -d)
           echo "TMP=$TMP" >> "$GITHUB_ENV"
           pwd
-          ls -al "${{ env.TMP }}"
+          ls -al "$TMP"
 
       - name: Fetch files from release
         working-directory: ${{ env.TMP }}
@@ -76,7 +76,7 @@ jobs:
           gpg --keyserver $KEYSERVER --receive-keys $KEY_PARITY_SEC
           echo -e "5\ny\n" | gpg --no-tty --command-fd 0 --expert --edit-key $KEY_PARITY_SEC trust;
 
-          if [[ ${{ github.event.release.prerelease }} == "true" ]]; then
+          if [[ "${{ github.event.release.prerelease }}" == "true" ]]; then
               for key in $KEY_CHEVDOR $KEY_EGOR; do
                 (
                   echo "Importing GPG key $key"

--- a/docker/injected.Dockerfile
+++ b/docker/injected.Dockerfile
@@ -17,22 +17,6 @@ LABEL io.parity.image.authors="devops-team@parity.io" \
 # show backtraces
 ENV RUST_BACKTRACE 1
 
-# install tools and dependencies
-# RUN apt-get update && \
-# 	DEBIAN_FRONTEND=noninteractive apt-get install -y \
-# 		libssl1.1 \
-# 		ca-certificates \
-# 		curl && \
-# # apt cleanup
-# 	apt-get autoremove -y && \
-# 	apt-get clean && \
-# 	find /var/lib/apt/lists/ -type f -not -name lock -delete; \
-# # add user and link ~/.local/share/polkadot to /data
-# 	useradd -m -u 1000 -U -s /bin/sh -d /polkadot polkadot && \
-# 	mkdir -p /data /polkadot/.local/share && \
-# 	chown -R polkadot:polkadot /data && \
-# 	ln -s /data /polkadot/.local/share/polkadot && \
-
 USER root
 
 RUN	mkdir -p /specs

--- a/docker/injected.Dockerfile
+++ b/docker/injected.Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/ubuntu:20.04
+FROM docker.io/parity/base-bin
 
 # metadata
 ARG VCS_REF
@@ -18,34 +18,35 @@ LABEL io.parity.image.authors="devops-team@parity.io" \
 ENV RUST_BACKTRACE 1
 
 # install tools and dependencies
-RUN apt-get update && \
-	DEBIAN_FRONTEND=noninteractive apt-get install -y \
-		libssl1.1 \
-		ca-certificates \
-		curl && \
-# apt cleanup
-	apt-get autoremove -y && \
-	apt-get clean && \
-	find /var/lib/apt/lists/ -type f -not -name lock -delete; \
-# add user and link ~/.local/share/polkadot to /data
-	useradd -m -u 1000 -U -s /bin/sh -d /polkadot polkadot && \
-	mkdir -p /data /polkadot/.local/share && \
-	chown -R polkadot:polkadot /data && \
-	ln -s /data /polkadot/.local/share/polkadot && \
-	mkdir -p /specs
+# RUN apt-get update && \
+# 	DEBIAN_FRONTEND=noninteractive apt-get install -y \
+# 		libssl1.1 \
+# 		ca-certificates \
+# 		curl && \
+# # apt cleanup
+# 	apt-get autoremove -y && \
+# 	apt-get clean && \
+# 	find /var/lib/apt/lists/ -type f -not -name lock -delete; \
+# # add user and link ~/.local/share/polkadot to /data
+# 	useradd -m -u 1000 -U -s /bin/sh -d /polkadot polkadot && \
+# 	mkdir -p /data /polkadot/.local/share && \
+# 	chown -R polkadot:polkadot /data && \
+# 	ln -s /data /polkadot/.local/share/polkadot && \
+
+USER root
+
+RUN	mkdir -p /specs
 
 # add polkadot-parachain binary to the docker image
-COPY ./target/release/polkadot-parachain /usr/local/bin
-COPY ./target/release/polkadot-parachain.asc /usr/local/bin
-COPY ./target/release/polkadot-parachain.sha256 /usr/local/bin
+COPY ./target/release-artifacts/* /usr/local/bin
 COPY ./parachains/chain-specs/*.json /specs/
 
-USER polkadot
+USER parity
 
 # check if executable works in this container
 RUN /usr/local/bin/polkadot-parachain --version
 
-EXPOSE 30333 9933 9944
-VOLUME ["/polkadot"]
+EXPOSE 30333 9933 9944 9615
+VOLUME ["/polkadot", "/specs"]
 
 ENTRYPOINT ["/usr/local/bin/polkadot-parachain"]

--- a/docker/scripts/build-injected-image.sh
+++ b/docker/scripts/build-injected-image.sh
@@ -2,5 +2,8 @@
 
 OWNER=${OWNER:-parity}
 IMAGE_NAME=${IMAGE_NAME:-polkadot-parachain}
-docker build --no-cache --build-arg IMAGE_NAME=$IMAGE_NAME -t $OWNER/$IMAGE_NAME -f ./docker/injected.Dockerfile .
-docker images | grep $IMAGE_NAME
+docker build --no-cache \
+    --build-arg IMAGE_NAME=$IMAGE_NAME \
+    -t $OWNER/$IMAGE_NAME \
+    -f ./docker/injected.Dockerfile \
+    . && docker images


### PR DESCRIPTION
This should fix failing GHA which creates a docker image for the cumulus node.