### PR TITLE
Flexibility in xcm-emulator methods

### DIFF
--- a/parachains/integration-tests/emulated/common/src/lib.rs
+++ b/parachains/integration-tests/emulated/common/src/lib.rs
@@ -22,7 +22,7 @@ use xcm_emulator::{
 	assert_expected_events, bx, decl_test_bridges, decl_test_networks, decl_test_parachains,
 	decl_test_relay_chains, decl_test_sender_receiver_accounts_parameter_types,
 	helpers::weight_within_threshold, BridgeMessageHandler, Chain, DefaultMessageProcessor, ParaId,
-	Parachain, RelayChain, TestExt,
+	Parachain, RelayChain, TestExt, RuntimeAccountId
 };
 
 pub use xcm::{

--- a/xcm/xcm-emulator/src/lib.rs
+++ b/xcm/xcm-emulator/src/lib.rs
@@ -372,7 +372,7 @@ macro_rules! decl_test_relay_chains {
 				type RuntimeEvent = $runtime::RuntimeEvent;
 				type System = $crate::SystemPallet::<Self::Runtime>;
 
-				fn account_data_of(account: AccountId) -> $crate::AccountData<Balance> {
+				fn account_data_of(account: RuntimeAccountId<Self::Runtime>>) -> $crate::AccountData<Balance> {
 					Self::ext_wrapper(|| $crate::SystemPallet::<Self::Runtime>::account(account).data.into())
 				}
 
@@ -596,7 +596,7 @@ macro_rules! decl_test_parachains {
 				type RuntimeEvent = $runtime::RuntimeEvent;
 				type System = $crate::SystemPallet::<Self::Runtime>;
 
-				fn account_data_of(account: AccountId) -> $crate::AccountData<Balance> {
+				fn account_data_of(account: RuntimeAccountId<Self::Runtime>) -> $crate::AccountData<Balance> {
 					Self::ext_wrapper(|| $crate::SystemPallet::<Self::Runtime>::account(account).data.into())
 				}
 

--- a/xcm/xcm-emulator/src/lib.rs
+++ b/xcm/xcm-emulator/src/lib.rs
@@ -233,7 +233,7 @@ pub trait Chain: TestExt + NetworkComponent {
 		helpers::get_account_id_from_seed::<sr25519::Public>(seed)
 	}
 
-	fn account_data_of(account:  RuntimeAccountId<Self::Runtime>) -> AccountData<Balance>;
+	fn account_data_of(account: RuntimeAccountId<Self::Runtime>) -> AccountData<Balance>;
 
 	fn events() -> Vec<<Self as Chain>::RuntimeEvent>;
 }
@@ -372,7 +372,7 @@ macro_rules! decl_test_relay_chains {
 				type RuntimeEvent = $runtime::RuntimeEvent;
 				type System = $crate::SystemPallet::<Self::Runtime>;
 
-				fn account_data_of(account: RuntimeAccountId<Self::Runtime>>) -> $crate::AccountData<Balance> {
+				fn account_data_of(account: RuntimeAccountId<Self::Runtime>) -> $crate::AccountData<Balance> {
 					Self::ext_wrapper(|| $crate::SystemPallet::<Self::Runtime>::account(account).data.into())
 				}
 


### PR DESCRIPTION
This PR decouples the `accountId` type from the `accountId32` type and rather makes emulator methods depend on the `accountId` type defined by the chain runtime in question. This is important if we want the emulator to stay compatible with chains that have 20 byte accounts like Moonbeam.

The only method I did not change is `account_id_of`, because it is tied to `sr25519` account generation. In any case this method is not that crucial because 20 byte account senders and receivers can be declared with the `parameter_types!` macro.

Kusama address: HZetxGJ1k9kJdNwHFHUn3i2Xk11jqiX6kRG89BJZXcNAm8z