### PR TITLE
[Backport] Fix release notes generation (#2868)

### DIFF
--- a/scripts/ci/changelog/bin/changelog
+++ b/scripts/ci/changelog/bin/changelog
@@ -29,8 +29,8 @@ ENV['REF2'] = ref2
 
 gh_cumulus = SubRef.new(format('%<owner>s/%<repo>s', { owner: owner, repo: repo }))
 
-polkadot_ref1 = gh_cumulus.get_dependency_reference(ref1, 'polkadot-client')
-polkadot_ref2 = gh_cumulus.get_dependency_reference(ref2, 'polkadot-client')
+polkadot_ref1 = gh_cumulus.get_dependency_reference(ref1, 'polkadot-primitives')
+polkadot_ref2 = gh_cumulus.get_dependency_reference(ref2, 'polkadot-primitives')
 
 substrate_ref1 = gh_cumulus.get_dependency_reference(ref1, 'sp-io')
 substrate_ref2 = gh_cumulus.get_dependency_reference(ref2, 'sp-io')


### PR DESCRIPTION
This PR backports fix #2868 for the release notes generation from release-v1.0.0 branch to master